### PR TITLE
Make select in DE2 editable after a selection has been made

### DIFF
--- a/frontend/packages/@depmap/data-explorer-2/src/utils/extend-react-select.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/extend-react-select.tsx
@@ -272,8 +272,14 @@ export default function extendReactSelect(
                 // This is the only case where we actually do want to wipe out
                 // the value.
                 if (input.value.length === 1 && e.key === "Backspace") {
-                  reactSelectRef.current.select.onInputChange("");
-                  reactSelectRef.current.select.onChange(null);
+                  if (props.isClearable) {
+                    reactSelectRef.current.select.onInputChange("");
+                    reactSelectRef.current.select.onChange(null);
+                  } else {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    reactSelectRef.current.select.onInputChange(value?.label);
+                  }
                 }
 
                 if (props.onKeyDown) {


### PR DESCRIPTION
This modifies the behavior of all select components in DE2's configuration panel. Before it was not possible to edit a value once it was selected. Now the cursor is automatically placed at the end of the value and the user can use the arrow keys or backspace key to modify it.

How is this useful to users? Consider this scenario:
- I select gene ABCD1
- I decide I actually want to look at gene ABCD2
- I can now press backspace once and type a '2' in place of the '1'
![modify](https://github.com/user-attachments/assets/9fd7339e-914d-489c-a596-b3363cdaa087)

"Edit mode" doesn't take effect until you start typing. This is to preserve the old behavior in cases where there is only a short list of features to choose from (and you never have to type anything at all).
![short-list](https://github.com/user-attachments/assets/485b0c0e-b6a1-40da-bcc9-2f3b5481dc31)

This also works with really long feature names that overflow the container.
![long-name](https://github.com/user-attachments/assets/702fbc9d-8eb5-495a-93eb-56db992419cd)

My dream is to preserve the line wrapping even after you press a key. Unfortunately, an HTML `<input>` element refuses to wrap. I experimented with rendering a `<textarea>` instead but that entirely freaked out the `react-select` library. I'm going to punt on that for now and circle back to it later.