### PR TITLE
make feature search input wrap to multiple lines

### DIFF
--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/EntitySelect/EntitySelect.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/EntitySelect/EntitySelect.tsx
@@ -143,6 +143,7 @@ function EntitySelect({
       cacheOptions={`${entity_type}-${dataType}-${units}-${dataset_id}`}
       swatchColor={swatchColor}
       isClearable
+      isEditable
     />
   );
 }

--- a/frontend/packages/@depmap/data-explorer-2/src/styles/ExtendedSelect.scss
+++ b/frontend/packages/@depmap/data-explorer-2/src/styles/ExtendedSelect.scss
@@ -53,6 +53,33 @@
   }
 }
 
+.ContentEditableDivInput {
+  & > div {
+    display: inline-block;
+    min-height: 32px;
+    vertical-align: middle;
+  }
+
+  div[contenteditable] {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    width: 98px;
+    min-height: 32px;
+    border: none;
+    outline: none;
+    margin-left: 2px;
+
+    &:empty {
+      line-height: 32px;
+    }
+  }
+}
+
+.hidden {
+  visibility: hidden;
+}
+
 .selectError > div {
   border: 1px solid #a94442;
 


### PR DESCRIPTION
Now that you can search by multiple properties, it's helpful to have more real estate to type long search queries. But this makes thing nicer even just when typing long feature names.
![expando](https://github.com/user-attachments/assets/a4e4bd3e-4b33-478b-8997-b4af424a49ba)



I made various attempts to get this working with a `<textarea>` element but those do not flexibly resize to fit the contents. I ended up going with a `<div>` with its `contenteditable` attribute set.

https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable