### PR TITLE
Add consistent label support to the data_access interface

### DIFF
--- a/portal-backend/depmap/data_access/__init__.py
+++ b/portal-backend/depmap/data_access/__init__.py
@@ -3,7 +3,7 @@ from .interface import (
     get_all_matrix_dataset_ids,
     get_all_matrix_datasets,
     get_matrix_dataset,
-    get_dataset_feature_ids_by_label,
+    get_dataset_feature_labels_by_id,
     get_dataset_feature_labels,
     get_dataset_sample_ids,
     get_dataset_sample_labels_by_id,

--- a/portal-backend/depmap/data_access/__init__.py
+++ b/portal-backend/depmap/data_access/__init__.py
@@ -6,6 +6,7 @@ from .interface import (
     get_dataset_feature_ids_by_label,
     get_dataset_feature_labels,
     get_dataset_sample_ids,
+    get_dataset_sample_labels_by_id,
     get_dataset_data_type,
     get_dataset_feature_type,
     get_dataset_sample_type,

--- a/portal-backend/depmap/data_access/breadbox_dao.py
+++ b/portal-backend/depmap/data_access/breadbox_dao.py
@@ -77,6 +77,12 @@ def get_dataset_feature_ids_by_label(dataset_id) -> dict[str, str]:
     return {feature["label"]: feature["id"] for feature in features}
 
 
+def get_dataset_sample_labels_by_id(dataset_id) -> dict[str, str]:
+    dataset_uuid = parse_breadbox_slice_id(dataset_id).dataset_id
+    samples = extensions.breadbox.client.get_dataset_samples(dataset_uuid)
+    return {sample["id"]: sample["label"] for sample in samples}
+
+
 def get_dataset_feature_labels(dataset_id: str) -> list[str]:
     dataset_uuid = parse_breadbox_slice_id(dataset_id).dataset_id
     features = extensions.breadbox.client.get_dataset_features(dataset_uuid)

--- a/portal-backend/depmap/data_access/breadbox_dao.py
+++ b/portal-backend/depmap/data_access/breadbox_dao.py
@@ -71,10 +71,10 @@ def get_dataset_sample_type(dataset_id: str) -> Optional[str]:
     return get_matrix_dataset(dataset_id).sample_type
 
 
-def get_dataset_feature_ids_by_label(dataset_id) -> dict[str, str]:
+def get_dataset_feature_labels_by_id(dataset_id) -> dict[str, str]:
     dataset_uuid = parse_breadbox_slice_id(dataset_id).dataset_id
     features = extensions.breadbox.client.get_dataset_features(dataset_uuid)
-    return {feature["label"]: feature["id"] for feature in features}
+    return {feature["id"]: feature["label"] for feature in features}
 
 
 def get_dataset_sample_labels_by_id(dataset_id) -> dict[str, str]:

--- a/portal-backend/depmap/data_access/interface.py
+++ b/portal-backend/depmap/data_access/interface.py
@@ -165,15 +165,26 @@ def get_subsetted_df_by_labels(
     )
 
 
+# TODO: convert this to labels by ID
 def get_dataset_feature_ids_by_label(dataset_id) -> dict[str, str]:
     """
-    Get a mapping of feature labels to feature IDs.
+    Get a mapping of feature labels to given IDs.
     Other data loading methods return dataframes indexed by labels, but there are occasional
     times where we need the IDs as well. This makes it easy to map between the two.
     """
     if is_breadbox_id(dataset_id):
         return breadbox_dao.get_dataset_feature_ids_by_label(dataset_id)
     return interactive_utils.get_dataset_feature_ids_by_label(dataset_id)
+
+
+def get_dataset_sample_labels_by_id(dataset_id) -> dict[str, str]:
+    """
+    Get a mapping of sample labels to given IDs.
+    For example, depmap models use cell line names as labels and depmap (ACH) IDs as given IDs. 
+    """
+    if is_breadbox_id(dataset_id):
+        return breadbox_dao.get_dataset_sample_labels_by_id(dataset_id)
+    return interactive_utils.get_dataset_sample_labels_by_id(dataset_id)
 
 
 def get_dataset_feature_labels(dataset_id: str) -> list[str]:

--- a/portal-backend/depmap/data_access/interface.py
+++ b/portal-backend/depmap/data_access/interface.py
@@ -166,15 +166,15 @@ def get_subsetted_df_by_labels(
 
 
 # TODO: convert this to labels by ID
-def get_dataset_feature_ids_by_label(dataset_id) -> dict[str, str]:
+def get_dataset_feature_labels_by_id(dataset_id) -> dict[str, str]:
     """
     Get a mapping of feature labels to given IDs.
     Other data loading methods return dataframes indexed by labels, but there are occasional
     times where we need the IDs as well. This makes it easy to map between the two.
     """
     if is_breadbox_id(dataset_id):
-        return breadbox_dao.get_dataset_feature_ids_by_label(dataset_id)
-    return interactive_utils.get_dataset_feature_ids_by_label(dataset_id)
+        return breadbox_dao.get_dataset_feature_labels_by_id(dataset_id)
+    return interactive_utils.get_dataset_feature_labels_by_id(dataset_id)
 
 
 def get_dataset_sample_labels_by_id(dataset_id) -> dict[str, str]:

--- a/portal-backend/depmap/data_access/interface.py
+++ b/portal-backend/depmap/data_access/interface.py
@@ -165,7 +165,6 @@ def get_subsetted_df_by_labels(
     )
 
 
-# TODO: convert this to labels by ID
 def get_dataset_feature_labels_by_id(dataset_id) -> dict[str, str]:
     """
     Get a mapping of feature labels to given IDs.

--- a/portal-backend/depmap/data_page/api.py
+++ b/portal-backend/depmap/data_page/api.py
@@ -47,7 +47,7 @@ def _get_drug_count_mapping(data_types: List[str]):
         if not dataset:
             return None
 
-        return len(data_access.get_dataset_feature_ids_by_label(dataset_name))
+        return len(data_access.get_dataset_feature_labels_by_id(dataset_name))
 
     drug_counts_by_data_type = {
         "Drug_CTD_Broad": _get_drug_count(DependencyEnum.CTRP_AUC.name),

--- a/portal-backend/depmap/dataset_manager/api.py
+++ b/portal-backend/depmap/dataset_manager/api.py
@@ -78,7 +78,8 @@ class CopyToBreadbox(
             dataset_id, feature_row_labels=None, sample_col_ids=None
         )
         # Convert column names from label -> id
-        feature_ids_by_label = data_access.get_dataset_feature_ids_by_label(dataset_id)
+        feature_labels_by_id = data_access.get_dataset_feature_labels_by_id(dataset_id)
+        feature_ids_by_label = {label: id for id, label in feature_labels_by_id}
         breadbox_upload_df = legacy_data_df.transpose().rename(
             columns=feature_ids_by_label
         )

--- a/portal-backend/depmap/interactive/interactive_utils/__init__.py
+++ b/portal-backend/depmap/interactive/interactive_utils/__init__.py
@@ -41,7 +41,7 @@ from .get_and_process_data import (
     get_category_config,  # used only by get-features calls which involve custom analysis two class comparisons
     get_context_dataset,  # 6 uses, mostly vector catalog, also predictability
     get_custom_cell_lines_dataset,  # used in custom analysis, DE1, and in other interactive function implementations
-    get_dataset_feature_ids_by_label,
+    get_dataset_feature_labels_by_id,
     get_dataset_feature_labels,
     get_dataset_sample_ids,
     get_dataset_sample_labels_by_id,

--- a/portal-backend/depmap/interactive/interactive_utils/__init__.py
+++ b/portal-backend/depmap/interactive/interactive_utils/__init__.py
@@ -44,6 +44,7 @@ from .get_and_process_data import (
     get_dataset_feature_ids_by_label,
     get_dataset_feature_labels,
     get_dataset_sample_ids,
+    get_dataset_sample_labels_by_id,
     get_matrix,  # downloads: check dataset size
     get_row_of_values,  # very heavily used
     get_row_of_values_from_slice_id,  # used by custom analysis, DE2, vector catalog, tests

--- a/portal-backend/depmap/interactive/interactive_utils/get_and_process_data.py
+++ b/portal-backend/depmap/interactive/interactive_utils/get_and_process_data.py
@@ -142,6 +142,22 @@ def get_dataset_feature_ids_by_label(dataset_id) -> dict[str, str]:
     return {row.label: row.entity_id for row in row_summaries}
 
 
+def get_dataset_sample_labels_by_id(dataset_id) -> dict[str, str]:
+    """
+    Get a mapping of sample labels to sample IDs.
+    Samples from the legacy backend are always depmap_models, so it's safe to
+    hard-code that labels should always be cell line display names. 
+    """
+    # TODO: write a unit test for this
+    dataset_sample_ids = get_dataset_sample_ids(dataset_id)
+    all_model_labels_by_id = CellLine.get_cell_line_display_name_series().to_dict()
+    return {
+        id: label
+        for label, id in all_model_labels_by_id.items()
+        if id in dataset_sample_ids
+    }
+
+
 def get_dataset_feature_labels(dataset_id: str) -> list[str]:
     """
     Get a list of all feature/entity labels for the given dataset.

--- a/portal-backend/depmap/interactive/interactive_utils/get_and_process_data.py
+++ b/portal-backend/depmap/interactive/interactive_utils/get_and_process_data.py
@@ -134,15 +134,15 @@ def get_all_row_indices_labels_entity_ids(dataset_id) -> List[RowSummary]:
         return nonstandard_utils.get_all_row_indices_labels_entity_ids(dataset_id)
 
 
-def get_dataset_feature_ids_by_label(dataset_id) -> dict[str, str]:
+def get_dataset_feature_labels_by_id(dataset_id: str) -> dict[str, str]:
     """
-    Get a mapping of feature labels to feature IDs.
+    Get a mapping of feature IDs to feature labels.
     """
     row_summaries = get_all_row_indices_labels_entity_ids(dataset_id)
-    return {row.label: row.entity_id for row in row_summaries}
+    return {row.entity_id: row.label for row in row_summaries}
 
 
-def get_dataset_sample_labels_by_id(dataset_id) -> dict[str, str]:
+def get_dataset_sample_labels_by_id(dataset_id: str) -> dict[str, str]:
     """
     Get a mapping of sample labels to sample IDs.
     Samples from the legacy backend are always depmap_models, so it's safe to

--- a/portal-backend/depmap/interactive/interactive_utils/get_and_process_data.py
+++ b/portal-backend/depmap/interactive/interactive_utils/get_and_process_data.py
@@ -148,12 +148,11 @@ def get_dataset_sample_labels_by_id(dataset_id) -> dict[str, str]:
     Samples from the legacy backend are always depmap_models, so it's safe to
     hard-code that labels should always be cell line display names. 
     """
-    # TODO: write a unit test for this
     dataset_sample_ids = get_dataset_sample_ids(dataset_id)
     all_model_labels_by_id = CellLine.get_cell_line_display_name_series().to_dict()
     return {
         id: label
-        for label, id in all_model_labels_by_id.items()
+        for id, label in all_model_labels_by_id.items()
         if id in dataset_sample_ids
     }
 


### PR DESCRIPTION
Currently, the way the `portal-backend` uses sample labels doesn't match the way we configure and use sample labels in breadbox. 

For example:
* In breadbox, `depmap_models` are configured [here](https://github.com/broadinstitute/depmap-deploy/blob/08651f06cb2994318ba6a5293bcdcab046483485/depmap_deploy/breadbox_loader/configs/release_files.py#L20C60-L20C72) to use `CellLineName` as their labels. 
* However, endpoints like DE2's `/context/labels` ignore this config and continue to return depmap_ids as the "labels" instead of using cell line names. 

Eventually, we would like DE2 to be able to use whatever "sample label" is configured in breadbox. This PR adds/updates some methods in the `data_access` interface to make that possible. 

**This includes:**
* Defining`get_dataset_sample_labels_by_id`
* Replacing the little-used function `get_dataset_feature_ids_by_label` with `get_dataset_feature_labels_by_id` (for consistent naming)

Once we decide on a new slice ID format, I will implement any other data_access functions that are needed to support the new format (ex. looking up data by sample label). 

