### PR TITLE
Resources page new accordions

### DIFF
--- a/frontend/packages/portal-frontend/src/resources/components/ResourcesPage.tsx
+++ b/frontend/packages/portal-frontend/src/resources/components/ResourcesPage.tsx
@@ -1,10 +1,8 @@
 import * as React from "react";
 import { useMemo } from "react";
-import { ListGroup, ListGroupItem } from "react-bootstrap";
-import { Accordion } from "@depmap/interactive";
+import { ListGroup, ListGroupItem, Panel, PanelGroup } from "react-bootstrap";
 import { Link, useLocation } from "react-router-dom";
 import styles from "src/resources/styles/ResourcesPage.scss";
-// import { CollapsiblePanel } from "src/dataPage/components/CollapsiblePanel";
 
 interface ResourcesPageProps {
   subcategories: any;
@@ -23,6 +21,7 @@ export default function ResourcesPage(props: ResourcesPageProps) {
   const { subcategories, defaultTopic } = props;
   console.log(subcategories);
   const query = useQuery();
+  const querySubcategory = query.get("subcategory");
 
   // If window location url has query params at the start, find the post to show
   const initPost = useMemo(() => {
@@ -52,32 +51,57 @@ export default function ResourcesPage(props: ResourcesPageProps) {
       </div>
 
       <section className={styles.postsNavList}>
-        {subcategories.map((subcategory: any) => {
-          return (
-            <Accordion key={subcategory.id} title={subcategory.title}>
-              <ListGroup style={{ marginBottom: 0, borderRadius: 0 }}>
-                {subcategory.topics.map((topic: any) => {
-                  return (
-                    <Link
-                      key={topic.id}
-                      to={`?subcategory=${subcategory.slug}&topic=${topic.slug}`}
-                      state={{ postHtml: topic }}
-                      style={{ textDecoration: "none" }}
-                    >
-                      <ListGroupItem
-                        className={styles.navPostItem}
-                        style={{ borderRadius: "0px" }}
-                        active={initPost ? initPost.slug === topic.slug : false}
-                      >
-                        {topic.title}
-                      </ListGroupItem>
-                    </Link>
-                  );
-                })}
-              </ListGroup>
-            </Accordion>
-          );
-        })}
+        <PanelGroup>
+          {subcategories.map((subcategory: any) => {
+            let isDefaultExpandedSubcategory: boolean;
+            if (querySubcategory) {
+              isDefaultExpandedSubcategory =
+                subcategory.slug === querySubcategory;
+            } else {
+              isDefaultExpandedSubcategory = !!subcategory.topics.find(
+                (t: any) => t.slug === defaultTopic.slug
+              );
+            }
+
+            return (
+              <Panel
+                key={subcategory.id}
+                eventKey={subcategory.slug}
+                defaultExpanded={isDefaultExpandedSubcategory}
+              >
+                <Panel.Heading className={styles.postHeading}>
+                  <Panel.Toggle componentClass="div">
+                    {subcategory.title}
+                  </Panel.Toggle>
+                </Panel.Heading>
+                <Panel.Collapse>
+                  <ListGroup>
+                    {subcategory.topics.map((topic: any) => {
+                      return (
+                        <Link
+                          key={topic.id}
+                          to={`?subcategory=${subcategory.slug}&topic=${topic.slug}`}
+                          state={{ postHtml: topic }}
+                          style={{ textDecoration: "none" }}
+                        >
+                          <ListGroupItem
+                            className={styles.navPostItem}
+                            style={{ borderRadius: "0px" }}
+                            active={
+                              initPost ? initPost.slug === topic.slug : false
+                            }
+                          >
+                            {topic.title}
+                          </ListGroupItem>
+                        </Link>
+                      );
+                    })}
+                  </ListGroup>
+                </Panel.Collapse>
+              </Panel>
+            );
+          })}
+        </PanelGroup>
       </section>
       <section className={styles.postContentContainer}>
         {initPost ? (

--- a/frontend/packages/portal-frontend/src/resources/components/ResourcesPage.tsx
+++ b/frontend/packages/portal-frontend/src/resources/components/ResourcesPage.tsx
@@ -21,7 +21,6 @@ function useQuery() {
 
 export default function ResourcesPage(props: ResourcesPageProps) {
   const { subcategories, defaultTopic } = props;
-  console.log(subcategories);
   const query = useQuery();
   const querySubcategory = query.get("subcategory");
 

--- a/frontend/packages/portal-frontend/src/resources/components/ResourcesPage.tsx
+++ b/frontend/packages/portal-frontend/src/resources/components/ResourcesPage.tsx
@@ -1,12 +1,14 @@
 import * as React from "react";
 import { useMemo } from "react";
-import { ListGroup, ListGroupItem, Panel, PanelGroup } from "react-bootstrap";
-import { Link, useLocation } from "react-router-dom";
+import { PanelGroup } from "react-bootstrap";
+import { useLocation } from "react-router-dom";
 import styles from "src/resources/styles/ResourcesPage.scss";
+import { Subcategory, Topic } from "../models/Category";
+import SubcategoryPanel from "./SubcategoryPanel";
 
 interface ResourcesPageProps {
-  subcategories: any;
-  defaultTopic: any;
+  subcategories: Subcategory[];
+  defaultTopic: Topic | null;
 }
 
 // A custom hook that builds on useLocation to parse
@@ -24,14 +26,14 @@ export default function ResourcesPage(props: ResourcesPageProps) {
   const querySubcategory = query.get("subcategory");
 
   // If window location url has query params at the start, find the post to show
-  const initPost = useMemo(() => {
+  const initOrSelectedPost = useMemo(() => {
     const subcategory = subcategories.find(
-      (sub: any) => sub.slug === query.get("subcategory")
+      (sub: Subcategory) => sub.slug === query.get("subcategory")
     );
     let post;
     if (subcategory) {
       const topic = subcategory.topics.find(
-        (t: any) => t.slug === query.get("topic")
+        (t: Topic) => t.slug === query.get("topic")
       );
       post = topic;
     } else {
@@ -52,67 +54,40 @@ export default function ResourcesPage(props: ResourcesPageProps) {
 
       <section className={styles.postsNavList}>
         <PanelGroup>
-          {subcategories.map((subcategory: any) => {
+          {subcategories.map((subcategory: Subcategory) => {
             let isDefaultExpandedSubcategory: boolean;
             if (querySubcategory) {
               isDefaultExpandedSubcategory =
                 subcategory.slug === querySubcategory;
             } else {
               isDefaultExpandedSubcategory = !!subcategory.topics.find(
-                (t: any) => t.slug === defaultTopic.slug
+                (t: Topic) => t.slug === defaultTopic?.slug
               );
             }
 
             return (
-              <Panel
+              <SubcategoryPanel
                 key={subcategory.id}
-                eventKey={subcategory.slug}
-                defaultExpanded={isDefaultExpandedSubcategory}
-              >
-                <Panel.Heading className={styles.postHeading}>
-                  <Panel.Toggle componentClass="div">
-                    {subcategory.title}
-                  </Panel.Toggle>
-                </Panel.Heading>
-                <Panel.Collapse>
-                  <ListGroup>
-                    {subcategory.topics.map((topic: any) => {
-                      return (
-                        <Link
-                          key={topic.id}
-                          to={`?subcategory=${subcategory.slug}&topic=${topic.slug}`}
-                          state={{ postHtml: topic }}
-                          style={{ textDecoration: "none" }}
-                        >
-                          <ListGroupItem
-                            className={styles.navPostItem}
-                            style={{ borderRadius: "0px" }}
-                            active={
-                              initPost ? initPost.slug === topic.slug : false
-                            }
-                          >
-                            {topic.title}
-                          </ListGroupItem>
-                        </Link>
-                      );
-                    })}
-                  </ListGroup>
-                </Panel.Collapse>
-              </Panel>
+                subcategory={subcategory}
+                isDefaultExpandedSubcategory={isDefaultExpandedSubcategory}
+                selectedTopic={initOrSelectedPost}
+              />
             );
           })}
         </PanelGroup>
       </section>
       <section className={styles.postContentContainer}>
-        {initPost ? (
+        {initOrSelectedPost ? (
           <div className={styles.postContent}>
             <div className={styles.postDate}>
-              <p>Posted: {initPost.creation_date}</p>
-              <p>Updated: {initPost.update_date}</p>
+              <p>Posted: {initOrSelectedPost.creation_date}</p>
+              <p>Updated: {initOrSelectedPost.update_date}</p>
             </div>
             <div
               // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{ __html: initPost.post_content }}
+              dangerouslySetInnerHTML={{
+                __html: initOrSelectedPost.post_content,
+              }}
             />
           </div>
         ) : null}

--- a/frontend/packages/portal-frontend/src/resources/components/SubcategoryPanel.tsx
+++ b/frontend/packages/portal-frontend/src/resources/components/SubcategoryPanel.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+import { useState } from "react";
+import { ListGroup, ListGroupItem, Panel } from "react-bootstrap";
+import { Link } from "react-router-dom";
+import styles from "src/resources/styles/ResourcesPage.scss";
+import { Subcategory, Topic } from "../models/Category";
+
+/**
+ * Make Panel into a controlled component so that we can keep track of each Panel's toggle state and render the correct glyphicon symbol for open/close
+ */
+
+interface SubcategoryPanelProps {
+  subcategory: Subcategory;
+  isDefaultExpandedSubcategory: boolean;
+  selectedTopic?: Topic | null;
+}
+
+export default function SubcategoryPanel({
+  subcategory,
+  isDefaultExpandedSubcategory,
+  selectedTopic = undefined,
+}: SubcategoryPanelProps) {
+  const [isOpen, setIsOpen] = useState(isDefaultExpandedSubcategory);
+
+  return (
+    <Panel
+      key={subcategory.id}
+      eventKey={subcategory.slug}
+      defaultExpanded={isDefaultExpandedSubcategory}
+      onToggle={(e) => {
+        setIsOpen(e);
+      }}
+    >
+      <Panel.Heading className={styles.postHeading}>
+        <Panel.Toggle componentClass="div">
+          {subcategory.title}
+          <span
+            className={
+              isOpen ? "glyphicon glyphicon-minus" : "glyphicon glyphicon-plus"
+            }
+            aria-hidden="true"
+            style={{
+              float: "right",
+              margin: "0",
+              position: "relative",
+              top: "50%",
+              lineHeight: "unset",
+            }}
+          />
+        </Panel.Toggle>
+      </Panel.Heading>
+      <Panel.Collapse>
+        <ListGroup>
+          {subcategory.topics.map((topic: Topic) => {
+            return (
+              <Link
+                key={topic.id}
+                to={`?subcategory=${subcategory.slug}&topic=${topic.slug}`}
+                state={{ postHtml: topic }}
+                style={{ textDecoration: "none" }}
+              >
+                <ListGroupItem
+                  className={styles.navPostItem}
+                  style={{ borderRadius: "0px" }}
+                  active={
+                    selectedTopic ? selectedTopic.slug === topic.slug : false
+                  }
+                >
+                  {topic.title}
+                </ListGroupItem>
+              </Link>
+            );
+          })}
+        </ListGroup>
+      </Panel.Collapse>
+    </Panel>
+  );
+}

--- a/frontend/packages/portal-frontend/src/resources/models/Category.ts
+++ b/frontend/packages/portal-frontend/src/resources/models/Category.ts
@@ -1,0 +1,15 @@
+export interface Subcategory {
+  id: number;
+  slug: string;
+  title: string;
+  topics: Topic[];
+}
+
+export interface Topic {
+  id: number;
+  slug: string;
+  title: string;
+  post_content: any;
+  creation_date: string;
+  update_date: string;
+}

--- a/frontend/packages/portal-frontend/src/resources/styles/ResourcesPage.scss
+++ b/frontend/packages/portal-frontend/src/resources/styles/ResourcesPage.scss
@@ -62,8 +62,8 @@
 
 .navPostItem {
   border: none;
-  border-bottom: 1px solid lightgray;
-  padding-left: 40px;
+  border-bottom: 1px solid lightgray !important;
+  padding-left: 55px;
   padding-right: 20px;
   font-weight: 500;
   font-size: 16px;

--- a/portal-backend/depmap/static/css/public/resources.scss
+++ b/portal-backend/depmap/static/css/public/resources.scss
@@ -10,3 +10,18 @@
     }
   }
 }
+
+.panel-default > .panel-heading {
+  padding: 8px 20px 8px 40px;
+  background-color: #f5f8fd;
+  border-bottom: 1px solid #585858;
+  font-weight: 500;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+.panel-group .panel {
+  border-radius: 0px;
+  margin: 0px !important;
+  border: 0px;
+}


### PR DESCRIPTION
Replaced old Accordion component with React bootstrap's Panel component. This makes it easier to set a default open Accordion/Panel when first entering Resources Page unlike before where I had to add a hack to set state for the old buggy Accordion component

https://github.com/user-attachments/assets/58a57099-d548-4614-b7d2-19060e971526

Reference [old PR for old implementation](https://github.com/broadinstitute/depmap-portal/pull/74)