### PR TITLE
Fix dimension type column in datasets table

### DIFF
--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -148,6 +148,19 @@ export default function Datasets() {
       <Spinner />
     );
   }
+  const getTabularDatasetDimensionTypeByAxis = (
+    dimensionName: string,
+    axis: "feature" | "sample"
+  ) => {
+    const dimType = dimensionTypes.find(
+      (dt) => dimensionName === dt.name && dt.axis === axis
+    );
+    if (dimType) {
+      return dimensionName;
+    }
+    return null;
+  };
+
   const formatDatasetTableData = (
     datasetsList: Dataset[]
   ): DatasetTableData[] => {
@@ -158,8 +171,20 @@ export default function Datasets() {
         id: dataset.id,
         name: dataset.name,
         groupName,
-        featureType: dataset.feature_type,
-        sampleType: dataset.sample_type,
+        featureType:
+          dataset.format === "matrix_dataset"
+            ? dataset.feature_type_name
+            : getTabularDatasetDimensionTypeByAxis(
+                dataset.index_type_name,
+                "feature"
+              ),
+        sampleType:
+          dataset.format === "matrix_dataset"
+            ? dataset.sample_type_name
+            : getTabularDatasetDimensionTypeByAxis(
+                dataset.index_type_name,
+                "sample"
+              ),
         dataType: dataset.data_type,
         datasetMetadata: (
           <div


### PR DESCRIPTION
Thought this was fixed but turns out not. Dimension type info for datasets was missing 
![Screenshot 2024-08-05 at 1 46 27 PM](https://github.com/user-attachments/assets/869e8eb9-8425-4677-afeb-85db1d69cd05)
![Screenshot 2024-08-05 at 1 46 44 PM](https://github.com/user-attachments/assets/ea5828f4-60d1-4c60-928d-74d6e0263d69)
