### PR TITLE
Update dataset form JSON schema

### DIFF
--- a/frontend/packages/@depmap/dataset-manager/src/components/MatrixDatasetForm.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/MatrixDatasetForm.tsx
@@ -191,7 +191,6 @@ const uiSchema: UiSchema = {
     "allowed_values",
     "data_type",
     "priority",
-    "taiga_id",
     "dataset_metadata",
     "is_transient",
     "format",

--- a/frontend/packages/@depmap/dataset-manager/src/components/TableDatasetForm.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/TableDatasetForm.tsx
@@ -84,7 +84,6 @@ const uiSchema: UiSchema = {
     "group_id",
     "data_type",
     "priority",
-    "taiga_id",
     "dataset_metadata",
     "is_transient",
     "format",

--- a/frontend/packages/@depmap/dataset-manager/src/models/matrixDatasetFormSchema.ts
+++ b/frontend/packages/@depmap/dataset-manager/src/models/matrixDatasetFormSchema.ts
@@ -11,7 +11,6 @@ export const matrixFormSchema: Required<Pick<RJSFSchema, "properties">> &
     "group_id",
     "format",
     "units",
-    "feature_type",
     "sample_type",
     "value_type",
   ],
@@ -87,21 +86,16 @@ export const matrixFormSchema: Required<Pick<RJSFSchema, "properties">> &
       title: "Group Id",
       type: "string",
       description:
-        "ID of the group the dataset belongs to. Required for non-transient datasets. The public group is `00000000-0000-0000-0000-000000000000`",
+        "ID of the group the dataset belongs to. Required for non-transient datasets.",
       format: "uuid",
     },
     priority: {
       title: "Priority",
       minimum: 1, // not in openapi.json but added to solve exclusiveMinimum problem
       // exclusiveMinimum: 0, In openapi.json but RJSF not recognizing exclusiveMinimum and exclusiveMaximum keywords?
-      type: "integer",
+      type: ["integer", "null"], // "null" must be string or else it throws an error
       description:
         "Numeric value assigned to the dataset with `1` being highest priority within the `data_type`, used for displaying order of datasets to show for a specific `data_type` in UI.",
-    },
-    taiga_id: {
-      title: "Taiga Id",
-      type: "string",
-      description: "Taiga ID the dataset is sourced from.",
     },
     is_transient: {
       // TODO: This should be required param in bb
@@ -113,7 +107,7 @@ export const matrixFormSchema: Required<Pick<RJSFSchema, "properties">> &
     },
     dataset_metadata: {
       title: "Dataset Metadata",
-      type: "object",
+      type: ["object", "null"],
       description:
         "Contains a dictionary of additional dataset values that are not already provided above.",
     },
@@ -130,7 +124,7 @@ export const matrixFormSchema: Required<Pick<RJSFSchema, "properties">> &
     },
     feature_type: {
       title: "Feature Type",
-      type: "string",
+      type: ["string", "null"],
       description: "Type of features your dataset contains",
     },
     sample_type: {

--- a/frontend/packages/@depmap/dataset-manager/src/models/tableDatasetFormSchema.ts
+++ b/frontend/packages/@depmap/dataset-manager/src/models/tableDatasetFormSchema.ts
@@ -78,20 +78,15 @@ export const tableFormSchema: Required<Pick<RJSFSchema, "properties">> &
       title: "Group Id",
       type: "string",
       description:
-        "ID of the group the dataset belongs to. Required for non-transient datasets. The public group is `00000000-0000-0000-0000-000000000000`",
+        "ID of the group the dataset belongs to. Required for non-transient datasets.",
       format: "uuid",
     },
     priority: {
       title: "Priority",
       minimum: 1,
-      type: "integer",
+      type: ["integer", "null"],
       description:
         "Numeric value assigned to the dataset with `1` being highest priority within the `data_type`, used for displaying order of datasets to show for a specific `data_type` in UI.",
-    },
-    taiga_id: {
-      title: "Taiga Id",
-      type: "string",
-      description: "Taiga ID the dataset is sourced from.",
     },
     is_transient: {
       // TODO: This should be required param in bb
@@ -103,7 +98,7 @@ export const tableFormSchema: Required<Pick<RJSFSchema, "properties">> &
     },
     dataset_metadata: {
       title: "Dataset Metadata",
-      type: "object",
+      type: ["object", "null"],
       description:
         "Contains a dictionary of additional dataset values that are not already provided above.",
     },


### PR DESCRIPTION
Changes:

- Explicitly allow null values previously causing error in RJSF validation. Fields that are not under "required" keyword in the JSON schema mean that they should be omitted or have value as `undefined` in the `formData` state value which is confusing. The default value in the backend for these form fields is `None` which corresponds to `null` and the openapi.json schema also allows "null" as a value so I updated the RJSF to be closer to the specs
- Remove `taiga_id` form field since users except ourselves shouldn't fill that out
- For matrix datasets, `feature_type` can be optional