### PR TITLE
Added data page updates

### DIFF
--- a/frontend/packages/portal-frontend/src/dataPage/components/DataPageDatatypeSelector.tsx
+++ b/frontend/packages/portal-frontend/src/dataPage/components/DataPageDatatypeSelector.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styles from "src/dataPage/styles/DataPage.scss";
 import { DataPageDataType, getDataPageDataTypeString } from "../models/types";
-import { BAR_THICKNESS, currentReleaseDatasets } from "./utils";
+import { BAR_THICKNESS, growingDatasets } from "./utils";
 
 interface Props {
   datatypes: string[];
@@ -49,7 +49,7 @@ const DataPageDatatypeSelector = ({
     const dataTypeDisplayName = getDataPageDataTypeString(
       datatype as DataPageDataType
     );
-    const inCurrentRelease = currentReleaseDatasets.includes(datatype);
+    const isGrowingDataset = growingDatasets.includes(datatype);
 
     display.push(
       <div className={styles.selector} key={`wapper-${dataTypeDisplayName}`}>
@@ -61,13 +61,16 @@ const DataPageDatatypeSelector = ({
             target="_blank"
             rel="noreferrer"
           >
-            {`${getDataTypeLabel(dataTypeDisplayName, inCurrentRelease)}`}
+            {getDataTypeLabel(dataTypeDisplayName, isGrowingDataset)}
+            {dataTypeDisplayName === "Repurposing (Broad)" && <sup>†</sup>}
             <br />
             {getDrugCountLabel(dataTypeDisplayName)}
           </a>
         ) : (
           <p>
-            {getDataTypeLabel(dataTypeDisplayName, inCurrentRelease)} <br />
+            {getDataTypeLabel(dataTypeDisplayName, isGrowingDataset)}
+            {dataTypeDisplayName === "Repurposing (Broad)" && <sup>†</sup>}{" "}
+            <br />
             {getDrugCountLabel(dataTypeDisplayName)}
           </p>
         )}

--- a/frontend/packages/portal-frontend/src/dataPage/components/LineageAvailabilityPlot.tsx
+++ b/frontend/packages/portal-frontend/src/dataPage/components/LineageAvailabilityPlot.tsx
@@ -46,7 +46,7 @@ const LineageAvailabilityPlot = ({
     promise
       .then((result: any) => {
         if (promise === latestPromise.current) {
-          if (result.error) {
+          if (result.error || Object.keys(result.lineage_counts).length === 0) {
             setIsError(true);
             setIsLoading(false);
           } else {

--- a/frontend/packages/portal-frontend/src/dataPage/components/OverviewPanel.tsx
+++ b/frontend/packages/portal-frontend/src/dataPage/components/OverviewPanel.tsx
@@ -144,7 +144,16 @@ function OverviewPanel(props: OverviewPanelProps) {
           />
           {plotElement && (
             <div className={styles.plotFooter}>
-              *These datasets are growing as part of the DepMap Release dataset.
+              <div className={styles.plotFooterSection1}>
+                *These datasets are growing as part of the DepMap Release
+                dataset.
+              </div>
+              <div className={styles.plotFooterSection2}>
+                <sup>†</sup> The Drug Repurposing screens varied in the number
+                of lines screened. Originally compounds screened were tested in
+                578 lines, but collection of lines grew over time with the last
+                batch of compounds being tested in 916 lines.
+              </div>
             </div>
           )}
         </div>

--- a/frontend/packages/portal-frontend/src/dataPage/components/utils.ts
+++ b/frontend/packages/portal-frontend/src/dataPage/components/utils.ts
@@ -5,6 +5,17 @@ export const currentReleaseDatasets = [
   "Sequencing_WGS_Broad",
   "Sequencing_RNA_Broad",
   "CRISPR_Achilles_Broad",
+  // "CRISPR_ParalogsScreens",
+  "Drug_OncRef_Broad",
+];
+
+// Defines what is asterisked on the DataAvailability
+// plot for the Overview tab.
+export const growingDatasets = [
+  "Sequencing_WGS_Broad",
+  "Sequencing_RNA_Broad",
+  "CRISPR_Achilles_Broad",
+  "CRISPR_ParalogsScreens",
   "Drug_OncRef_Broad",
 ];
 

--- a/frontend/packages/portal-frontend/src/dataPage/components/utils.ts
+++ b/frontend/packages/portal-frontend/src/dataPage/components/utils.ts
@@ -5,7 +5,6 @@ export const currentReleaseDatasets = [
   "Sequencing_WGS_Broad",
   "Sequencing_RNA_Broad",
   "CRISPR_Achilles_Broad",
-  // "CRISPR_ParalogsScreens",
   "Drug_OncRef_Broad",
 ];
 

--- a/frontend/packages/portal-frontend/src/dataPage/models/types.ts
+++ b/frontend/packages/portal-frontend/src/dataPage/models/types.ts
@@ -173,11 +173,11 @@ export function getDataPageDataTypeString(datatype: DataPageDataType) {
     case DataPageDataType.Sequencing_WGS_Broad:
       return "WGS (Broad)";
     case DataPageDataType.CRISPR_Achilles_Broad:
-      return "Standard KO Screens (Broad)";
+      return "CRISPR KO screens (Broad)";
     case DataPageDataType.CRISPR_Score_Sanger:
-      return "Score (Sanger)";
+      return "CRISPR KO screens (Sanger)";
     case DataPageDataType.CRISPR_ParalogsScreens:
-      return "Paralog Screens";
+      return "Paralog CRISPR KO screens (Broad)";
     case DataPageDataType.Methylation_Sanger:
       return "Sanger";
     case DataPageDataType.Methylation_CCLE:
@@ -185,7 +185,7 @@ export function getDataPageDataTypeString(datatype: DataPageDataType) {
     case DataPageDataType.Uncategorized_miRNA_CCLE:
       return "miRNA (CCLE)";
     case DataPageDataType.Uncategorized_ATACSeq_Broad:
-      return "Atac Seq (Broad)";
+      return "ATAC-seq (Broad)";
     default:
       throw new Error(`Cannot map datatype ${datatype} to color category`);
   }

--- a/frontend/packages/portal-frontend/src/dataPage/styles/DataAvailabilityPlot.scss
+++ b/frontend/packages/portal-frontend/src/dataPage/styles/DataAvailabilityPlot.scss
@@ -32,6 +32,10 @@
 
     .selector {
       padding-bottom: 3px;
+
+      & > p {
+        margin-top: 5px;
+      }
     }
   }
 }

--- a/frontend/packages/portal-frontend/src/dataPage/styles/DataPage.scss
+++ b/frontend/packages/portal-frontend/src/dataPage/styles/DataPage.scss
@@ -188,6 +188,18 @@
     font-family: roboto;
     font-size: 16px;
     margin-top: 20px;
+    max-width: 72ch;
+  }
+
+  .plotFooterSection1 {
+    font-family: roboto;
+    font-size: 16px;
+  }
+
+  .plotFooterSection2 {
+    font-family: roboto;
+    font-size: 16px;
+    margin-top: 20px;
   }
 
   .customDownloads {

--- a/portal-backend/depmap/data_page/api.py
+++ b/portal-backend/depmap/data_page/api.py
@@ -86,7 +86,9 @@ def _get_data_type_url_mapping(data_types: List[str]):
 
     full_mapping = {
         "CRISPR_Achilles_Broad": _get_dataset_url(DependencyEnum.Chronos_Combined.name),
-        "CRISPR_Score_Sanger": _get_dataset_url(DependencyEnum.Chronos_Score.name),
+        # CRISPR_Score_Sanger url is set to None by request. _get_dataset_url WILL return
+        # a url for crispr sanger, but we do not want this url to show up in the data availability graph.
+        "CRISPR_Score_Sanger": None,
         "CRISPR_ParalogsScreens": None,
         "RNAi_Marcotte": None,
         "RNAi_Achilles_Broad": _get_dataset_url(DependencyEnum.RNAi_merged.name),


### PR DESCRIPTION
Asana Task: https://app.asana.com/0/1165651979405609/1208561850640047
Update dataset names as shown on the data overview figure:

- CRISPR KO screens (Broad)
- CRISPR KO screens (Sanger) - remove link 
- Paralog CRISPR KO screens (Broad)
- For Atac seq update to “ATAC-seq”
- Remove * from WES 
- Add * to Paralog screens since, for now, they are growing
- Add a "†" to repurposing dataset and add to the footnotes at the bottom: "† The Drug Repurposing screens varied in the number of lines screened. Originally compounds screened were tested in 578 lines, but collection of lines grew over time with the last batch of compounds being tested in 916 lines."

<img width="681" alt="Screenshot 2024-10-18 at 1 01 59 PM" src="https://github.com/user-attachments/assets/f3aa7c9c-4c43-4f1f-9eeb-8e4d57a36e04">
<img width="694" alt="Screenshot 2024-10-18 at 1 01 16 PM" src="https://github.com/user-attachments/assets/7d9a148b-e7b0-46b0-8535-4ae388eb781e">
