### PR TITLE
Set default resources topic

### DIFF
--- a/config/dev/settings.py
+++ b/config/dev/settings.py
@@ -170,6 +170,9 @@ class DevConfig(Config):
     RELEASE_NOTES_URL = get_setting_from_config("RELEASE_NOTES_URL", ENV_TYPE)
     FORUM_URL = get_setting_from_config("FORUM_URL", ENV_TYPE)
     FORUM_RESOURCES_CATEGORY = "resources-prototype"
+    FORUM_RESOURCES_DEFAULT_TOPIC_ID = get_setting_from_config(
+        "FORUM_RESOURCES_DEFAULT_TOPIC_ID", ENV_TYPE
+    )
 
     # to test oauth signing using ssh tunnel
     # SERVER_NAME = "dev.cds.team"

--- a/config/public/settings.py
+++ b/config/public/settings.py
@@ -55,6 +55,7 @@ class ExternalConfig(RemoteConfig):
     RELEASE_NOTES_URL = "https://forum.depmap.org/c/announcements/15"
     FORUM_URL = "https://forum.depmap.org/"
     FORUM_RESOURCES_CATEGORY = "resources-prototype"
+    FORUM_RESOURCES_DEFAULT_TOPIC_ID = 3396
     BREADBOX_PROXY_DEFAULT_USER = "anonymous"
 
 

--- a/frontend/packages/portal-frontend/src/apps/resourcesPage.tsx
+++ b/frontend/packages/portal-frontend/src/apps/resourcesPage.tsx
@@ -28,6 +28,7 @@ const App = () => {
         <ResourcesPage
           subcategories={rootCategory.subcategories}
           title={rootCategory.title}
+          default_topic={rootCategory.default_topic}
         />
       </Router>
     </ErrorBoundary>

--- a/frontend/packages/portal-frontend/src/resources/components/ResourcesPage.tsx
+++ b/frontend/packages/portal-frontend/src/resources/components/ResourcesPage.tsx
@@ -9,6 +9,7 @@ import styles from "src/resources/styles/ResourcesPage.scss";
 interface ResourcesPageProps {
   subcategories: any;
   title: string;
+  default_topic: any;
 }
 
 // A custom hook that builds on useLocation to parse
@@ -20,7 +21,7 @@ function useQuery() {
 }
 
 export default function ResourcesPage(props: ResourcesPageProps) {
-  const { subcategories, title } = props;
+  const { subcategories, title, default_topic } = props;
   console.log(subcategories);
   const query = useQuery();
 
@@ -29,15 +30,17 @@ export default function ResourcesPage(props: ResourcesPageProps) {
     const subcategory = subcategories.find(
       (sub: any) => sub.slug === query.get("subcategory")
     );
-    let post = null;
+    let post;
     if (subcategory) {
       const topic = subcategory.topics.find(
         (t: any) => t.slug === query.get("topic")
       );
       post = topic;
+    } else {
+      post = default_topic;
     }
     return post;
-  }, [subcategories, query]);
+  }, [subcategories, query, default_topic]);
 
   return (
     <div>

--- a/portal-backend/depmap/public/resources.py
+++ b/portal-backend/depmap/public/resources.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 from dataclasses import dataclass
 from ..discourse.client import DiscourseClient
 from ..discourse.utils import reformat_date
@@ -31,6 +31,7 @@ class Subcategory:
 class RootCategory:
     title: str
     subcategories: List[Subcategory]
+    default_topic: Optional[Topic] = None
 
 
 def create_sanitizer() -> Sanitizer:
@@ -114,7 +115,10 @@ def modify_html(
 
 
 def get_root_category_subcategory_topics(
-    client: DiscourseClient, sanitizer: Sanitizer, category_slug: str
+    client: DiscourseClient,
+    sanitizer: Sanitizer,
+    category_slug: str,
+    default_topic_id: Optional[int],
 ):
     # Get the root category
     category = client.get_category_with_subcategories(category_slug)
@@ -155,6 +159,8 @@ def get_root_category_subcategory_topics(
                 creation_date=creation_date,
                 update_date=update_date,
             )
+            if default_topic_id == topic_id:
+                root_category.default_topic = topic
 
             # Add Topic to list of topics for Subcategory
             sub_category.topics.append(topic)

--- a/portal-backend/depmap/public/views.py
+++ b/portal-backend/depmap/public/views.py
@@ -186,7 +186,10 @@ def resources_prototype():
 
     try:
         root_category = get_root_category_subcategory_topics(
-            client, sanitizer, current_app.config.get("FORUM_RESOURCES_CATEGORY")
+            client,
+            sanitizer,
+            current_app.config.get("FORUM_RESOURCES_CATEGORY"),
+            current_app.config.get("FORUM_RESOURCES_DEFAULT_TOPIC_ID"),
         )
 
     except requests.exceptions.HTTPError as err:


### PR DESCRIPTION
Ops has decided that they want to draft their own post that the resources page will default to when a user first arrives at the resources page. I've added a new Flask variable to store the stable topic identifier from Discourse that maps to the default post that ops wants to show. 