### PR TITLE
allow searching by multiple search index properties

### DIFF
--- a/frontend/packages/@depmap/common-components/src/components/Highlighter.tsx
+++ b/frontend/packages/@depmap/common-components/src/components/Highlighter.tsx
@@ -4,7 +4,7 @@ import WordBreaker from "./WordBreaker";
 interface Props {
   text: string;
   termToHiglight: string;
-  textColor?: string;
+  style?: React.CSSProperties;
   // Set this to `true` if you want highlight within words (rather than exactly
   // matching words)
   matchPartialTerms?: boolean;
@@ -15,7 +15,7 @@ interface Props {
 function Highlighter({
   text,
   termToHiglight,
-  textColor = "black",
+  style = undefined,
   matchPartialTerms = false,
 }: Props) {
   if (!text) {
@@ -48,7 +48,7 @@ function Highlighter({
         <span
           // eslint-disable-next-line react/no-array-index-key
           key={`${i}-h`}
-          style={{ color: textColor, backgroundColor: "yellow" }}
+          style={{ ...style, backgroundColor: "yellow" }}
         >
           <WordBreaker text={matches[i]} />
         </span>

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/EntitySelect/EntitySelect.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/EntitySelect/EntitySelect.tsx
@@ -10,8 +10,8 @@ import {
   toDemapModelOptions,
   toOutputValue,
   toReactSelectOptions,
-  useApi,
   useEntityLabels,
+  useSearch,
 } from "./utils";
 
 interface Props {
@@ -35,7 +35,7 @@ function EntitySelect({
   units,
   swatchColor = undefined,
 }: Props) {
-  const api = useApi();
+  const search = useSearch();
 
   const {
     aliases,
@@ -47,11 +47,7 @@ function EntitySelect({
 
   const loadOptions = useCallback(
     async (inputValue: string) => {
-      const results = await api.searchDimensions({
-        substring: inputValue,
-        limit: 100,
-        type_name: entity_type,
-      });
+      const results = await search(inputValue, entity_type);
 
       // HACK: We want the user to be able to start typing right away, before
       // waiting for the `useEntityLabels` hook to have updated. This will run
@@ -77,7 +73,7 @@ function EntitySelect({
         cached.disabledReasons
       );
     },
-    [api, entity_type, waitForCachedValues]
+    [search, entity_type, waitForCachedValues]
   );
 
   const defaultOptions = useMemo(() => {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/EntitySelect/utils.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/EntitySelect/utils.tsx
@@ -437,13 +437,11 @@ export function formatOptionLabel(
           <Highlighter
             text={option.label}
             style={{ color: disabledReason ? "inherit" : "black" }}
-            termToHiglight={(() => {
-              return (
-                tokenize(inputValue).find((token) =>
-                  option.label?.toLowerCase().includes(token.toLowerCase())
-                ) || ""
-              );
-            })()}
+            termToHiglight={
+              tokenize(inputValue).find((token) =>
+                option.label?.toLowerCase().includes(token.toLowerCase())
+              ) || ""
+            }
             matchPartialTerms
           />
         </div>

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/EntitySelect/utils.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/EntitySelect/utils.tsx
@@ -44,6 +44,29 @@ export function useApi() {
   return ref.current as SharedApi;
 }
 
+function tokenize(input: string | null) {
+  const str = input || "";
+  const tokens = str.split(/\s+/g).filter(Boolean);
+  const uniqueTokens = new Set(tokens);
+
+  return [...uniqueTokens];
+}
+
+export function useSearch() {
+  const api = useApi();
+
+  return useCallback(
+    (input: string, type_name: string) => {
+      return api.searchDimensions({
+        substring: tokenize(input),
+        type_name,
+        limit: 100,
+      });
+    },
+    [api]
+  );
+}
+
 function doNotOverlap(a: number[], b: number[]) {
   const setA = new Set(a);
 
@@ -176,7 +199,7 @@ export function useEntityLabels(
   };
 }
 
-const makeSortComparator = (term: string | null) => (a: Option, b: Option) => {
+const makeSortComparator = (tokens: string[]) => (a: Option, b: Option) => {
   if (a.isDisabled && !b.isDisabled) {
     return 1;
   }
@@ -188,12 +211,12 @@ const makeSortComparator = (term: string | null) => (a: Option, b: Option) => {
   const labelA = (a.nonLabelProperties[0]?.values[0] || a.label)?.toLowerCase();
   const labelB = (b.nonLabelProperties[0]?.values[0] || b.label)?.toLowerCase();
 
-  if (!term) {
+  if (tokens.length === 0) {
     return labelA < labelB ? -1 : 1;
   }
 
-  const indexA = labelA.indexOf(term);
-  const indexB = labelB.indexOf(term);
+  const indexA = tokens.reduce((sum, token) => labelA.indexOf(token) + sum, 0);
+  const indexB = tokens.reduce((sum, token) => labelB.indexOf(token) + sum, 0);
 
   if (indexA === indexB) {
     return labelA < labelB ? -1 : 1;
@@ -208,12 +231,29 @@ export function toReactSelectOptions(
   entityLabels: string[],
   disabledReasons: Record<string, string>
 ) {
-  const term = inputValue?.toLowerCase() || null;
+  const tokens = tokenize(inputValue);
+  const labelsWithAdditionalMatchingProps = new Set(
+    searchResults
+      .filter(({ matching_properties }) => matching_properties.length > 1)
+      .map(({ label }) => label)
+  );
 
+  // `labelOptions` is a fallback for cases where the search indexer doesn't
+  // know anything about the given dimension type.
   const labelOptions = entityLabels
     .filter((label) => {
-      return !term || label.toLowerCase().includes(term);
+      return (
+        // The user hasn't typed anything yet, so show the full list.
+        tokens.length === 0 ||
+        // Only try to search by label if there is only one token. There just
+        // isn't a reliable way to emulate what the search endpoint does when
+        // it matches multiple tokens to different properties.
+        (tokens.length === 1 &&
+          label.toLowerCase().includes(tokens[0].toLowerCase()))
+      );
     })
+    // Prefer showing results from the search indexer, where they exist.
+    .filter((label) => !labelsWithAdditionalMatchingProps.has(label))
     .map((label) => ({
       label,
       value: label,
@@ -233,7 +273,7 @@ export function toReactSelectOptions(
       );
     })
     .map((result) => {
-      const groupedProps: Record<string, string[]> = {};
+      const groupedProps: Record<string, Set<string>> = {};
 
       result.matching_properties.forEach(({ property, value }) => {
         const prop = property
@@ -241,20 +281,23 @@ export function toReactSelectOptions(
           .replace(/_/g, " ")
           // capitalize "ID"
           .replace(/\bids?\b/gi, "ID")
-          // A second-level "label" property is not interesting
+          // Never use "label" as a nested property (it doesn't give the user
+          // any real information)
           .replace(/\.label$/, "")
-          // Use parens instead of dot notation for other second-level properties
-          .replace(/\.(.+)$/, " ($1)");
+          // Now return only the last member of the property chain (this
+          // assumes that's the most meaningful info we can show the user).
+          .split(".")
+          .slice(-1)[0];
 
-        groupedProps[prop] ||= [];
-        groupedProps[prop].push(value);
+        groupedProps[prop] ||= new Set();
+        groupedProps[prop].add(value);
       });
 
       const nonLabelProperties = Object.keys(groupedProps)
         .filter((property) => property !== "label")
         .map((property) => ({
           property,
-          values: groupedProps[property],
+          values: [...groupedProps[property]],
         }));
 
       return {
@@ -267,10 +310,16 @@ export function toReactSelectOptions(
     });
 
   return [...labelOptions, ...searchIndexOptions].sort(
-    makeSortComparator(term)
+    makeSortComparator(tokens)
   );
 }
 
+// FIXME: We have a special case for models because they can be searched by
+// aliases. In practice there is only one alias we use, which is the cell line
+// name. This concept is a holdover from a time before the search indexer.
+// Going forward, we should instead make sure that the depmap_model sample type
+// has CellLineName (or StrippedCellLineName?) as one of its
+// `properties_to_index`.
 export function toDemapModelOptions(
   searchResults: SearchDimenionsResponse,
   inputValue: string | null,
@@ -278,7 +327,7 @@ export function toDemapModelOptions(
   aliases: Aliases | null,
   disabledReasons: Record<string, string>
 ) {
-  const term = inputValue?.toLowerCase() || null;
+  const tokens = tokenize(inputValue);
   const nameToId: Record<string, string> = {};
   const idToName: Record<string, string> = {};
 
@@ -295,8 +344,12 @@ export function toDemapModelOptions(
       ? aliases![0].values
           .filter((cellLineName) => {
             return (
-              (!term && cellLineName) ||
-              (term && cellLineName?.toLowerCase().includes(term))
+              tokens.length === 0 ||
+              // Only try to search by alias if there is only one token. There just
+              // isn't a reliable way to emulate what the search endpoint does when
+              // it matches multiple tokens to different properties.
+              (tokens.length === 1 &&
+                cellLineName?.toLowerCase().includes(tokens[0].toLowerCase()))
             );
           })
           .map((cellLineName) => {
@@ -341,7 +394,7 @@ export function toDemapModelOptions(
   });
 
   return [...aliasOptions, ...labelAndSearchIndexOptions].sort(
-    makeSortComparator(term)
+    makeSortComparator(tokens)
   );
 }
 
@@ -376,27 +429,43 @@ export function formatOptionLabel(
   return (
     <div>
       <MaybeTooltip>
-        {nonLabelProperties?.length ? (
-          <b>{option.label}</b>
-        ) : (
+        <div
+          style={{
+            fontWeight: nonLabelProperties?.length ? "bold" : "normal",
+          }}
+        >
           <Highlighter
             text={option.label}
-            termToHiglight={inputValue}
+            style={{ color: disabledReason ? "inherit" : "black" }}
+            termToHiglight={(() => {
+              return (
+                tokenize(inputValue).find((token) =>
+                  option.label?.toLowerCase().includes(token.toLowerCase())
+                ) || ""
+              );
+            })()}
             matchPartialTerms
-            textColor={disabledReason ? "inherit" : "black"}
           />
-        )}
+        </div>
       </MaybeTooltip>
       {nonLabelProperties?.map((match) => {
+        const termToHiglight = tokenize(inputValue)
+          .filter((token) => {
+            return match.values.some((value) => {
+              return value.toLowerCase().includes(token.toLowerCase());
+            });
+          })
+          .join(" ");
+
         return (
           <div key={`${match.property}=${match.values}`}>
             <MaybeTooltip>
               {match.property.replace(/^(.)/, (c: string) => c.toUpperCase())}:{" "}
               <Highlighter
                 text={match.values.join(", ")}
-                termToHiglight={inputValue}
+                termToHiglight={termToHiglight}
                 matchPartialTerms
-                textColor={disabledReason ? "inherit" : "black"}
+                style={{ color: disabledReason ? "inherit" : "black" }}
               />
             </MaybeTooltip>
           </div>

--- a/frontend/packages/@depmap/data-explorer-2/src/utils/extend-react-select.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/extend-react-select.tsx
@@ -185,6 +185,11 @@ export default function extendReactSelect(
                 menuPortal: (base) => ({ ...base, zIndex: 3 }),
                 clearIndicator: (base) => ({ ...base, padding: 2 }),
                 dropdownIndicator: (base) => ({ ...base, padding: 4 }),
+                loadingIndicator: (base) => ({
+                  ...base,
+                  position: "absolute",
+                  right: 22,
+                }),
                 menu: (base) => ({
                   ...base,
                   fontSize: 12,
@@ -214,6 +219,7 @@ export default function extendReactSelect(
                 const inputContainer = valContainerItem.nextSibling as HTMLElement;
 
                 valContainer.style.display = "inline";
+                valContainer.style.paddingRight = "0";
                 inputContainer.style.display = "inline";
 
                 valContainerItem.style.cssText = `

--- a/frontend/packages/@depmap/types/src/Metadata.ts
+++ b/frontend/packages/@depmap/types/src/Metadata.ts
@@ -43,7 +43,7 @@ interface SearchDimensionPrefix extends SearchDimensionCommon {
 }
 
 interface SearchDimensionSubstring extends SearchDimensionCommon {
-  substring: string;
+  substring: string | string[];
   prefix?: never;
 }
 


### PR DESCRIPTION
As a follow-up to PR #14, this modifies the behavior of feature/sample search in DE2. You can now type multiple, space-separated properties and the result set will be narrowed accordingly.

![multi-search](https://github.com/user-attachments/assets/301f5c49-2a16-40fa-a116-85cf567950e8)
