### PR TITLE
Fix split line link text within list; Add spacing under headers

### DIFF
--- a/frontend/packages/portal-frontend/src/resources/styles/ResourcesPage.scss
+++ b/frontend/packages/portal-frontend/src/resources/styles/ResourcesPage.scss
@@ -29,12 +29,19 @@
   a {
     overflow-wrap: break-word;
   }
-  h1 {
+  h1,
+  h2,
+  h3 {
     margin-bottom: 20px;
   }
   p {
     font-size: 16px;
     line-height: 25px;
+  }
+
+  ul {
+    font-size: 16px;
+    line-height: 35px;
   }
 
   .postDate {

--- a/portal-backend/depmap/public/resources.py
+++ b/portal-backend/depmap/public/resources.py
@@ -78,7 +78,6 @@ def add_forum_link_to_html(
     forum_url: str, topic_id: int, topic_slug: str, topic_html: str
 ):
     soup = BeautifulSoup(str(topic_html), features="html.parser")
-    link_p = soup.new_tag("p")
     link_tag = soup.new_tag("a")
     link_tag.attrs.update(
         {
@@ -88,9 +87,8 @@ def add_forum_link_to_html(
         }
     )
     link_tag.string = "View Post in Forum"
-    link_p.append(link_tag)
     last_element = soup.find_all()[-1]
-    last_element.insert_after(link_p)
+    last_element.insert_after(link_tag)
     return str(soup)
 
 

--- a/portal-backend/tests/depmap/public/test_resources.py
+++ b/portal-backend/tests/depmap/public/test_resources.py
@@ -35,8 +35,8 @@ def test_add_forum_link_to_html():
         "https://forum.depmap.org", 1, "topic-slug", html
     )
     assert 'href="https://forum.depmap.org/t/topic-slug/1"' in added_forum_link_to_html
-    assert "</p><p><a" in added_forum_link_to_html
-    assert added_forum_link_to_html.endswith("</a></p>")
+    assert "</p><a" in added_forum_link_to_html
+    assert added_forum_link_to_html.endswith("</a>")
 
 
 def test_remove_anchor_links():


### PR DESCRIPTION
Styling error in links within list

![image](https://github.com/user-attachments/assets/5818f17e-b096-42e8-8e3f-4ca35471ab7e)

![Screenshot 2024-10-28 at 2 13 05 PM](https://github.com/user-attachments/assets/18983f98-3b6a-4f45-94c2-f37e4d105f0f)
