### PR TITLE
Resources open init post accordion

### DIFF
--- a/frontend/packages/@depmap/interactive/src/components/Accordion.tsx
+++ b/frontend/packages/@depmap/interactive/src/components/Accordion.tsx
@@ -42,7 +42,7 @@ export default class Accordion extends React.Component<Props, State> {
     const { isOpen } = this.props;
 
     if (prevProps.isOpen !== isOpen) {
-      if (isOpen !== undefined) {
+      if (isOpen !== undefined && prevProps.isOpen !== undefined) {
         this.toggle();
       }
     }

--- a/frontend/packages/@depmap/interactive/src/components/Accordion.tsx
+++ b/frontend/packages/@depmap/interactive/src/components/Accordion.tsx
@@ -42,7 +42,9 @@ export default class Accordion extends React.Component<Props, State> {
     const { isOpen } = this.props;
 
     if (prevProps.isOpen !== isOpen) {
-      this.toggle();
+      if (isOpen !== undefined) {
+        this.toggle();
+      }
     }
   };
 

--- a/frontend/packages/portal-frontend/src/resources/components/ResourcesPage.tsx
+++ b/frontend/packages/portal-frontend/src/resources/components/ResourcesPage.tsx
@@ -23,6 +23,7 @@ export default function ResourcesPage(props: ResourcesPageProps) {
   const { subcategories, defaultTopic } = props;
   console.log(subcategories);
   const query = useQuery();
+  const [initSubcategory] = useState(query.get("subcategory"));
 
   // If window location url has query params at the start, find the post to show
   const initPost = useMemo(() => {
@@ -52,14 +53,20 @@ export default function ResourcesPage(props: ResourcesPageProps) {
           return true;
         }
 
-        return false;
+        return undefined;
       }
       // eslint-disable-next-line no-else-return
       else {
+        const selectedTopic = subcategory.topics.find(
+          (topic: any) => initPost.id === topic.id
+        );
+        if (selectedTopic && initSubcategory === subcategory.slug) {
+          return true;
+        }
         return undefined;
       }
     },
-    [defaultTopic.id, query]
+    [defaultTopic.id, initPost.id, initSubcategory, query]
   );
 
   return (

--- a/frontend/packages/portal-frontend/src/resources/components/ResourcesPage.tsx
+++ b/frontend/packages/portal-frontend/src/resources/components/ResourcesPage.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useMemo } from "react";
+import { useMemo, useCallback, useState } from "react";
 import { ListGroup, ListGroupItem } from "react-bootstrap";
 import { Accordion } from "@depmap/interactive";
 import { Link, useLocation } from "react-router-dom";
@@ -41,6 +41,27 @@ export default function ResourcesPage(props: ResourcesPageProps) {
     return post;
   }, [subcategories, query, defaultTopic]);
 
+  const subcategoryIsOpen = useCallback(
+    (subcategory: any) => {
+      console.log("query ", query.get("subcategory"));
+      const welcomeTopic = subcategory.topics.find(
+        (topic: any) => defaultTopic.id === topic.id
+      );
+      if (query.get("subcategory") === null) {
+        if (welcomeTopic) {
+          return true;
+        }
+
+        return false;
+      }
+      // eslint-disable-next-line no-else-return
+      else {
+        return undefined;
+      }
+    },
+    [defaultTopic.id, query]
+  );
+
   return (
     <div className={styles.ResourcesPageContainer}>
       <div className={styles.resourcesPageHeader}>
@@ -54,7 +75,11 @@ export default function ResourcesPage(props: ResourcesPageProps) {
       <section className={styles.postsNavList}>
         {subcategories.map((subcategory: any) => {
           return (
-            <Accordion key={subcategory.id} title={subcategory.title}>
+            <Accordion
+              key={subcategory.id}
+              title={subcategory.title}
+              isOpen={subcategoryIsOpen(subcategory)}
+            >
               <ListGroup style={{ marginBottom: 0, borderRadius: 0 }}>
                 {subcategory.topics.map((topic: any) => {
                   return (

--- a/frontend/packages/portal-frontend/src/resources/components/ResourcesPage.tsx
+++ b/frontend/packages/portal-frontend/src/resources/components/ResourcesPage.tsx
@@ -21,12 +21,12 @@ function useQuery() {
 
 export default function ResourcesPage(props: ResourcesPageProps) {
   const { subcategories, defaultTopic } = props;
-  console.log(subcategories);
   const query = useQuery();
+  // the subcategory url query param value when the Resources Page is first rendered
   const [initSubcategory] = useState(query.get("subcategory"));
 
-  // If window location url has query params at the start, find the post to show
-  const initPost = useMemo(() => {
+  // If window location url has query params, find the corresponding post to show. If there are no query params, show the default post
+  const postToShow = useMemo(() => {
     const subcategory = subcategories.find(
       (sub: any) => sub.slug === query.get("subcategory")
     );
@@ -42,12 +42,13 @@ export default function ResourcesPage(props: ResourcesPageProps) {
     return post;
   }, [subcategories, query, defaultTopic]);
 
+  // Determines whether the accordion for the subcategory should be open. The default state is undefined
   const subcategoryIsOpen = useCallback(
     (subcategory: any) => {
-      console.log("query ", query.get("subcategory"));
       const welcomeTopic = subcategory.topics.find(
         (topic: any) => defaultTopic.id === topic.id
       );
+      // when there are no url query params, this means the default welcome post should be shown. Open accordion for the subcategory of that topic
       if (query.get("subcategory") === null) {
         if (welcomeTopic) {
           return true;
@@ -58,15 +59,16 @@ export default function ResourcesPage(props: ResourcesPageProps) {
       // eslint-disable-next-line no-else-return
       else {
         const selectedTopic = subcategory.topics.find(
-          (topic: any) => initPost.id === topic.id
+          (topic: any) => postToShow.id === topic.id
         );
+        // Open the accordion for the post that matches the initial url query params at time of component's render
         if (selectedTopic && initSubcategory === subcategory.slug) {
           return true;
         }
         return undefined;
       }
     },
-    [defaultTopic.id, initPost.id, initSubcategory, query]
+    [defaultTopic.id, postToShow.id, initSubcategory, query]
   );
 
   return (
@@ -99,7 +101,9 @@ export default function ResourcesPage(props: ResourcesPageProps) {
                       <ListGroupItem
                         className={styles.navPostItem}
                         style={{ borderRadius: "0px" }}
-                        active={initPost ? initPost.slug === topic.slug : false}
+                        active={
+                          postToShow ? postToShow.slug === topic.slug : false
+                        }
                       >
                         {topic.title}
                       </ListGroupItem>
@@ -112,15 +116,15 @@ export default function ResourcesPage(props: ResourcesPageProps) {
         })}
       </section>
       <section className={styles.postContentContainer}>
-        {initPost ? (
+        {postToShow ? (
           <div className={styles.postContent}>
             <div className={styles.postDate}>
-              <p>Posted: {initPost.creation_date}</p>
-              <p>Updated: {initPost.update_date}</p>
+              <p>Posted: {postToShow.creation_date}</p>
+              <p>Updated: {postToShow.update_date}</p>
             </div>
             <div
               // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{ __html: initPost.post_content }}
+              dangerouslySetInnerHTML={{ __html: postToShow.post_content }}
             />
           </div>
         ) : null}


### PR DESCRIPTION
We want the accordion open for the initial post on the resources page. However, some changes to the Accordion component were necessary since it appears that the toggle behavior is somewhat buggy

The previous buggy behavior was that if the initial Accordion is set to be open, when we choose a different post, the accordion closes.


https://github.com/user-attachments/assets/3521c5a7-3ad5-4cfd-88c0-1fd770916410



Upon further investigation, it seems like this is due to the Accordion component's `isOpen` state. When that is set to `isOpen=true`, the next time that Accordion's state is changed it will automatically be set to `isOpen=false` through its `toggle()` function. However, I only want to activate the toggle function when we click the Accordion and in order to do that, it needs to determine the previous state. Note that the default `isOpen` state is `undefined`



https://github.com/user-attachments/assets/4602c6d3-b4fa-4680-9c59-73eba06d158f


