### PR TITLE
Add drug counts to data page data availability graph

### DIFF
--- a/frontend/packages/portal-frontend/src/dAPI.ts
+++ b/frontend/packages/portal-frontend/src/dAPI.ts
@@ -657,6 +657,7 @@ export class DepmapApi {
       // mapped to color category integers. The integer maps to Heatmap.tsx's
       // color scale.
       data_type_url_mapping: boolSummary.data_type_url_mapping,
+      drug_count_mapping: boolSummary.drug_count_mapping,
       values: dataAvailVals,
       data_types: boolSummary.data_types,
     };

--- a/frontend/packages/portal-frontend/src/dataPage/components/DataAvailabilityPlot.tsx
+++ b/frontend/packages/portal-frontend/src/dataPage/components/DataAvailabilityPlot.tsx
@@ -97,6 +97,22 @@ const DataAvailabilityPlot = ({
 
     return graphSectionUrlMapping;
   };
+
+  const getDrugCountMapping = (categoryKey: string) => {
+    const graphSectionDrugCountMapping: {
+      [key: string]: number | undefined;
+    } = {};
+    dataValuesByDataTypeCategory[categoryKey].forEach((category: any) => {
+      const dataTypeString = getDataPageDataTypeString(category.dataType);
+
+      const count =
+        currentReleaseDataAvil.drug_count_mapping[category.dataType];
+
+      graphSectionDrugCountMapping[dataTypeString] = count;
+    });
+
+    return graphSectionDrugCountMapping;
+  };
   return (
     <div>
       {dataValuesByDataTypeCategory && (
@@ -112,6 +128,7 @@ const DataAvailabilityPlot = ({
                       (category: any) => category.dataType
                     )}
                     dataTypeUrlMapping={getDataTypeUrlMapping(categoryKey)}
+                    drugCountMapping={getDrugCountMapping(categoryKey)}
                     dataTypeGroupName={categoryKey}
                     isCurrentRelease={isCurrentRelease}
                   />
@@ -131,7 +148,7 @@ const DataAvailabilityPlot = ({
                   BAR_THICKNESS *
                   dataValuesByDataTypeCategory[categoryKey].length
                 }
-                customWidth={400}
+                customWidth={350}
                 customColorScale={COLOR_SCALE}
                 margin={{
                   l: 0,

--- a/frontend/packages/portal-frontend/src/dataPage/components/DataPage.tsx
+++ b/frontend/packages/portal-frontend/src/dataPage/components/DataPage.tsx
@@ -33,6 +33,7 @@ export const DataPage = ({
   const [allDataAvail, setAllDataAvail] = useState<DataAvailability>({
     all_depmap_ids: [],
     data_type_url_mapping: {},
+    drug_count_mapping: {},
     data_types: [],
     values: [],
   });
@@ -42,6 +43,7 @@ export const DataPage = ({
   ] = useState<DataAvailability>({
     all_depmap_ids: [],
     data_type_url_mapping: {},
+    drug_count_mapping: {},
     data_types: [],
     values: [],
   });
@@ -65,18 +67,22 @@ export const DataPage = ({
       const currentDataValues: number[][] = [];
       const currentDataTypes: string[] = [];
       const currentDataTypeUrlMapping: { [key: string]: string } = {};
+      const currentDataTypeDrugCountMapping: { [key: string]: number } = {};
       dataAvail.data_types.forEach((data_type: string, index: number) => {
         if (currentReleaseDatasets.includes(data_type)) {
           currentDataTypes.push(data_type);
           currentDataValues.push(dataAvail.values[index]);
           currentDataTypeUrlMapping[data_type] =
             dataAvail.data_type_url_mapping[data_type];
+          currentDataTypeDrugCountMapping[data_type] =
+            dataAvail.drug_count_mapping[data_type];
         }
       });
 
       setCurrentReleaseDataAvail({
         all_depmap_ids: dataAvail.all_depmap_ids,
         data_type_url_mapping: currentDataTypeUrlMapping,
+        drug_count_mapping: currentDataTypeDrugCountMapping,
         data_types: currentDataTypes,
         values: currentDataValues,
       });

--- a/frontend/packages/portal-frontend/src/dataPage/components/DataPageDatatypeSelector.tsx
+++ b/frontend/packages/portal-frontend/src/dataPage/components/DataPageDatatypeSelector.tsx
@@ -51,15 +51,6 @@ const DataPageDatatypeSelector = ({
     );
     const inCurrentRelease = currentReleaseDatasets.includes(datatype);
 
-    if (!isCurrentRelease) {
-      console.log("datatype");
-      console.log(datatype);
-      console.log("dataTypeDisplayName");
-      console.log(dataTypeDisplayName);
-      console.log("dataTypeUrlMapping");
-      console.log(dataTypeUrlMapping);
-    }
-
     display.push(
       <div className={styles.selector} key={`wapper-${dataTypeDisplayName}`}>
         {Object.keys(dataTypeUrlMapping).includes(dataTypeDisplayName) &&

--- a/frontend/packages/portal-frontend/src/dataPage/components/DataPageDatatypeSelector.tsx
+++ b/frontend/packages/portal-frontend/src/dataPage/components/DataPageDatatypeSelector.tsx
@@ -7,6 +7,7 @@ interface Props {
   datatypes: string[];
   dataTypeGroupName: string;
   dataTypeUrlMapping: { [key: string]: string | undefined };
+  drugCountMapping: { [data_type: string]: number | undefined };
   isCurrentRelease: boolean;
 }
 
@@ -14,9 +15,22 @@ const DataPageDatatypeSelector = ({
   datatypes,
   dataTypeGroupName,
   dataTypeUrlMapping,
+  drugCountMapping,
   isCurrentRelease,
 }: Props) => {
   const display: any = [];
+
+  const getDrugCountLabel = (dataType: string) => {
+    if (
+      Object.keys(drugCountMapping).includes(dataType) &&
+      drugCountMapping[dataType] !== null &&
+      drugCountMapping[dataType] !== undefined
+    ) {
+      return `(${drugCountMapping[dataType]} drugs)`;
+    }
+
+    return "";
+  };
 
   // If the data type is in the current release, add an asterisk.
   const getDataTypeLabel = (
@@ -37,6 +51,15 @@ const DataPageDatatypeSelector = ({
     );
     const inCurrentRelease = currentReleaseDatasets.includes(datatype);
 
+    if (!isCurrentRelease) {
+      console.log("datatype");
+      console.log(datatype);
+      console.log("dataTypeDisplayName");
+      console.log(dataTypeDisplayName);
+      console.log("dataTypeUrlMapping");
+      console.log(dataTypeUrlMapping);
+    }
+
     display.push(
       <div className={styles.selector} key={`wapper-${dataTypeDisplayName}`}>
         {Object.keys(dataTypeUrlMapping).includes(dataTypeDisplayName) &&
@@ -47,7 +70,9 @@ const DataPageDatatypeSelector = ({
             target="_blank"
             rel="noreferrer"
           >
-            {getDataTypeLabel(dataTypeDisplayName, inCurrentRelease)}
+            {`${getDataTypeLabel(dataTypeDisplayName, inCurrentRelease)}`}
+            <br />
+            {getDrugCountLabel(dataTypeDisplayName)}
           </a>
         ) : (
           <p>{getDataTypeLabel(dataTypeDisplayName, inCurrentRelease)}</p>

--- a/frontend/packages/portal-frontend/src/dataPage/components/DataPageDatatypeSelector.tsx
+++ b/frontend/packages/portal-frontend/src/dataPage/components/DataPageDatatypeSelector.tsx
@@ -66,7 +66,10 @@ const DataPageDatatypeSelector = ({
             {getDrugCountLabel(dataTypeDisplayName)}
           </a>
         ) : (
-          <p>{getDataTypeLabel(dataTypeDisplayName, inCurrentRelease)}</p>
+          <p>
+            {getDataTypeLabel(dataTypeDisplayName, inCurrentRelease)} <br />
+            {getDrugCountLabel(dataTypeDisplayName)}
+          </p>
         )}
       </div>
     );

--- a/frontend/packages/portal-frontend/src/dataPage/components/utils.ts
+++ b/frontend/packages/portal-frontend/src/dataPage/components/utils.ts
@@ -1,4 +1,4 @@
-export const BAR_THICKNESS = 42;
+export const BAR_THICKNESS = 43;
 
 export const currentReleaseDatasets = [
   "Sequencing_WES_Broad",

--- a/frontend/packages/portal-frontend/src/dataPage/models/types.ts
+++ b/frontend/packages/portal-frontend/src/dataPage/models/types.ts
@@ -21,6 +21,7 @@ export const COLOR_SCALE = [
 export interface DataAvailSummary {
   all_depmap_ids: [number, string][];
   data_type_url_mapping: { [data_type: string]: string };
+  drug_count_mapping: { [data_type: string]: number };
   data_types: string[];
   values: boolean[][];
 }
@@ -38,6 +39,7 @@ export interface DataSummary {
 export interface DataAvailability {
   all_depmap_ids: [number, string][];
   data_type_url_mapping: { [data_type: string]: string };
+  drug_count_mapping: { [data_type: string]: number };
   values: number[][];
   data_types: string[];
 }

--- a/frontend/packages/portal-frontend/src/dataPage/styles/DataAvailabilityPlot.scss
+++ b/frontend/packages/portal-frontend/src/dataPage/styles/DataAvailabilityPlot.scss
@@ -1,30 +1,22 @@
 .dataAvailabilityPlotContainer {
-  width: 290px;
-  min-width: 290px;
+  width: 275px;
+  min-width: 275px;
   margin-top: 2px;
   border-bottom: 1px solid black;
   padding-bottom: 0px;
   margin-right: 8px;
 
-  @media (max-width: 910px) {
-    width: 200px;
-    min-width: 200px;
-  }
   .datatypeSelector {
-    margin-left: 5px;
-    font-size: 16px;
-    min-width: 101px;
-
-    @media (max-width: 910px) {
-      font-size: 14px;
-    }
+    margin-left: 4px;
+    font-size: 14px;
+    min-width: 150px;
 
     .groupContainer {
       display: grid;
       grid-template-columns: repeat(2, 1fr);
       .groupLabel {
         grid-column: 1;
-        margin-right: 20px;
+        margin-right: 10px;
         align-self: normal;
         font-family: roboto;
         font-size: 16px;

--- a/frontend/packages/portal-frontend/src/plot/components/Heatmap.tsx
+++ b/frontend/packages/portal-frontend/src/plot/components/Heatmap.tsx
@@ -107,7 +107,7 @@ function Heatmap({
           height,
 
           margin,
-          width: 400,
+          width: customWidth,
         }
       : {
           title: "",

--- a/portal-backend/tests/conftest.py
+++ b/portal-backend/tests/conftest.py
@@ -186,6 +186,11 @@ class InteractiveConfigFakeMutationsDownload(InteractiveConfig):
         return "this-is-test-nonsense-that-should-never-be-checked-against.1/except-for-taiga-alias-loading"
 
 
+class InteractiveConfigFakeDrugDataset(InteractiveConfig):
+    def is_standard(self, dataset_id):
+        return True
+
+
 class DefaultDictMock(defaultdict):
     def __contains__(self, item):
         """

--- a/portal-backend/tests/conftest.py
+++ b/portal-backend/tests/conftest.py
@@ -186,11 +186,6 @@ class InteractiveConfigFakeMutationsDownload(InteractiveConfig):
         return "this-is-test-nonsense-that-should-never-be-checked-against.1/except-for-taiga-alias-loading"
 
 
-class InteractiveConfigFakeDrugDataset(InteractiveConfig):
-    def is_standard(self, dataset_id):
-        return True
-
-
 class DefaultDictMock(defaultdict):
     def __contains__(self, item):
         """

--- a/portal-backend/tests/depmap/data_page/test_all_data_avail_partial.csv
+++ b/portal-backend/tests/depmap/data_page/test_all_data_avail_partial.csv
@@ -1,2 +1,5 @@
 ModelID,Drug_CTD_Broad,Drug_Repurposing_Broad,CRISPR_Achilles_Broad
-ACH-000019,True,False,True
+ACH-000019,False,False,True
+ACH-000020,True,False,False
+ACH-000021,True,False,False
+ACH-000022,True,False,False

--- a/portal-backend/tests/depmap/data_page/test_api.py
+++ b/portal-backend/tests/depmap/data_page/test_api.py
@@ -6,8 +6,12 @@ from tests.factories import (
     DependencyDatasetFactory,
     DepmapModelFactory,
     GeneFactory,
+    CompoundFactory,
+    CompoundExperimentFactory,
     MatrixFactory,
 )
+import numpy as np
+from tests.utilities import interactive_test_utils
 
 
 def test_get_data_availability(populated_db):
@@ -19,6 +23,7 @@ def test_get_data_availability(populated_db):
         assert list(data_availablity.keys()) == [
             "values",
             "data_type_url_mapping",
+            "drug_count_mapping",
             "data_types",
             "all_depmap_ids",
         ]
@@ -65,7 +70,23 @@ def test_get_data_availability_not_all_data_types_present(
     )
     dataset = DependencyDatasetFactory(matrix=matrix, name=dataset_name, priority=1,)
 
+    drug_dataset_name = DependencyDataset.DependencyEnum.CTRP_AUC
+    cell_lines = [
+        DepmapModelFactory(model_id="ACH-000020"),
+        DepmapModelFactory(model_id="ACH-000021"),
+        DepmapModelFactory(model_id="ACH-000022"),
+    ]
+    compounds = [CompoundFactory() for _ in range(3)]
+    compound_experiments = [CompoundExperimentFactory(compound=c) for c in compounds]
+    matrix = MatrixFactory(
+        data=[[2, 3, 4], [0, 2, 1], [np.NaN, np.NaN, np.NaN]],
+        cell_lines=cell_lines,
+        entities=compound_experiments,
+        using_depmap_model_table=True,
+    )
+    DependencyDatasetFactory(matrix=matrix, name=drug_dataset_name, priority=1)
     empty_db_mock_downloads.session.flush()
+    interactive_test_utils.reload_interactive_config()
 
     def mock_get_all_data_avail_df():
         with open(
@@ -77,16 +98,25 @@ def test_get_data_availability_not_all_data_types_present(
     monkeypatch.setattr(
         data_page_api, "_get_all_data_avail_df", mock_get_all_data_avail_df
     )
+
     with empty_db_mock_downloads.app.test_client() as c:
         r = c.get(
             url_for("api.data_page_data_availability"), content_type="application/json",
         )
         data_availability = r.json
         assert data_availability == {
-            "values": [[True], [True], [False]],
+            "values": [
+                [True, False, False, False],
+                [False, True, True, True],
+                [False, False, False, False],
+            ],
             "data_type_url_mapping": {
                 "CRISPR_Achilles_Broad": "/data_page/?release=test+name+version&file=test+file+name+2",
-                "Drug_CTD_Broad": None,
+                "Drug_CTD_Broad": "/data_page/?release=test+name+version&file=test+file+name+2",
+                "Drug_Repurposing_Broad": None,
+            },
+            "drug_count_mapping": {
+                "Drug_CTD_Broad": 3,
                 "Drug_Repurposing_Broad": None,
             },
             "data_types": [
@@ -94,5 +124,10 @@ def test_get_data_availability_not_all_data_types_present(
                 "Drug_CTD_Broad",
                 "Drug_Repurposing_Broad",
             ],
-            "all_depmap_ids": [[0, "ACH-000019"]],
+            "all_depmap_ids": [
+                [0, "ACH-000019"],
+                [1, "ACH-000020"],
+                [2, "ACH-000021"],
+                [3, "ACH-000022"],
+            ],
         }


### PR DESCRIPTION
Added drug counts to the data overview figure. This required tweaking the spacing of the figure a lot, as the labels for the drug datasets are now much longer than the labels for the other datasets. Is this spacing too squished?
Asana task: https://app.asana.com/0/1165651979405609/1207908982851416
<img width="1380" alt="Screenshot 2024-08-01 at 7 20 52 PM" src="https://github.com/user-attachments/assets/29705b54-4f37-4058-a773-8387df86be4d">
