### PR TITLE
Wrapping up support for v2 Contexts

### DIFF
--- a/portal-backend/depmap/data_access/interface.py
+++ b/portal-backend/depmap/data_access/interface.py
@@ -269,24 +269,39 @@ def get_slice_data(slice_query: SliceQuery) -> pd.Series:
     dataset_id = slice_query.dataset_id
 
     if slice_query.identifier_type == "feature_id":
-        raise NotImplementedError()
+        feature_labels_by_id = get_dataset_feature_labels_by_id(dataset_id)
+        query_feature_label = feature_labels_by_id[slice_query.identifier]
+        values_by_sample_id = get_subsetted_df_by_labels(
+            slice_query.dataset_id, feature_row_labels=[query_feature_label]
+        ).squeeze()
+        return values_by_sample_id
 
     elif slice_query.identifier_type == "feature_label":
-        values_by_label = get_subsetted_df_by_labels(
+        values_by_sample_id = get_subsetted_df_by_labels(
             slice_query.dataset_id, feature_row_labels=[slice_query.identifier]
         ).squeeze()
-        ids_by_label = get_dataset_dimension_ids_by_label(dataset_id, axis="sample")
-        return values_by_label.rename(ids_by_label)
+        return values_by_sample_id
 
     elif slice_query.identifier_type == "sample_id":
-        values_by_label: pd.Series = get_subsetted_df_by_labels(
+        values_by_feature_label: pd.Series = get_subsetted_df_by_labels(
             slice_query.dataset_id, sample_col_ids=[slice_query.identifier]
         ).squeeze()
-        ids_by_label = get_dataset_dimension_ids_by_label(dataset_id, axis="feature")
-        return values_by_label.rename(ids_by_label)
+        feature_ids_by_label = get_dataset_dimension_ids_by_label(
+            dataset_id, axis="feature"
+        )
+        return values_by_feature_label.rename(feature_ids_by_label)
 
     elif slice_query.identifier_type == "sample_label":
-        raise NotImplementedError()
+        ids_by_label = get_dataset_dimension_ids_by_label(dataset_id, axis="sample")
+        query_sample_id = ids_by_label[slice_query.identifier]
+
+        values_by_feature_label: pd.Series = get_subsetted_df_by_labels(
+            slice_query.dataset_id, sample_col_ids=[query_sample_id]
+        ).squeeze()
+        feature_ids_by_label = get_dataset_dimension_ids_by_label(
+            dataset_id, axis="feature"
+        )
+        return values_by_feature_label.rename(feature_ids_by_label)
 
     elif slice_query.identifier_type == "column":
         return get_tabular_dataset_column(dataset_id, slice_query.identifier)

--- a/portal-backend/depmap/data_explorer_2/utils.py
+++ b/portal-backend/depmap/data_explorer_2/utils.py
@@ -449,8 +449,7 @@ def get_ids_and_labels_matching_context(context: dict) -> tuple[list[str], list[
         context_evaluator = ContextEvaluator(context, data_access.get_slice_data)
 
     if dimension_type is None:
-        abort(400, "Context requests must specify a dimension type.")
-
+        raise ValueError("Context requests must specify a dimension type.")
     # Load all dimension labels and ids
     all_labels_by_id = get_all_dimension_labels_by_id(dimension_type)
 

--- a/portal-backend/depmap/data_explorer_2/utils.py
+++ b/portal-backend/depmap/data_explorer_2/utils.py
@@ -8,7 +8,11 @@ from collections import defaultdict
 from logging import getLogger
 from flask import abort, json, make_response
 
-from depmap_compute.context import decode_slice_id, ContextEvaluator
+from depmap_compute.context import (
+    decode_slice_id,
+    ContextEvaluator,
+    LegacyContextEvaluator,
+)
 from depmap_compute.slice import SliceQuery
 from depmap import data_access
 from depmap.data_access.models import MatrixDataset
@@ -428,3 +432,34 @@ def get_union_of_index_labels(index_type, dataset_ids):
 
 def clear_cache():
     get_vector_labels.cache_clear()
+
+
+def get_ids_and_labels_matching_context(context: dict) -> tuple[list[str], list[str]]:
+    """
+    For a given context, load all matching IDs and labels.
+    Both context versions are supported here. 
+    """
+    # Identify which type of context has been provided
+    # Legacy contexts use the "context_type" field name, while newer contexts use "dimension_type"
+    if context.get("context_type"):
+        dimension_type = context.get("context_type")
+        context_evaluator = LegacyContextEvaluator(context, slice_to_dict)
+    else:
+        dimension_type = context.get("dimension_type")
+        context_evaluator = ContextEvaluator(context, data_access.get_slice_data)
+
+    if dimension_type is None:
+        abort(400, "Context requests must specify a dimension type.")
+
+    # Load all dimension labels and ids
+    all_labels_by_id = get_all_dimension_labels_by_id(dimension_type)
+
+    # Evaluate each against the context
+    ids_matching_context = []
+    labels_matching_context = []
+    for given_id, label in all_labels_by_id.items():
+        if context_evaluator.is_match(given_id):
+            ids_matching_context.append(given_id)
+            labels_matching_context.append(label)
+
+    return ids_matching_context, labels_matching_context

--- a/portal-backend/depmap/data_explorer_2/views.py
+++ b/portal-backend/depmap/data_explorer_2/views.py
@@ -455,7 +455,7 @@ def unique_values_or_range():
 @csrf_protect.exempt
 def get_labels_matching_context():
     """
-    Get the full list of labels (in any dataset) which match the given context.
+    DEPRECATED: Get the full list of labels (in any dataset) which match the given context.
     """
     inputs = request.get_json()
     context = inputs["context"]
@@ -524,7 +524,7 @@ def get_v2_context_summary():
 @csrf_protect.exempt
 def get_datasets_matching_context():
     """
-    Get the list of datasets which have data matching the given context. For
+    DEPRECATED: Get the list of datasets which have data matching the given context. For
     each dataset, include the full list of dimension labels matching the
     context. Returns a list of dictionaries like:
     [
@@ -547,7 +547,7 @@ def get_datasets_matching_context():
 @csrf_protect.exempt
 def get_context_summary():
     """
-    Get the number of matching labels and candidate labels.
+    DEPRECATED: Get the number of matching labels and candidate labels.
     "Candidate" labels are all labels belonging to the context's dimension type.
     """
     inputs = request.get_json()

--- a/portal-backend/depmap/data_explorer_2/views.py
+++ b/portal-backend/depmap/data_explorer_2/views.py
@@ -31,6 +31,7 @@ from depmap.data_explorer_2.utils import (
     get_dimension_labels_across_datasets,
     get_dimension_labels_to_datasets_mapping,
     get_file_and_release_from_dataset,
+    get_ids_and_labels_matching_context,
     get_reoriented_df,
     get_series_from_de2_slice_id,
     get_union_of_index_labels,
@@ -478,25 +479,10 @@ def evaluate_v2_context():
     """
     inputs = request.get_json()
     context = inputs["context"]
-    dimension_type = context.get("dimension_type")
-    if dimension_type is None:
-        abort(400, "v2 Contexts must have a 'dimension_type' field")
 
-    # Load all dimension labels and ids
-    all_labels_by_id = get_all_dimension_labels_by_id(dimension_type)
+    matching_ids, matching_labels = get_ids_and_labels_matching_context(context)
 
-    # Evaluate each against the context
-    context_evaluator = ContextEvaluator(context, data_access.get_slice_data)
-    ids_matching_context = []
-    labels_matching_context = []
-    for given_id, label in all_labels_by_id.items():
-        if context_evaluator.is_match(given_id):
-            ids_matching_context.append(given_id)
-            labels_matching_context.append(label)
-
-    return make_gzipped_json_response(
-        {"ids": ids_matching_context, "labels": labels_matching_context,}
-    )
+    return make_gzipped_json_response({"ids": matching_ids, "labels": matching_labels,})
 
 
 @blueprint.route("/v2/context/summary", methods=["POST"])
@@ -508,23 +494,22 @@ def get_v2_context_summary():
     """
     inputs = request.get_json()
     context = inputs["context"]
+
+    # Legacy contexts use the "context_type" field name, while newer contexts use "dimension_type"
     dimension_type = context.get("dimension_type")
     if dimension_type is None:
-        abort(400, "v2 Contexts must have a 'dimension_type' field")
+        dimension_type = context.get("context_type")
+
+    if dimension_type is None:
+        abort(400, "Context requests must specify a dimension type.")
 
     # Load all dimension labels and ids
     all_labels_by_id = get_all_dimension_labels_by_id(dimension_type)
-
-    # Evaluate each against the context
-    context_evaluator = ContextEvaluator(context, data_access.get_slice_data)
-    ids_matching_context = []
-    for given_id, label in all_labels_by_id.items():
-        if context_evaluator.is_match(given_id):
-            ids_matching_context.append(given_id)
+    matching_ids, _ = get_ids_and_labels_matching_context(context)
 
     return {
         "num_candidates": len(all_labels_by_id.keys()),
-        "num_matches": len(ids_matching_context),
+        "num_matches": len(matching_ids),
     }
 
 

--- a/portal-backend/tests/depmap/data_access/test_interface.py
+++ b/portal-backend/tests/depmap/data_access/test_interface.py
@@ -54,9 +54,18 @@ def test_get_matrix_dataset(interactive_db_mock_downloads):
 
 @override(config=config)
 def test_get_slice_data_for_matrix_dataset(app, empty_db_mock_downloads):
-    # Set up a simple 5x5 dataset where samples are cell lines and features are genes
-    cell_lines = CellLineFactory.create_batch(3)
-    genes = GeneFactory.create_batch(4)
+    # Set up a simple 3x4 dataset where samples are cell lines and features are genes
+    genes = [
+        GeneFactory(label="gene1", entrez_id=1),
+        GeneFactory(label="gene2", entrez_id=2),
+        GeneFactory(label="gene3", entrez_id=3),
+        GeneFactory(label="gene4", entrez_id=4),
+    ]
+    cell_lines = [
+        CellLineFactory(depmap_id="ACH-1", cell_line_display_name="cell_line1"),
+        CellLineFactory(depmap_id="ACH-2", cell_line_display_name="cell_line2"),
+        CellLineFactory(depmap_id="ACH-3", cell_line_display_name="cell_line3"),
+    ]
     standard_dataset_name = DependencyDataset.DependencyEnum.Chronos_Combined
     dataset_data = np.array([[1, 10, 100], [2, 20, 200], [3, 30, 300], [4, 40, 400],])
     matrix = MatrixFactory(cell_lines=cell_lines, entities=genes, data=dataset_data)
@@ -73,12 +82,18 @@ def test_get_slice_data_for_matrix_dataset(app, empty_db_mock_downloads):
     feature_ids = list(feature_labels_by_id.keys())
     sample_ids = data_access.get_dataset_sample_ids(dataset_id)
 
-    # Test a query by feature label
-    query_gene = genes[0]
+    # Test a query by feature ID
     feature_id_query = SliceQuery(
-        dataset_id=dataset_id,
-        identifier=query_gene.label,
-        identifier_type="feature_label",
+        dataset_id=dataset_id, identifier="1", identifier_type="feature_id",
+    )
+    result = data_access.get_slice_data(slice_query=feature_id_query)
+    assert result is not None
+    assert result.index.to_list() == sample_ids
+    assert result.values.tolist() == [1, 10, 100]
+
+    # Test a query by feature label
+    feature_id_query = SliceQuery(
+        dataset_id=dataset_id, identifier="gene1", identifier_type="feature_label",
     )
     result = data_access.get_slice_data(slice_query=feature_id_query)
     assert result is not None
@@ -88,6 +103,15 @@ def test_get_slice_data_for_matrix_dataset(app, empty_db_mock_downloads):
     # Test a query by sample ID
     sample_id_query = SliceQuery(
         dataset_id=dataset_id, identifier=sample_ids[0], identifier_type="sample_id",
+    )
+    result = data_access.get_slice_data(slice_query=sample_id_query)
+    assert result is not None
+    assert result.index.to_list() == feature_ids
+    assert result.values.tolist() == [1, 2, 3, 4]
+
+    # Test a query by sample label
+    sample_id_query = SliceQuery(
+        dataset_id=dataset_id, identifier="cell_line1", identifier_type="sample_label",
     )
     result = data_access.get_slice_data(slice_query=sample_id_query)
     assert result is not None


### PR DESCRIPTION
[Asana](https://app.asana.com/0/1165651979405609/1208261191969003/f) 

There are a couple of things that were left out in my last set of changes:
* Support for slice queries which use the identifier types `feature_id` or `sample_label`
* Making sure that the new `/v2/context` endpoints work with the legacy context format as well. 
* Making a reusable function `get_ids_and_labels_matching_context` as suggested by Randy

After this, I'll consider this "v2 context" support done for now.