### PR TITLE
Remove forum anchor links causing crawler errors

### DIFF
--- a/portal-backend/depmap/public/resources.py
+++ b/portal-backend/depmap/public/resources.py
@@ -58,7 +58,7 @@ def create_sanitizer() -> Sanitizer:
 # The discourse api returns non-image attachments with ONLY relative urls.
 # Example: /uploads/short-url/random_letters_and_numbers.pdf
 # This function adds a prefix equal to the url of the relevant forum (DMC vs public).
-def expand_forum_relative_urls(forum_url: str, html: str):
+def modify_forum_relative_urls(forum_url: str, html: str):
     # html.parser must be used to avoid automatically adding <html> and <body>
     # tags to the post html
     soup = BeautifulSoup(str(html), features="html.parser")
@@ -66,6 +66,9 @@ def expand_forum_relative_urls(forum_url: str, html: str):
         if str(a["href"]).startswith("/"):
             short_link = str(a["href"])
             a["href"] = urljoin(forum_url, short_link)
+        # remove link anchors to forum post
+        elif str(a["href"]).startswith("#p"):
+            a.extract()
         # add attribute to open links in new tab
         a["target"] = "_blank"
     return str(soup)
@@ -110,7 +113,7 @@ def modify_html(
     forum_url: str,
 ):
     sanitized_html = sanitizer.sanitize(topic_html)
-    modified_urls_html = expand_forum_relative_urls(forum_url, sanitized_html)
+    modified_urls_html = modify_forum_relative_urls(forum_url, sanitized_html)
     added_forum_link_html = add_forum_link_to_html(
         forum_url, topic_id, topic_slug, modified_urls_html
     )

--- a/portal-backend/tests/depmap/public/test_resources.py
+++ b/portal-backend/tests/depmap/public/test_resources.py
@@ -1,4 +1,4 @@
-from depmap.public.resources import expand_forum_relative_urls, add_forum_link_to_html
+from depmap.public.resources import modify_forum_relative_urls, add_forum_link_to_html
 
 
 def test_expand_forum_relative_urls():
@@ -11,7 +11,7 @@ def test_expand_forum_relative_urls():
     expected_output_html = f'<a class="attachment" href="{expected_long_url1}" target="_blank">test_random_non_image_pdf.pdf</a> (13.9 KB)'
 
     # Checks full link html element
-    html_with_absolute_urls = expand_forum_relative_urls(
+    html_with_absolute_urls = modify_forum_relative_urls(
         "https://forum.depmap.org", input_html
     )
 
@@ -19,7 +19,7 @@ def test_expand_forum_relative_urls():
 
     # Checks only href value
     input_html = '<a href="depmap.org/portal">test</a>'
-    expect_no_change_html = expand_forum_relative_urls(
+    expect_no_change_html = modify_forum_relative_urls(
         "https://forum.depmap.org", input_html
     )
 
@@ -37,3 +37,12 @@ def test_add_forum_link_to_html():
     assert 'href="https://forum.depmap.org/t/topic-slug/1"' in added_forum_link_to_html
     assert "</p><p><a" in added_forum_link_to_html
     assert added_forum_link_to_html.endswith("</a></p>")
+
+
+def test_remove_anchor_links():
+    input_html = f'<h1><a href="#p-100-welcome" name="p-100-welcome"></a>Welcome to the Resources Page!</h1>'
+    expected_output_html = f"<h1>Welcome to the Resources Page!</h1>"
+
+    # Checks full link html element
+    modified_html = modify_forum_relative_urls("https://forum.depmap.org", input_html)
+    assert expected_output_html == modified_html


### PR DESCRIPTION
Returned html string from forum may contain reference or anchor links to a forum topic post which contain the prefix `#p`. This seems to be automatically added when the poster uses the topic title as a header within the post.