### PR TITLE
feat(breadbox): Support tabular dataset metadata lookups

### DIFF
--- a/breadbox/breadbox/api/datasets.py
+++ b/breadbox/breadbox/api/datasets.py
@@ -54,6 +54,7 @@ from ..schemas.dataset import (
     DimensionDataResponse,
     SliceQueryIdentifierType,
 )
+from breadbox.service import metadata as metadata_service
 from .dependencies import get_dataset as get_dataset_dep
 from .dependencies import get_db_with_user, get_user
 
@@ -496,8 +497,8 @@ def get_dimension_data(
 
     # Load the labels separately, ensuring they're in the same order as the other values
     slice_ids: list = slice_values_by_id.index.tolist()
-    labels_by_id = slice_crud.get_labels_for_slice_type(db, parsed_slice_query)
-    slice_labels = [labels_by_id[id] for id in slice_ids] if labels_by_id else slice_ids
+    labels_by_id = metadata_service.get_labels_for_slice_type(db, parsed_slice_query)
+    slice_labels = [labels_by_id[id] for id in slice_ids]
 
     return {
         "ids": slice_ids,

--- a/breadbox/breadbox/api/temp.py
+++ b/breadbox/breadbox/api/temp.py
@@ -43,7 +43,9 @@ def evaluate_context(
     context_evaluator = ContextEvaluator(context.dict(), slice_loader_function)
 
     # Load all dimension labels and ids
-    all_labels_by_id = types_crud.get_dimension_labels_by_id(db, context.dimension_type)
+    all_labels_by_id = types_crud.get_dimension_type_labels_by_id(
+        db, context.dimension_type
+    )
 
     # Evaluate each against the context
     matching_ids = []

--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -1006,7 +1006,10 @@ def get_tabular_dataset_index_given_ids(
     This can be used for joining the metadata that's relevant for this particular dataset.
     Warning: this may contain given IDs that do not exist in the metadata.
     """
-    id_col_name = dataset.index_type.id_column
+    dimension_type = (
+        db.query(DimensionType).filter_by(name=dataset.index_type_name).one_or_none()
+    )
+    id_col_name = dimension_type.id_column
     cells_in_id_column = (
         db.query(TabularCell)
         .join(TabularColumn)

--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -968,7 +968,9 @@ def get_dataset_feature_dimensions(db: SessionWithUser, user: str, dataset_id: s
     return dimensions
 
 
-def get_dataset_features(db: SessionWithUser, dataset: Dataset, user: str):
+def get_dataset_features(
+    db: SessionWithUser, dataset: MatrixDataset, user: str
+) -> list[DatasetFeature]:
     assert_user_has_access_to_dataset(dataset, user)
 
     dataset_features = (
@@ -981,7 +983,9 @@ def get_dataset_features(db: SessionWithUser, dataset: Dataset, user: str):
     return dataset_features
 
 
-def get_dataset_samples(db: SessionWithUser, dataset: Dataset, user: str):
+def get_dataset_samples(
+    db: SessionWithUser, dataset: MatrixDataset, user: str
+) -> list[DatasetSample]:
     assert_user_has_access_to_dataset(dataset, user)
 
     dataset_samples = (
@@ -992,6 +996,21 @@ def get_dataset_samples(db: SessionWithUser, dataset: Dataset, user: str):
     )
 
     return dataset_samples
+
+
+def get_dataset_columns(
+    db: SessionWithUser, dataset: TabularDataset
+) -> list[TabularColumn]:
+    assert_user_has_access_to_dataset(dataset, db.user)
+
+    dataset_columns = (
+        db.query(TabularColumn)
+        .filter(TabularColumn.dataset_id == dataset.id)
+        .order_by(TabularColumn.given_id)
+        .all()
+    )
+
+    return dataset_columns
 
 
 def get_dataset_feature_labels_by_id(

--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -1009,6 +1009,8 @@ def get_tabular_dataset_index_given_ids(
     dimension_type = (
         db.query(DimensionType).filter_by(name=dataset.index_type_name).one_or_none()
     )
+    assert dimension_type is not None
+
     id_col_name = dimension_type.id_column
     cells_in_id_column = (
         db.query(TabularCell)

--- a/breadbox/breadbox/crud/slice.py
+++ b/breadbox/breadbox/crud/slice.py
@@ -84,24 +84,3 @@ def get_slice_data(
 
     # Convert the single-col/row DataFrame into a series and drop null values
     return slice_data.dropna().squeeze()
-
-
-def get_labels_for_slice_type(
-    db: SessionWithUser, slice_query: SliceQuery
-) -> Optional[dict[str, str]]:
-    """
-    For the given slice query identifier type, get a dictionary of all the dataset labels and IDs
-    that should be used to index the resulting slice.
-    If the identifier type does not have labels, return None.
-    """
-    dataset = dataset_crud.get_dataset(db, db.user, slice_query.dataset_id)
-    if dataset is None:
-        raise ResourceNotFoundError(f"Dataset '{slice_query.dataset_id}' not found.")
-
-    if slice_query.identifier_type in {"feature_label", "feature_id"}:
-        return dataset_crud.get_dataset_sample_labels_by_id(db, db.user, dataset)
-    elif slice_query.identifier_type in {"sample_label", "sample_id"}:
-        return dataset_crud.get_dataset_feature_labels_by_id(db, db.user, dataset)
-    else:
-        # Columns don't have labels, so just return None
-        return None

--- a/breadbox/breadbox/crud/types.py
+++ b/breadbox/breadbox/crud/types.py
@@ -499,7 +499,7 @@ def get_dimension_labels_by_id(
     """
     For a given dimension, get all IDs and labels that exist in the metadata.
     """
-    return get_dimension_type_metadata_col(dimension_type_name, col_name="label")
+    return get_dimension_type_metadata_col(db, dimension_type_name, col_name="label")
 
 
 def get_dimension_type_metadata_col(

--- a/breadbox/breadbox/crud/types.py
+++ b/breadbox/breadbox/crud/types.py
@@ -493,7 +493,7 @@ def check_id_mapping_is_valid(
         )
 
 
-def get_dimension_labels_by_id(
+def get_dimension_type_labels_by_id(
     db: SessionWithUser, dimension_type_name: str
 ) -> dict[str, str]:
     """

--- a/breadbox/breadbox/crud/types.py
+++ b/breadbox/breadbox/crud/types.py
@@ -508,6 +508,7 @@ def get_dimension_type_metadata_col(
     """
     Get a column of values from the dimension type's metadata. 
     Return a dictionary of values indexed by given ID.
+    If there is no metadata for the given dimension type, return an empty dict.
     """
     dimension_type = get_dimension_type(db=db, name=dimension_type_name)
 
@@ -515,6 +516,8 @@ def get_dimension_type_metadata_col(
         raise ResourceNotFoundError(
             f"Dimension type '{dimension_type_name}' not found. "
         )
+    if dimension_type.dataset_id is None:
+        return {}
 
     values_by_id_tuples = (
         db.query(TabularCell)

--- a/breadbox/breadbox/crud/types.py
+++ b/breadbox/breadbox/crud/types.py
@@ -459,6 +459,7 @@ def update_dimension_type_metadata(
 
 
 def delete_dimension_type(db: SessionWithUser, dimension_type: DimensionType):
+    """Delete the dimension type as well as its metadata dataset."""
     db.delete(dimension_type)
     db.flush()
     return True

--- a/breadbox/breadbox/crud/types.py
+++ b/breadbox/breadbox/crud/types.py
@@ -532,4 +532,4 @@ def get_dimension_type_metadata_col(
         .with_entities(TabularCell.dimension_given_id, TabularCell.value)
         .all()
     )
-    return {id: label for id, label in values_by_id_tuples}
+    return {id: value for id, value in values_by_id_tuples}

--- a/breadbox/breadbox/models/dataset.py
+++ b/breadbox/breadbox/models/dataset.py
@@ -116,7 +116,6 @@ class TabularDataset(Dataset):
     index_type_name = Column(
         String, ForeignKey("dimension_type.name", ondelete="CASCADE"), nullable=False
     )
-    index_type = relationship("DimensionType", foreign_keys=[index_type_name])
     __mapper_args__ = {"polymorphic_identity": "tabular_dataset"}
 
     @property

--- a/breadbox/breadbox/models/dataset.py
+++ b/breadbox/breadbox/models/dataset.py
@@ -116,6 +116,7 @@ class TabularDataset(Dataset):
     index_type_name = Column(
         String, ForeignKey("dimension_type.name", ondelete="CASCADE"), nullable=False
     )
+    index_type = relationship("DimensionType", foreign_keys=[index_type_name])
     __mapper_args__ = {"polymorphic_identity": "tabular_dataset"}
 
     @property

--- a/breadbox/breadbox/service/metadata.py
+++ b/breadbox/breadbox/service/metadata.py
@@ -1,0 +1,118 @@
+import logging
+from typing import Any, Optional
+
+from breadbox.crud import dataset as dataset_crud
+from breadbox.crud import types as types_crud
+from breadbox.db.session import SessionWithUser
+from breadbox.schemas.custom_http_exception import ResourceNotFoundError
+from breadbox.models.dataset import (
+    Dataset,
+    MatrixDataset,
+)
+
+from depmap_compute.slice import SliceQuery
+
+log = logging.getLogger(__name__)
+
+
+def get_matrix_dataset_feature_annotations(
+    db: SessionWithUser, user: str, dataset: MatrixDataset, metadata_col_name: str,
+) -> dict[str, Any]:
+    """
+    For the given dataset, load metadata of the specified type, keyed by given id.
+    If there is no metadata of this type, return an empty dictionary.
+    """
+    if dataset.feature_type is None or dataset.feature_type.dataset_id is None:
+        return {}
+
+    full_metadata_col = types_crud.get_dimension_type_metadata_col(
+        db, dimension_type_name=dataset.feature_type, col_name=metadata_col_name
+    )
+    # Filter the metadata to only include the given IDs belonging to this dataset
+    dataset_features = dataset_crud.get_dataset_features(db, dataset, user=db.user)
+    dataset_given_ids = [feature.given_id for feature in dataset_features]
+    return {given_id: full_metadata_col[given_id] for given_id in dataset_given_ids}
+
+
+def get_matrix_dataset_sample_annotations(
+    db: SessionWithUser, user: str, dataset: MatrixDataset, metadata_col_name: str,
+) -> dict[str, Any]:
+    """
+    For the given dataset, load metadata of the specified type, keyed by given id.
+    If there is no metadata of this type, return an empty dictionary.
+    """
+    full_metadata_col = types_crud.get_dimension_type_metadata_col(
+        db, dimension_type_name=dataset.sample_type, col_name=metadata_col_name
+    )
+    # Filter the metadata to only include the given IDs belonging to this dataset
+    dataset_samples = dataset_crud.get_dataset_samples(db, dataset, user=db.user)
+    dataset_given_ids = [sample.given_id for sample in dataset_samples]
+    return {given_id: full_metadata_col[given_id] for given_id in dataset_given_ids}
+
+
+def get_dataset_feature_labels_by_id(
+    db: SessionWithUser, user: str, dataset: Dataset,
+) -> dict[str, str]:
+    """
+    Try loading feature labels from metadata. 
+    If there is no metadata, then just return the given IDs as labels.
+    """
+    metadata_labels_by_given_id = get_matrix_dataset_feature_annotations(
+        db=db, user=user, dataset=dataset, metadata_col_name="label"
+    )
+
+    if metadata_labels_by_given_id:
+        return metadata_labels_by_given_id
+    else:
+        all_dataset_features = dataset_crud.get_dataset_features(
+            db=db, dataset=dataset, user=user
+        )
+        return {feature.given_id: feature.given_id for feature in all_dataset_features}
+
+
+def get_dataset_sample_labels_by_id(
+    db: SessionWithUser, user: str, dataset: Dataset,
+) -> dict[str, str]:
+    """
+    Try loading sample labels from metadata.
+    If there is no metadata, then just return the given IDs as labels.
+    """
+    metadata_labels = get_matrix_dataset_sample_annotations(
+        db=db, user=user, dataset=dataset, metadata_col_name="label"
+    )
+    if metadata_labels:
+        return metadata_labels
+    else:
+        samples = dataset_crud.get_dataset_samples(db=db, dataset=dataset, user=user)
+        return {sample.given_id: sample.given_id for sample in samples}
+
+
+def get_tabular_dataset_labels_by_id(
+    db: SessionWithUser, dataset: Dataset,
+) -> dict[str, str]:
+    """
+    For the index (rows) of a tabular dataset, try loading labels from metadata.
+    If there are no labels in the metadata or there is no metadata, then just return the given IDs as labels.
+    """
+    raise NotImplementedError()
+
+
+def get_labels_for_slice_type(
+    db: SessionWithUser, slice_query: SliceQuery
+) -> Optional[dict[str, str]]:
+    """
+    For the given slice query identifier type, get a dictionary of all the dataset labels and IDs
+    that should be used to index the resulting slice.
+    If the identifier type does not have labels, return None.
+    """
+    dataset = dataset_crud.get_dataset(db, db.user, slice_query.dataset_id)
+    if dataset is None:
+        raise ResourceNotFoundError(f"Dataset '{slice_query.dataset_id}' not found.")
+
+    if slice_query.identifier_type in {"feature_label", "feature_id"}:
+        return dataset_crud.get_dataset_sample_labels_by_id(db, db.user, dataset)
+    elif slice_query.identifier_type in {"sample_label", "sample_id"}:
+        return dataset_crud.get_dataset_feature_labels_by_id(db, db.user, dataset)
+    elif slice_query.identifier == "column":
+        # TODO: return the labels for the tabular dataset index
+        return None

--- a/breadbox/breadbox/service/metadata.py
+++ b/breadbox/breadbox/service/metadata.py
@@ -5,101 +5,51 @@ from breadbox.crud import dataset as dataset_crud
 from breadbox.crud import types as types_crud
 from breadbox.db.session import SessionWithUser
 from breadbox.schemas.custom_http_exception import ResourceNotFoundError
-from breadbox.models.dataset import (
-    Dataset,
-    MatrixDataset,
-)
+from breadbox.models.dataset import MatrixDataset, TabularDataset
 
 from depmap_compute.slice import SliceQuery
 
 log = logging.getLogger(__name__)
 
 
-def get_matrix_dataset_feature_annotations(
-    db: SessionWithUser, user: str, dataset: MatrixDataset, metadata_col_name: str,
+def get_tabular_dataset_metadata_annotations(
+    db: SessionWithUser, dataset: MatrixDataset, metadata_col_name: str,
 ) -> dict[str, Any]:
     """
-    For the given dataset, load metadata of the specified type, keyed by given id.
-    If there is no metadata of this type, return an empty dictionary.
-    """
-    if dataset.feature_type is None or dataset.feature_type.dataset_id is None:
-        return {}
-
-    full_metadata_col = types_crud.get_dimension_type_metadata_col(
-        db, dimension_type_name=dataset.feature_type, col_name=metadata_col_name
-    )
-    # Filter the metadata to only include the given IDs belonging to this dataset
-    dataset_features = dataset_crud.get_dataset_features(db, dataset, user=db.user)
-    dataset_given_ids = [feature.given_id for feature in dataset_features]
-    return {given_id: full_metadata_col[given_id] for given_id in dataset_given_ids}
-
-
-def get_matrix_dataset_sample_annotations(
-    db: SessionWithUser, user: str, dataset: MatrixDataset, metadata_col_name: str,
-) -> dict[str, Any]:
-    """
-    For the given dataset, load metadata of the specified type, keyed by given id.
-    If there is no metadata of this type, return an empty dictionary.
+    For the given tabular dataset, load a column from the associated metadata.
+    Return a dictionary of values keyed by given id.
+    Note: this should work regardless of whether or not the given dataset IS metadata
+    or HAS metadata.
     """
     full_metadata_col = types_crud.get_dimension_type_metadata_col(
         db, dimension_type_name=dataset.sample_type, col_name=metadata_col_name
     )
     # Filter the metadata to only include the given IDs belonging to this dataset
-    dataset_samples = dataset_crud.get_dataset_samples(db, dataset, user=db.user)
+    dataset_samples = dataset_crud.get_dataset_columns(db, dataset)
     dataset_given_ids = [sample.given_id for sample in dataset_samples]
     return {given_id: full_metadata_col[given_id] for given_id in dataset_given_ids}
 
 
-def get_dataset_feature_labels_by_id(
-    db: SessionWithUser, user: str, dataset: Dataset,
-) -> dict[str, str]:
-    """
-    Try loading feature labels from metadata. 
-    If there is no metadata, then just return the given IDs as labels.
-    """
-    metadata_labels_by_given_id = get_matrix_dataset_feature_annotations(
-        db=db, user=user, dataset=dataset, metadata_col_name="label"
-    )
-
-    if metadata_labels_by_given_id:
-        return metadata_labels_by_given_id
-    else:
-        all_dataset_features = dataset_crud.get_dataset_features(
-            db=db, dataset=dataset, user=user
-        )
-        return {feature.given_id: feature.given_id for feature in all_dataset_features}
-
-
-def get_dataset_sample_labels_by_id(
-    db: SessionWithUser, user: str, dataset: Dataset,
-) -> dict[str, str]:
-    """
-    Try loading sample labels from metadata.
-    If there is no metadata, then just return the given IDs as labels.
-    """
-    metadata_labels = get_matrix_dataset_sample_annotations(
-        db=db, user=user, dataset=dataset, metadata_col_name="label"
-    )
-    if metadata_labels:
-        return metadata_labels
-    else:
-        samples = dataset_crud.get_dataset_samples(db=db, dataset=dataset, user=user)
-        return {sample.given_id: sample.given_id for sample in samples}
-
-
 def get_tabular_dataset_labels_by_id(
-    db: SessionWithUser, dataset: Dataset,
+    db: SessionWithUser, dataset: TabularDataset,
 ) -> dict[str, str]:
     """
     For the index (rows) of a tabular dataset, try loading labels from metadata.
     If there are no labels in the metadata or there is no metadata, then just return the given IDs as labels.
     """
-    raise NotImplementedError()
+    metadata_labels = get_tabular_dataset_metadata_annotations(
+        db=db, dataset=dataset, metadata_col_name="label"
+    )
+    if metadata_labels:
+        return metadata_labels
+    else:
+        columns = dataset_crud.get_dataset_columns(db=db, dataset=dataset)
+        return {column.given_id: column.given_id for column in columns}
 
 
 def get_labels_for_slice_type(
     db: SessionWithUser, slice_query: SliceQuery
-) -> Optional[dict[str, str]]:
+) -> dict[str, str]:
     """
     For the given slice query identifier type, get a dictionary of all the dataset labels and IDs
     that should be used to index the resulting slice.
@@ -113,6 +63,9 @@ def get_labels_for_slice_type(
         return dataset_crud.get_dataset_sample_labels_by_id(db, db.user, dataset)
     elif slice_query.identifier_type in {"sample_label", "sample_id"}:
         return dataset_crud.get_dataset_feature_labels_by_id(db, db.user, dataset)
-    elif slice_query.identifier == "column":
-        # TODO: return the labels for the tabular dataset index
-        return None
+    elif slice_query.identifier_type == "column":
+        return get_tabular_dataset_labels_by_id(db, dataset)
+    else:
+        raise ResourceNotFoundError(
+            f"Unknown identifier type: '{slice_query.identifier_type}'"
+        )

--- a/breadbox/tests/api/test_types.py
+++ b/breadbox/tests/api/test_types.py
@@ -124,6 +124,10 @@ def test_all_dimension_type_methods(client: TestClient, minimal_db, settings):
     # make sure we can delete it
     response = client.delete("/types/dimensions/sample_id_name", headers=admin_headers,)
     assert_status_ok(response)
+    metadata_dataset = (
+        minimal_db.query(Dataset).filter_by(id=new_metadata.id).one_or_none()
+    )
+    assert metadata_dataset is None
 
     # and now reports as missing
     response = client.get("/types/dimensions/sample_id_name")

--- a/breadbox/tests/service/test_metadata.py
+++ b/breadbox/tests/service/test_metadata.py
@@ -1,0 +1,61 @@
+import pandas as pd
+
+from breadbox.db.session import SessionWithUser
+from breadbox.service.metadata import get_tabular_dataset_labels_by_id
+from breadbox.models.dataset import AnnotationType
+from breadbox.schemas.dataset import ColumnMetadata
+
+from tests import factories
+
+
+def test_get_tabular_dataset_labels_by_id(minimal_db: SessionWithUser, settings):
+    """
+    Test that this function loads labels correctly for 
+    - tabular datasets that are metadata and
+    - tabular datasets that are not metadata
+    """
+    # Define metadata
+    dimension_type = factories.add_dimension_type(
+        minimal_db,
+        settings,
+        user=settings.admin_users[0],
+        name="some_feature_type",
+        display_name="Feature With Metadata",
+        id_column="ID",
+        annotation_type_mapping={
+            "ID": AnnotationType.text,
+            "label": AnnotationType.text,
+        },
+        axis="feature",
+        metadata_df=pd.DataFrame(
+            {
+                "ID": ["1", "2", "5"],
+                "label": ["featureLabel1", "featureLabel2", "featureLabel5"],
+            }
+        ),
+    )
+    tabular_dataset = factories.tabular_dataset(
+        minimal_db,
+        settings,
+        data_df=pd.DataFrame(
+            {"ID": ["1", "2", "3", "4"], "SomeOtherColumn": ["a", "b", "c", "d"]}
+        ),
+        index_type_name="some_feature_type",
+        columns_metadata={
+            "ID": ColumnMetadata(col_type=AnnotationType.text),
+            "SomeOtherColumn": ColumnMetadata(col_type=AnnotationType.text),
+        },
+    )
+
+    # This should only include the labels that overlap between the dataset and its metadata
+    non_metadata_result = get_tabular_dataset_labels_by_id(minimal_db, tabular_dataset)
+    assert non_metadata_result == {"1": "featureLabel1", "2": "featureLabel2"}
+
+    metadata_result = get_tabular_dataset_labels_by_id(
+        minimal_db, dimension_type.dataset
+    )
+    assert metadata_result == {
+        "1": "featureLabel1",
+        "2": "featureLabel2",
+        "5": "featureLabel5",
+    }


### PR DESCRIPTION
[Asana](https://app.asana.com/0/1165651979405609/1208554346294688/f)

**The problem:** For tabular datasets, there weren't any reusable methods for loading the labels (or other metadata) associated with a tabular dataset's index. As a result, when when the `/temp/context/` or `/datasets/dimension/data/` endpoints are called for a "column" slice type, they currently just return IDs as the labels (instead of getting the actual labels).

**The solution:** Defining a few new reusable methods:
* `get_dimension_type_metadata_col` - Gets a column of values from the given dimension type's metadata. 
* `get_tabular_dataset_index_given_ids` - identify all of the row IDs belonging to a tabular dataset. This can be used to join the dataset's metadata. 
* `get_tabular_dataset_metadata_annotations` - Gets a column of values from the given tabular dataset's metadata (this is a subset of the full dimension type's metadata) 
* `get_tabular_dataset_labels_by_id` Get all of the labels for the index of a tabular dataset. If a tabular dataset does not have any metadata associated with it, use the given IDs as labels. 

**Setting up a service layer:** I also wanted to use this as an opportunity to create a "service" module/layer, as we'd discussed at our last breadbox meeting (notes [here](https://app.asana.com/0/0/1208553414820117/1208578469618061/f)). The reason I'm setting this up now is that I couldn't define a function like `get_tabular_dataset_labels_by_id` in the dataset crud without creating a circular import (because it needs to import methods from `crud/types.py,` which in turn imports from `crud/dataset.py`). Instead of dealing with the circular imports, I thought it might be time to make a "service" directory. 

**Future steps:** There are 3-4 other places that re-implement a query very similar to  `get_dimension_type_metadata_col` (at least [here](https://github.com/broadinstitute/depmap-portal/blob/0820da05015e65ac76fceb2d04a04ba734aa9df1/breadbox/breadbox/crud/dataset.py#L1061), [here](https://github.com/broadinstitute/depmap-portal/blob/0820da05015e65ac76fceb2d04a04ba734aa9df1/breadbox/breadbox/crud/dataset.py#L1109), and [here](https://github.com/broadinstitute/depmap-portal/blob/0820da05015e65ac76fceb2d04a04ba734aa9df1/breadbox/breadbox/crud/dataset.py#L1527)). I would eventually like to combine these and remove the duplication. 