### PR TITLE
fix(breadbox): Improve error handling for context requests

### DIFF
--- a/breadbox/breadbox/api/temp.py
+++ b/breadbox/breadbox/api/temp.py
@@ -6,6 +6,7 @@ from breadbox.api.dependencies import get_db_with_user
 from breadbox.config import Settings, get_settings
 from breadbox.crud import types as types_crud
 from breadbox.crud import slice as slice_crud
+from breadbox.schemas.custom_http_exception import UserError
 from breadbox.db.session import SessionWithUser
 from breadbox.schemas.context import (
     Context,
@@ -48,10 +49,14 @@ def evaluate_context(
     # Evaluate each against the context
     matching_ids = []
     matching_labels = []
-    for given_id, label in all_labels_by_id.items():
-        if context_evaluator.is_match(given_id):
-            matching_ids.append(given_id)
-            matching_labels.append(label)
+    try:
+        for given_id, label in all_labels_by_id.items():
+            if context_evaluator.is_match(given_id):
+                matching_ids.append(given_id)
+                matching_labels.append(label)
+    except LookupError as e:
+        # This happens when the request is malformed
+        raise UserError(f"Encountered lookup error: {e}")
 
     return ContextMatchResponse(
         ids=matching_ids,

--- a/breadbox/poetry.lock
+++ b/breadbox/poetry.lock
@@ -722,13 +722,13 @@ files = [
 
 [[package]]
 name = "depmap-compute"
-version = "0.1.12"
+version = "0.1.13"
 description = "Code related to computations shared between the Depmap Portal and BreadBox"
 optional = false
 python-versions = ">=3.9,<4.0"
 files = [
-    {file = "depmap_compute-0.1.12-py3-none-any.whl", hash = "sha256:bd82da7a2da8d360af3c344e3f2fb2427bec66cb374df16ab5011cebd3b3a3a2"},
-    {file = "depmap_compute-0.1.12.tar.gz", hash = "sha256:3f2cd033b9f540dd66d949bfa230706728417dca00a68227000e959831113555"},
+    {file = "depmap_compute-0.1.13-py3-none-any.whl", hash = "sha256:233e37638d637c87257628d0aaf8f14c272ba95eb80eaeb5171d084abd0ff0ae"},
+    {file = "depmap_compute-0.1.13.tar.gz", hash = "sha256:71c8016b74883d2bec1160e6c68659e211694558562864887d799641fe5152eb"},
 ]
 
 [package.dependencies]
@@ -3840,4 +3840,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "f1ca769dad54ebc354d7a83ad6a099a94277150a3cdb5c915dd3f4eb43024f76"
+content-hash = "24b0ace7e81ac72f75e19da5a073e9f755dec894b4acc843ec8f284fad7249b6"

--- a/breadbox/pyproject.toml
+++ b/breadbox/pyproject.toml
@@ -29,7 +29,8 @@ itsdangerous = "^2.1.2"
 pandera = "^0.18.3"
 bpython = "^0.24"
 pydantic-settings = "^2.2.1"
-depmap-compute = {version = "0.1.12", source = "public-python"}
+depmap-compute = {version = "0.1.13", source = "public-python"}
+# depmap-compute = {path = "../depmap-compute", develop = true}
 
 [tool.poetry.group.dev.dependencies]
 pyright-ratchet = {git = "https://github.com/pgm/pyright-ratchet.git", rev = "v0.3.1"}

--- a/depmap-compute/depmap_compute/context.py
+++ b/depmap-compute/depmap_compute/context.py
@@ -67,13 +67,7 @@ class ContextEvaluator:
         dictionary_override = _JsonLogicVarLookup(
             given_id, self.cache, self.get_slice_data, self.slice_query_vars,
         )
-
-        try:
-            return jsonLogic(self.expr, dictionary_override)
-        except (TypeError, ValueError) as e:
-            print("Exception evaluating", self.expr, "against", given_id)
-            print(e)
-            return False
+        return jsonLogic(self.expr, dictionary_override)
 
 
 class _JsonLogicVarLookup(dict):
@@ -121,8 +115,12 @@ class _JsonLogicVarLookup(dict):
 
         else:
             if var_name not in self.cache:
-                slice_query = SliceQuery(**self.slice_query_vars[var_name])
-                self.cache[var_name] = self.get_slice_data(slice_query).to_dict()
+                try:
+                    slice_query = SliceQuery(**self.slice_query_vars[var_name])
+                    self.cache[var_name] = self.get_slice_data(slice_query).to_dict()
+                except (KeyError, TypeError, ValueError) as e:
+                    raise LookupError(e)
+
             slice_values = self.cache[var_name]
             return slice_values[self.given_id]
 

--- a/depmap-compute/pyproject.toml
+++ b/depmap-compute/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "depmap-compute"
-version = "0.1.12"
+version = "0.1.13"
 description = "Code related to computations shared between the Depmap Portal and BreadBox"
 authors = []
 


### PR DESCRIPTION
Currently, when the `ContextEvaluator` runs into a problem, it just hides the errors returns 0 matches. 

@rcreasi had made some helpful suggestions ([here](https://github.com/broadinstitute/depmap-portal/pull/110#discussion_r1821452610)) for how error handling could be improved. I implemented those changes and added a couple of tests to make sure it's now actually returning reasonable errors to users.