### PR TITLE
chore(breadbox): Deprecate feature type and sample type endpoints

### DIFF
--- a/breadbox-client/latest-breadbox-api.json
+++ b/breadbox-client/latest-breadbox-api.json
@@ -6062,6 +6062,7 @@
     },
     "/types/feature": {
       "get": {
+        "deprecated": true,
         "operationId": "get_feature_types",
         "responses": {
           "200": {
@@ -6125,6 +6126,7 @@
         ]
       },
       "post": {
+        "deprecated": true,
         "operationId": "add_feature_type",
         "requestBody": {
           "content": {
@@ -6206,6 +6208,7 @@
     },
     "/types/feature/{feature_type_name}/metadata": {
       "patch": {
+        "deprecated": true,
         "operationId": "update_feature_type_metadata",
         "parameters": [
           {
@@ -6298,6 +6301,7 @@
     },
     "/types/feature/{feature_type}": {
       "delete": {
+        "deprecated": true,
         "description": "Delete a feature type, if the user is an admin.",
         "operationId": "remove_feature_type",
         "parameters": [
@@ -6379,6 +6383,7 @@
     },
     "/types/sample": {
       "get": {
+        "deprecated": true,
         "operationId": "get_sample_types",
         "responses": {
           "200": {
@@ -6442,6 +6447,7 @@
         ]
       },
       "post": {
+        "deprecated": true,
         "operationId": "add_sample_type",
         "requestBody": {
           "content": {
@@ -6523,6 +6529,7 @@
     },
     "/types/sample/{sample_type_name}/metadata": {
       "patch": {
+        "deprecated": true,
         "operationId": "update_sample_type_metadata",
         "parameters": [
           {
@@ -6615,6 +6622,7 @@
     },
     "/types/sample/{sample_type}": {
       "delete": {
+        "deprecated": true,
         "description": "Delete a sample type, if the user is an admin.",
         "operationId": "remove_sample_type",
         "parameters": [

--- a/breadbox/breadbox/api/types.py
+++ b/breadbox/breadbox/api/types.py
@@ -45,6 +45,7 @@ from pydantic import Json
     response_model=SampleTypeOut,
     response_model_by_alias=False,
     response_model_exclude_none=True,
+    deprecated=True,
 )
 def add_sample_type(
     name: str = Form(...),
@@ -171,6 +172,7 @@ def add_dimension_type(
     response_model=FeatureTypeOut,
     response_model_by_alias=False,
     response_model_exclude_none=True,
+    deprecated=True,
 )
 def add_feature_type(
     name: Annotated[str, Form(...)],
@@ -244,6 +246,7 @@ def add_feature_type(
     response_model=List[SampleTypeOut],
     response_model_by_alias=False,
     response_model_exclude_none=True,
+    deprecated=True,
 )
 def get_sample_types(db: SessionWithUser = Depends(get_db_with_user)):
     samples = type_crud.get_dimension_types(db, axis="sample")
@@ -256,6 +259,7 @@ def get_sample_types(db: SessionWithUser = Depends(get_db_with_user)):
     response_model=List[FeatureTypeOut],
     response_model_by_alias=False,
     response_model_exclude_none=True,
+    deprecated=True,
 )
 def get_feature_types(db: SessionWithUser = Depends(get_db_with_user)):
     features = type_crud.get_dimension_types(db, axis="feature")
@@ -267,6 +271,7 @@ def get_feature_types(db: SessionWithUser = Depends(get_db_with_user)):
     operation_id="update_sample_type_metadata",
     response_model=SampleTypeOut,
     response_model_exclude_none=True,
+    deprecated=True,
 )
 def update_sample_type_metadata(
     sample_type_name: str,
@@ -364,6 +369,7 @@ def update_sample_type_metadata(
     operation_id="update_feature_type_metadata",
     response_model=FeatureTypeOut,
     response_model_exclude_none=True,
+    deprecated=True,
 )
 def update_feature_type_metadata(
     feature_type_name: str,
@@ -444,7 +450,7 @@ def update_feature_type_metadata(
 
 
 @router.delete(
-    "/sample/{sample_type}", operation_id="remove_sample_type",
+    "/sample/{sample_type}", operation_id="remove_sample_type", deprecated=True
 )
 def delete_sample_type(
     sample_type: str,
@@ -478,7 +484,7 @@ def delete_sample_type(
 
 
 @router.delete(
-    "/feature/{feature_type}", operation_id="remove_feature_type",
+    "/feature/{feature_type}", operation_id="remove_feature_type", deprecated=True
 )
 def delete_feature_type(
     feature_type: str,

--- a/breadbox/db_load.py
+++ b/breadbox/db_load.py
@@ -9,7 +9,7 @@ import pandas as pd
 from breadbox.crud.types import add_dimension_type
 
 from breadbox.crud.data_type import get_data_types
-from breadbox.api.types import add_feature_type, add_sample_type, Settings
+from breadbox.api.types import Settings
 from breadbox.schemas.types import IdMapping, AnnotationTypeMap
 import os
 from typing import Protocol, Any


### PR DESCRIPTION
These endpoints should now be under the URI "dimensions"