### PR TITLE
add flag for faster development

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -43,8 +43,17 @@ or
 yarn dev:portal
 ```
 
-(But you can still do `./flask webpack` from the portal-backend directory if
-that's what you're used to. All it does is call `yarn dev:portal` for you).
+This runs Webpack Dev Server which watches for changes and automatically pushes
+them to the browser. Most of the time changes are applied in a second or two.
+But if you find that it's getting hung up or you're just impatient, you can use
+this:
+
+```
+yarn dev:portal:nocheck
+```
+
+This will speed up the compilation time but be warned that TypeScript errors
+will no longer be displayed in the terminal or browser console!
 
 ## @depmap packages
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,9 @@
   "scripts": {
     "test": "yarn workspaces run test",
     "dev:elara": "yarn workspace elara-frontend dev",
+    "dev:elara:nocheck": "yarn workspace elara-frontend dev --env transpileOnly=true",
     "dev:portal": "yarn workspace portal-frontend dev",
+    "dev:portal:nocheck": "yarn workspace portal-frontend dev --env transpileOnly=true",
     "build:elara": "yarn workspace elara-frontend build",
     "build:portal": "yarn workspace portal-frontend build",
     "analyze:elara": "yarn workspace elara-frontend analyze",

--- a/frontend/packages/elara-frontend/webpack.dev.js
+++ b/frontend/packages/elara-frontend/webpack.dev.js
@@ -4,7 +4,7 @@ const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin"
 const ReactRefreshTypeScript = require("react-refresh-typescript");
 const jsonImporter = require("node-sass-json-importer");
 
-module.exports = merge(common, {
+const devConfig = (env, argv) => ({
   mode: "development",
 
   devtool: "cheap-module-source-map",
@@ -44,6 +44,7 @@ module.exports = merge(common, {
           {
             loader: require.resolve("ts-loader"),
             options: {
+              transpileOnly: env.transpileOnly === "true",
               getCustomTransformers: () => ({
                 before: [ReactRefreshTypeScript()],
               }),
@@ -82,3 +83,5 @@ module.exports = merge(common, {
     ],
   },
 });
+
+module.exports = (env, argv) => merge(common, devConfig(env, argv));

--- a/frontend/packages/portal-frontend/webpack.dev.js
+++ b/frontend/packages/portal-frontend/webpack.dev.js
@@ -4,7 +4,7 @@ const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin"
 const ReactRefreshTypeScript = require("react-refresh-typescript");
 const jsonImporter = require("node-sass-json-importer");
 
-module.exports = merge(common, {
+const devConfig = (env, argv) => ({
   mode: "development",
 
   devtool: "cheap-module-source-map",
@@ -42,6 +42,7 @@ module.exports = merge(common, {
           {
             loader: require.resolve("ts-loader"),
             options: {
+              transpileOnly: env.transpileOnly === "true",
               getCustomTransformers: () => ({
                 before: [ReactRefreshTypeScript()],
               }),
@@ -77,3 +78,5 @@ module.exports = merge(common, {
     ],
   },
 });
+
+module.exports = (env, argv) => merge(common, devConfig(env, argv));


### PR DESCRIPTION
This adds a new `yarn dev:portal:nocheck` script that will start the frontend dev server with type checking disabled. This is a nice option to use when you're making lots of small incremental changes and you prefer speed over visibility of errors. You'll notice updates happening faster but you'll also no longer see type errors in the terminal or browser console.

Modern IDEs like Visual Studio Code run their own language server which is constantly compiling the codebase in the background in order to show inline error messages. This makes those other forms of error reporting somewhat redundant.

Note that this only affects the TypeScript compiler. ESLint will continue to run as before so you'll still see linting errors.