### PR TITLE
Link filtering of Context Explorer overview table to filtering of table

### DIFF
--- a/frontend/packages/portal-frontend/src/contextExplorer/components/ContextExplorerTabs.tsx
+++ b/frontend/packages/portal-frontend/src/contextExplorer/components/ContextExplorerTabs.tsx
@@ -114,7 +114,13 @@ const ContextExplorerTabs = ({
           </div>
           <div className={styles.plot}>
             <OverviewTable
-              cellLineData={formattedFilteredData}
+              cellLineData={
+                overlappingDepmapIds.length > 0
+                  ? formattedFilteredData.filter((dataItem: CellLineOverview) =>
+                      overlappingDepmapIds.includes(dataItem.depmapId)
+                    )
+                  : formattedFilteredData
+              }
               getCellLineUrlRoot={getCellLineUrlRoot}
             />
           </div>


### PR DESCRIPTION
Updated Context Explorer's overview table so that the selection of a data type (e.g. "RNAi") will filter the table to cell lines available in RNAi. Notice, in the screenshot below, that the graph shows 15 cell lines for RNAi, and RNAi selected, the table is filtered to 15 cell lines. Previously, the table always showed every single cell line available across all data types.
<img width="1705" alt="Screenshot 2024-10-08 at 3 04 01 PM" src="https://github.com/user-attachments/assets/068f2ce7-56d4-444e-89c2-4efb632cf7a4">

