### PR TITLE
Fix resources heading style

### DIFF
--- a/frontend/packages/portal-frontend/src/resources/components/SubcategoryPanel.tsx
+++ b/frontend/packages/portal-frontend/src/resources/components/SubcategoryPanel.tsx
@@ -31,20 +31,18 @@ export default function SubcategoryPanel({
         setIsOpen(e);
       }}
     >
-      <Panel.Heading className={styles.postHeading}>
-        <Panel.Toggle componentClass="div">
-          {subcategory.title}
+      <Panel.Heading>
+        <Panel.Toggle componentClass="div" className={styles.panelHeading}>
+          <span className={styles.headingTitle}>{subcategory.title}</span>
           <span
             className={
               isOpen ? "glyphicon glyphicon-minus" : "glyphicon glyphicon-plus"
             }
             aria-hidden="true"
             style={{
+              gridArea: "glyph-symbol",
               float: "right",
-              margin: "0",
-              position: "relative",
-              top: "50%",
-              lineHeight: "unset",
+              alignSelf: "center",
             }}
           />
         </Panel.Toggle>

--- a/frontend/packages/portal-frontend/src/resources/styles/ResourcesPage.scss
+++ b/frontend/packages/portal-frontend/src/resources/styles/ResourcesPage.scss
@@ -75,3 +75,14 @@
   font-weight: 500;
   font-size: 16px;
 }
+
+.panelHeading {
+  display: grid;
+  grid-template-columns: 95% 5%;
+  grid-template-areas: "title glyph-symbol";
+}
+
+.headingTitle {
+  grid-area: "title";
+  padding-right: "10px";
+}

--- a/frontend/packages/portal-frontend/src/resources/styles/ResourcesPage.scss
+++ b/frontend/packages/portal-frontend/src/resources/styles/ResourcesPage.scss
@@ -70,10 +70,17 @@
 .navPostItem {
   border: none;
   border-bottom: 1px solid lightgray !important;
-  padding-left: 55px;
-  padding-right: 20px;
   font-weight: 500;
-  font-size: 16px;
+
+  @media screen and (min-width: 800px) {
+    padding-left: 55px;
+    padding-right: 20px;
+    font-size: 16px;
+  }
+  @media screen and (max-width: 799px) {
+    padding-left: 20px;
+    padding-right: 10px;
+  }
 }
 
 .panelHeading {

--- a/portal-backend/depmap/static/css/public/resources.scss
+++ b/portal-backend/depmap/static/css/public/resources.scss
@@ -1,9 +1,13 @@
 .panel-default > .panel-heading {
-  padding: 8px 20px 8px 40px;
+  @media screen and (min-width: 800px) {
+    padding: 8px 20px 8px 40px;
+    font-size: 18px;
+  }
+
+  font-weight: 500;
   background-color: #f5f8fd;
   border-bottom: 1px solid #585858;
-  font-weight: 500;
-  font-size: 18px;
+
   cursor: pointer;
 }
 
@@ -19,15 +23,6 @@
 // list-group when expanded has white border-top as default so get rid of border-top
 .panel-group .panel-heading + .panel-collapse > .list-group {
   border-top: 0px;
-}
-
-.panel-default > .panel-heading {
-  padding: 8px 20px 8px 40px;
-  background-color: #f5f8fd;
-  border-bottom: 1px solid #585858;
-  font-weight: 500;
-  font-size: 18px;
-  cursor: pointer;
 }
 
 .panel-group .panel {


### PR DESCRIPTION
### Issue: Open close glyph symbol not aligned correctly for smaller screen widths
![image (1)](https://github.com/user-attachments/assets/ec0eccf3-a6c8-463a-b9f0-e00389f262f3)

The styling for the open-close glyph symbol was copied from the old Accordion component but seemed buggy with the Panel component. I had a lot of trouble trying to fix the styling and centering before giving up and using CSS Grid instead so I highly recommend using it!

- Fixed maligned glyph symbol when heading title is long
- Make panel heading padding responsive to screen width so it doesn't look strange

https://github.com/user-attachments/assets/a985c241-9c70-477e-a48b-8a8b189b61ee

