### PR TITLE
Delete and decrease hardcoded timeout

### DIFF
--- a/portal-backend/depmap/public/views.py
+++ b/portal-backend/depmap/public/views.py
@@ -143,9 +143,7 @@ def documentation():
 
 
 @blueprint.route("/resources_prototype/")
-@cache_without_user_permissions(
-    timeout=1000
-)  # arbitrarily set timeout to longer than default 300s
+@cache_without_user_permissions()  # default timeout 300s
 def resources_prototype():
     forum_api_key_value = current_app.config.get("FORUM_API_KEY")
     forum_url = current_app.config.get("FORUM_URL")


### PR DESCRIPTION
Delete hardcoded timeout on Flask view cache since it takes a long time for ops to see their changes. In other places of the portal that use `@cache_without_user_permissions()` we don't seem to specify a timeout anyways. Looking at the Flask Cache documentation, it seems like the default timeout is 300 seconds which at least would be faster than it is currently for the changes on the page to update