### PR TITLE
fix(breadbox): throw FileValidationError for duplicate CSV columns

### DIFF
--- a/breadbox/breadbox/io/data_validation.py
+++ b/breadbox/breadbox/io/data_validation.py
@@ -200,6 +200,8 @@ def _read_csv(file: BinaryIO, value_type: ValueType) -> pd.DataFrame:
     text_io = io.TextIOWrapper(file, encoding="utf-8")
     dict_reader = csv.DictReader(text_io)
     headers = dict_reader.fieldnames
+    if headers is None:
+        raise FileValidationError(f"Unable to read CSV file header.")
     if len(set(headers)) != len(headers):
         raise FileValidationError(f"Make sure all column names are unique.")
 

--- a/breadbox/breadbox/io/data_validation.py
+++ b/breadbox/breadbox/io/data_validation.py
@@ -1,5 +1,7 @@
+import csv
 from dataclasses import dataclass
 from typing import Any, BinaryIO, Dict, List, Optional, Sequence, Union
+import io
 import json
 
 import numpy as np
@@ -118,10 +120,6 @@ def _validate_dimension_type_metadata_file(
     except ValueError as e:
         raise AnnotationValidationError(str(e))
 
-    # make sure id column is unique
-    if not df[id_column].is_unique:
-        raise FileValidationError(f"Make sure all ids in {id_column} are unique.")
-
     # make sure id column have no missing info
     if df[id_column].isnull().values.any():
         raise FileValidationError(
@@ -197,8 +195,15 @@ from typing import cast
 
 
 def _read_csv(file: BinaryIO, value_type: ValueType) -> pd.DataFrame:
-    cols = pd.read_csv(file, nrows=0).columns
+    # When pandas reads non-unique columns from a CSV, it mangles them to make them unique.
+    # As a workaround, load and validate the columns first using csv.DictReader.
+    text_io = io.TextIOWrapper(file, encoding="utf-8")
+    dict_reader = csv.DictReader(text_io)
+    headers = dict_reader.fieldnames
+    if len(set(headers)) != len(headers):
+        raise FileValidationError(f"Make sure all column names are unique.")
 
+    cols = pd.read_csv(text_io, nrows=0).columns
     if value_type == ValueType.continuous:
         dtypes_ = dict(zip(cols, ["string"] + (["Float64"] * (len(cols) - 1))))
     elif value_type == ValueType.categorical:
@@ -216,7 +221,10 @@ def _read_csv(file: BinaryIO, value_type: ValueType) -> pd.DataFrame:
 
 
 def _validate_data_file(
-    df: pd.DataFrame, value_type: ValueType, allowed_values: Optional[List[str]],
+    df: pd.DataFrame,
+    file: BinaryIO,
+    value_type: ValueType,
+    allowed_values: Optional[List[str]],
 ) -> pd.DataFrame:
     """
     Validates the data values against it's given value_type.
@@ -232,6 +240,7 @@ def _validate_data_file(
 
 
 def verify_unique_rows_and_cols(df: pd.DataFrame):
+    # TODO: this is the place where uniqueness is getting verified now
     duplicated_columns = df.columns[df.columns.duplicated()]
     if len(duplicated_columns) > 0:
         raise FileValidationError(
@@ -399,7 +408,9 @@ def validate_and_upload_dataset_files(
 
     unchecked_df.set_index(unchecked_df.columns[0], inplace=True)
 
-    data_df = _validate_data_file(unchecked_df, value_type, allowed_values,)
+    data_df = _validate_data_file(
+        unchecked_df, data_file.file, value_type, allowed_values,
+    )
 
     dataframe_validated_dimensions = _validate_dataset_dimensions(
         db, data_df, feature_type, sample_type

--- a/breadbox/breadbox/io/data_validation.py
+++ b/breadbox/breadbox/io/data_validation.py
@@ -207,7 +207,10 @@ def _read_csv(file: BinaryIO, value_type: ValueType) -> pd.DataFrame:
     if headers and len(set(headers)) != len(headers):
         raise FileValidationError(f"Make sure all column names are unique.")
 
-    cols = pd.read_csv(text_io, nrows=0).columns
+    # Reset the cursor and read the file into a dataframe
+    file.seek(0)
+    cols = pd.read_csv(file, nrows=0).columns
+
     if value_type == ValueType.continuous:
         dtypes_ = dict(zip(cols, ["string"] + (["Float64"] * (len(cols) - 1))))
     elif value_type == ValueType.categorical:


### PR DESCRIPTION
[Asana](https://app.asana.com/0/1165651979405609/1208078862632786/f)

When the pandas `read_csv` function encounters duplicate columns, it renames one of the duplicates instead of throwing an error. As a result, our CSV reading function needs to do one additional step:
1. First, read the header with `csv.DictReader` and check for duplicate columns
2. Then, read the full file with pandas and continue on as usual. 

I learned that this isn't an issue for parquet file uploads because the file format doesn't support duplicate column names. If you try to do `pd.to_parquet` with a duplicate column name, you get a clear error message like: `ValueError: Duplicate column names found: ['a', 'b', 'b']`

