### PR TITLE
refactor(breadbox): Part 1 of removing duplicate metadata lookups

### DIFF
--- a/breadbox/breadbox/api/datasets.py
+++ b/breadbox/breadbox/api/datasets.py
@@ -53,6 +53,7 @@ from ..schemas.dataset import (
     DimensionDataResponse,
     SliceQueryIdentifierType,
 )
+from breadbox.service import dataset as dataset_service
 from breadbox.service import metadata as metadata_service
 from breadbox.service import slice as slice_service
 from .dependencies import get_dataset as get_dataset_dep
@@ -324,7 +325,7 @@ def get_matrix_dataset_data(
     ] = False,
 ):
     try:
-        df = dataset_crud.get_subsetted_matrix_dataset_df(
+        df = dataset_service.get_subsetted_matrix_dataset_df(
             db,
             user,
             dataset,
@@ -405,7 +406,7 @@ def get_dataset_data(
     except UserError as e:
         raise e
 
-    df = dataset_crud.get_subsetted_matrix_dataset_df(
+    df = dataset_service.get_subsetted_matrix_dataset_df(
         db, user, dataset, dim_info, settings.filestore_location
     )
 

--- a/breadbox/breadbox/api/datasets.py
+++ b/breadbox/breadbox/api/datasets.py
@@ -30,7 +30,6 @@ from ..config import Settings, get_settings
 from breadbox.crud.access_control import PUBLIC_GROUP_ID
 from ..crud import dataset as dataset_crud
 from ..crud import types as type_crud
-from ..crud import slice as slice_crud
 
 from ..models.dataset import (
     Dataset as DatasetModel,
@@ -55,6 +54,7 @@ from ..schemas.dataset import (
     SliceQueryIdentifierType,
 )
 from breadbox.service import metadata as metadata_service
+from breadbox.service import slice as slice_service
 from .dependencies import get_dataset as get_dataset_dep
 from .dependencies import get_db_with_user, get_user
 
@@ -491,7 +491,7 @@ def get_dimension_data(
         identifier=identifier,
         identifier_type=identifier_type.name,
     )
-    slice_values_by_id = slice_crud.get_slice_data(
+    slice_values_by_id = slice_service.get_slice_data(
         db, settings.filestore_location, parsed_slice_query
     )
 

--- a/breadbox/breadbox/api/datasets.py
+++ b/breadbox/breadbox/api/datasets.py
@@ -112,7 +112,7 @@ def get_dataset_features(
     if dataset is None:
         raise HTTPException(404, "Dataset not found")
 
-    feature_labels_by_id = metadata_service.get_dataset_feature_labels_by_id(
+    feature_labels_by_id = metadata_service.get_matrix_dataset_feature_labels_by_id(
         db=db, user=user, dataset=dataset,
     )
     return [{"id": id, "label": label} for id, label in feature_labels_by_id.items()]
@@ -135,7 +135,7 @@ def get_dataset_samples(
     if dataset is None:
         raise HTTPException(404, "Dataset not found")
 
-    sample_labels_by_id = metadata_service.get_dataset_sample_labels_by_id(
+    sample_labels_by_id = metadata_service.get_matrix_dataset_sample_labels_by_id(
         db=db, user=user, dataset=dataset,
     )
     return [{"id": id, "label": label} for id, label in sample_labels_by_id.items()]
@@ -187,7 +187,7 @@ def get_feature_data(
         # Get the feature label
         if dataset.feature_type_name:
             # Note: this would be faster if we had a query to load one label instead of all labels - but performance hasn't been an issue
-            feature_labels_by_id = metadata_service.get_dataset_feature_labels_by_id(
+            feature_labels_by_id = metadata_service.get_matrix_dataset_feature_labels_by_id(
                 db=db, user=user, dataset=dataset
             )
             label = feature_labels_by_id[feature.given_id]

--- a/breadbox/breadbox/api/datasets.py
+++ b/breadbox/breadbox/api/datasets.py
@@ -111,7 +111,7 @@ def get_dataset_features(
     if dataset is None:
         raise HTTPException(404, "Dataset not found")
 
-    feature_labels_by_id = dataset_crud.get_dataset_feature_labels_by_id(
+    feature_labels_by_id = metadata_service.get_dataset_feature_labels_by_id(
         db=db, user=user, dataset=dataset,
     )
     return [{"id": id, "label": label} for id, label in feature_labels_by_id.items()]
@@ -134,7 +134,7 @@ def get_dataset_samples(
     if dataset is None:
         raise HTTPException(404, "Dataset not found")
 
-    sample_labels_by_id = dataset_crud.get_dataset_sample_labels_by_id(
+    sample_labels_by_id = metadata_service.get_dataset_sample_labels_by_id(
         db=db, user=user, dataset=dataset,
     )
     return [{"id": id, "label": label} for id, label in sample_labels_by_id.items()]
@@ -186,7 +186,7 @@ def get_feature_data(
         # Get the feature label
         if dataset.feature_type_name:
             # Note: this would be faster if we had a query to load one label instead of all labels - but performance hasn't been an issue
-            feature_labels_by_id = dataset_crud.get_dataset_feature_labels_by_id(
+            feature_labels_by_id = metadata_service.get_dataset_feature_labels_by_id(
                 db=db, user=user, dataset=dataset
             )
             label = feature_labels_by_id[feature.given_id]

--- a/breadbox/breadbox/api/temp.py
+++ b/breadbox/breadbox/api/temp.py
@@ -5,13 +5,13 @@ from fastapi import APIRouter, Body, Depends
 from breadbox.api.dependencies import get_db_with_user
 from breadbox.config import Settings, get_settings
 from breadbox.crud import types as types_crud
-from breadbox.crud import slice as slice_crud
 from breadbox.schemas.custom_http_exception import UserError
 from breadbox.db.session import SessionWithUser
 from breadbox.schemas.context import (
     Context,
     ContextMatchResponse,
 )
+from breadbox.service import slice as slice_service
 
 from depmap_compute.context import ContextEvaluator
 
@@ -38,7 +38,7 @@ def evaluate_context(
     Also get the total number of "candidate" records (all records with labels belonging to the dimension type).
     Requests must be in the version 2 context format. 
     """
-    slice_loader_function = lambda slice_query: slice_crud.get_slice_data(
+    slice_loader_function = lambda slice_query: slice_service.get_slice_data(
         db, settings.filestore_location, slice_query
     )
     context_evaluator = ContextEvaluator(context.dict(), slice_loader_function)

--- a/breadbox/breadbox/compute/analysis_tasks.py
+++ b/breadbox/breadbox/compute/analysis_tasks.py
@@ -166,12 +166,12 @@ def get_features_info_and_dataset(
     dataset = dataset_crud.get_dataset(db, user, dataset_id)
     if dataset is None:
         raise ResourceNotFoundError(f"Dataset '{dataset_id}' not found.")
-    dataset_features = dataset_crud.get_dataset_features(db, dataset)
+    dataset_features = dataset_crud.get_matrix_dataset_features(db, dataset)
 
     result_features: List[Feature] = []
     dataset_feature_ids: List[str] = []
     datasets: List[Dataset] = []
-    feature_labels_by_id = metadata_service.get_dataset_feature_labels_by_id(
+    feature_labels_by_id = metadata_service.get_matrix_dataset_feature_labels_by_id(
         db, user, dataset
     )
     feature_indices = []

--- a/breadbox/breadbox/compute/analysis_tasks.py
+++ b/breadbox/breadbox/compute/analysis_tasks.py
@@ -25,6 +25,7 @@ from breadbox.models.dataset import (
 from breadbox.schemas.custom_http_exception import ResourceNotFoundError, UserError
 
 from breadbox.schemas.dataset import MatrixDatasetIn
+from breadbox.service import metadata as metadata_service
 
 from ..crud.types import get_dimension_type
 from ..crud import dataset as dataset_crud
@@ -170,7 +171,7 @@ def get_features_info_and_dataset(
     result_features: List[Feature] = []
     dataset_feature_ids: List[str] = []
     datasets: List[Dataset] = []
-    feature_labels_by_id = dataset_crud.get_dataset_feature_labels_by_id(
+    feature_labels_by_id = metadata_service.get_dataset_feature_labels_by_id(
         db, user, dataset
     )
     feature_indices = []

--- a/breadbox/breadbox/compute/analysis_tasks.py
+++ b/breadbox/breadbox/compute/analysis_tasks.py
@@ -166,7 +166,7 @@ def get_features_info_and_dataset(
     dataset = dataset_crud.get_dataset(db, user, dataset_id)
     if dataset is None:
         raise ResourceNotFoundError(f"Dataset '{dataset_id}' not found.")
-    dataset_features = dataset_crud.get_dataset_features(db, dataset, user)
+    dataset_features = dataset_crud.get_dataset_features(db, dataset)
 
     result_features: List[Feature] = []
     dataset_feature_ids: List[str] = []

--- a/breadbox/breadbox/compute/analysis_tasks.py
+++ b/breadbox/breadbox/compute/analysis_tasks.py
@@ -497,12 +497,12 @@ def create_cell_line_group(
 
         # Return the feature ID associated with the new dataset feature
         if use_feature_ids:
-            feature: DatasetFeature = dataset_crud.get_dataset_feature_by_label(
+            feature: DatasetFeature = metadata_service.get_dataset_feature_by_label(
                 db=db, dataset_id=dataset_id, feature_label=feature_label
             )
             return _format_breadbox_shim_slice_id(feature.dataset_id, feature.given_id)
         else:
-            dataset_feature = dataset_crud.get_dataset_feature_by_label(
+            dataset_feature = metadata_service.get_dataset_feature_by_label(
                 db, dataset_id, feature_label
             )
             return str(dataset_feature.id)

--- a/breadbox/breadbox/compute/download_tasks.py
+++ b/breadbox/breadbox/compute/download_tasks.py
@@ -11,7 +11,6 @@ from breadbox.schemas.custom_http_exception import UserError
 from breadbox.crud.dataset import get_sample_indexes_by_given_ids
 from breadbox.crud.dataset import get_all_sample_indexes
 from breadbox.crud.partial import get_cell_line_selector_lines
-from breadbox.crud.dataset import get_dataset_feature_labels_by_id
 from ..config import get_settings
 from ..models.dataset import (
     Dataset,
@@ -21,6 +20,7 @@ from ..models.dataset import (
 )
 from .celery import app
 from ..db.util import db_context
+from breadbox.service import metadata as metadata_service
 
 
 def _progress_callback(task, percentage, message="Fetching data"):
@@ -67,7 +67,9 @@ def _get_subsetted_df_by_indexes(
         # Only include dataset names in column names if we're merging datasets
         col_rename_map = {}
 
-        feature_labels = get_dataset_feature_labels_by_id(db, user, dataset)
+        feature_labels = metadata_service.get_dataset_feature_labels_by_id(
+            db, user, dataset
+        )
 
         for col in subsetted_df.columns:
             if include_dataset_name_in_row_name:

--- a/breadbox/breadbox/compute/download_tasks.py
+++ b/breadbox/breadbox/compute/download_tasks.py
@@ -67,7 +67,7 @@ def _get_subsetted_df_by_indexes(
         # Only include dataset names in column names if we're merging datasets
         col_rename_map = {}
 
-        feature_labels = metadata_service.get_dataset_feature_labels_by_id(
+        feature_labels = metadata_service.get_matrix_dataset_feature_labels_by_id(
             db, user, dataset
         )
 

--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -976,7 +976,7 @@ def get_dataset_feature_dimensions(db: SessionWithUser, user: str, dataset_id: s
     return dimensions
 
 
-def get_dataset_features(
+def get_matrix_dataset_features(
     db: SessionWithUser, dataset: MatrixDataset
 ) -> list[DatasetFeature]:
     assert_user_has_access_to_dataset(dataset, db.user)
@@ -991,7 +991,7 @@ def get_dataset_features(
     return dataset_features
 
 
-def get_dataset_samples(
+def get_matrix_dataset_samples(
     db: SessionWithUser, dataset: MatrixDataset
 ) -> list[DatasetSample]:
     assert_user_has_access_to_dataset(dataset, db.user)

--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -1043,6 +1043,7 @@ def get_matching_feature_metadata_labels(
     db: SessionWithUser, feature_labels: List[str]
 ) -> set[str]:
     """
+    DEPRECATED: this method should be removed when the old data_slicer functionality is replaced.
     Return the subset of the given list which matches any feature metadata label
     Use case-insensitive matching, but return a list of properly-cased labels.
     """
@@ -1335,54 +1336,6 @@ def get_dataset_sample_by_given_id(
             f"Sample given ID '{sample_given_id}' not found in dataset '{dataset_id}'."
         )
     return sample
-
-
-def get_dataset_feature_by_label(
-    db: SessionWithUser, dataset_id: str, feature_label: str
-) -> DatasetFeature:
-    """Load the dataset feature corresponding to the given dataset ID and feature label"""
-
-    dataset = get_dataset(db, db.user, dataset_id)
-    if dataset is None:
-        raise ResourceNotFoundError(f"Dataset '{dataset_id}' not found.")
-    assert_user_has_access_to_dataset(dataset, db.user)
-    assert isinstance(dataset, MatrixDataset)
-
-    labels_by_given_id = metadata_service.get_dataset_feature_labels_by_id(
-        db, db.user, dataset
-    )
-    given_ids_by_label = {label: id for id, label in labels_by_given_id.items()}
-    feature_given_id = given_ids_by_label.get(feature_label)
-    if feature_given_id is None:
-        raise ResourceNotFoundError(
-            f"Feature label '{feature_label}' not found in dataset '{dataset_id}'."
-        )
-
-    return get_dataset_feature_by_given_id(db, dataset_id, feature_given_id)
-
-
-def get_dataset_sample_by_label(
-    db: SessionWithUser, dataset_id: str, sample_label: str
-) -> DatasetSample:
-    """Load the dataset sample corresponding to the given dataset ID and sample label"""
-
-    dataset = get_dataset(db, db.user, dataset_id)
-    if dataset is None:
-        raise ResourceNotFoundError(f"Dataset '{dataset_id}' not found.")
-    assert_user_has_access_to_dataset(dataset, db.user)
-    assert isinstance(dataset, MatrixDataset)
-
-    labels_by_given_id = metadata_service.get_dataset_sample_labels_by_id(
-        db, db.user, dataset
-    )
-    given_ids_by_label = {label: id for id, label in labels_by_given_id.items()}
-    sample_given_id = given_ids_by_label.get(sample_label)
-    if sample_given_id is None:
-        raise ResourceNotFoundError(
-            f"Sample label '{sample_label}' not found in dataset '{dataset_id}'."
-        )
-
-    return get_dataset_sample_by_given_id(db, dataset_id, sample_given_id)
 
 
 def _get_column_types(columns_metadata, columns: Optional[List[str]]):

--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -20,7 +20,6 @@ from ..schemas.dataset import (
     TabularDatasetIn,
     DimensionSearchIndexResponse,
     FeatureSampleIdentifier,
-    MatrixDimensionsInfo,
     ColumnMetadata,
     TabularDimensionsInfo,
     UpdateDatasetParams,
@@ -53,13 +52,9 @@ from breadbox.crud.group import (
     TRANSIENT_GROUP_ID,
     get_transient_group,
 )
-from breadbox.io.filestore_crud import (
-    get_slice,
-    delete_data_files,
-)
+from breadbox.io.filestore_crud import delete_data_files
 from .metadata import cast_tabular_cell_value_type
 from .dataset_reference import add_id_mapping
-from breadbox.service import metadata as metadata_service
 import typing
 
 log = logging.getLogger(__name__)
@@ -1528,80 +1523,3 @@ def get_missing_tabular_columns_and_indices(
             )
 
     return missing_columns, missing_indices
-
-
-def get_subsetted_matrix_dataset_df(
-    db: SessionWithUser,
-    user: str,
-    dataset: Dataset,
-    dimensions_info: MatrixDimensionsInfo,
-    filestore_location,
-    strict: bool = False,  # False default for backwards compatibility
-):
-    """
-    Load a dataframe containing data for the specified dimensions.
-    If the dimensions are specified by label, then return a result indexed by labels
-    """
-
-    missing_features = []
-    missing_samples = []
-
-    if dimensions_info.features is None:
-        feature_indexes = None
-    elif dimensions_info.feature_identifier.value == "id":
-        feature_indexes, missing_features = get_feature_indexes_by_given_ids(
-            db, user, dataset, dimensions_info.features
-        )
-    else:
-        assert dimensions_info.feature_identifier.value == "label"
-        feature_indexes, missing_features = get_dimension_indexes_of_labels(
-            db, user, dataset, axis="feature", dimension_labels=dimensions_info.features
-        )
-
-    if len(missing_features) > 0:
-        log.warning(f"Could not find features: {missing_features}")
-
-    if dimensions_info.samples is None:
-        sample_indexes = None
-    elif dimensions_info.sample_identifier.value == "id":
-        sample_indexes, missing_samples = get_sample_indexes_by_given_ids(
-            db, user, dataset, dimensions_info.samples
-        )
-    else:
-        sample_indexes, missing_samples = get_dimension_indexes_of_labels(
-            db, user, dataset, axis="sample", dimension_labels=dimensions_info.samples
-        )
-
-    if len(missing_samples) > 0:
-        log.warning(f"Could not find samples: {missing_samples}")
-
-    if strict:
-        num_missing_features = len(missing_features)
-        missing_features_msg = f"{num_missing_features} missing features: {missing_features[:20] + ['...'] if num_missing_features >= 20 else missing_features}"
-        num_missing_samples = len(missing_samples)
-        missing_samples_msg = f"{num_missing_samples} missing samples: {missing_samples[:20] + ['...'] if num_missing_samples >= 20 else missing_samples}"
-        if len(missing_features) > 0 or len(missing_samples) > 0:
-            raise UserError(f"{missing_features_msg} and {missing_samples_msg}")
-
-    # call sort on the indices because hdf5_read requires indices be in ascending order
-    if feature_indexes is not None:
-        feature_indexes = sorted(feature_indexes)
-    if sample_indexes is not None:
-        sample_indexes = sorted(sample_indexes)
-
-    df = get_slice(dataset, feature_indexes, sample_indexes, filestore_location)
-
-    # Re-index by label if applicable
-    if dimensions_info.feature_identifier == FeatureSampleIdentifier.label:
-        labels_by_id = metadata_service.get_dataset_feature_labels_by_id(
-            db, user, dataset
-        )
-        df = df.rename(columns=labels_by_id)
-
-    if dimensions_info.sample_identifier == FeatureSampleIdentifier.label:
-        label_by_id = metadata_service.get_dataset_sample_labels_by_id(
-            db, user, dataset
-        )
-        df = df.rename(index=label_by_id)
-
-    return df

--- a/breadbox/breadbox/service/dataset.py
+++ b/breadbox/breadbox/service/dataset.py
@@ -1,0 +1,97 @@
+import logging
+
+from breadbox.crud import dataset as dataset_crud
+from breadbox.db.session import SessionWithUser
+from breadbox.io.filestore_crud import get_slice
+from breadbox.models.dataset import MatrixDataset
+from breadbox.schemas.dataset import (
+    FeatureSampleIdentifier,
+    MatrixDimensionsInfo,
+)
+from breadbox.schemas.custom_http_exception import UserError
+from breadbox.service import metadata as metadata_service
+
+log = logging.getLogger(__name__)
+
+
+def get_subsetted_matrix_dataset_df(
+    db: SessionWithUser,
+    user: str,
+    dataset: MatrixDataset,
+    dimensions_info: MatrixDimensionsInfo,
+    filestore_location,
+    strict: bool = False,  # False default for backwards compatibility
+):
+    """
+    Load a dataframe containing data for the specified dimensions.
+    If the dimensions are specified by label, then return a result indexed by labels
+    """
+
+    missing_features = []
+    missing_samples = []
+
+    if dimensions_info.features is None:
+        feature_indexes = None
+    elif dimensions_info.feature_identifier.value == "id":
+        (
+            feature_indexes,
+            missing_features,
+        ) = dataset_crud.get_feature_indexes_by_given_ids(
+            db, user, dataset, dimensions_info.features
+        )
+    else:
+        assert dimensions_info.feature_identifier.value == "label"
+        (
+            feature_indexes,
+            missing_features,
+        ) = dataset_crud.get_dimension_indexes_of_labels(
+            db, user, dataset, axis="feature", dimension_labels=dimensions_info.features
+        )
+
+    if len(missing_features) > 0:
+        log.warning(f"Could not find features: {missing_features}")
+
+    if dimensions_info.samples is None:
+        sample_indexes = None
+    elif dimensions_info.sample_identifier.value == "id":
+        sample_indexes, missing_samples = dataset_crud.get_sample_indexes_by_given_ids(
+            db, user, dataset, dimensions_info.samples
+        )
+    else:
+        sample_indexes, missing_samples = dataset_crud.get_dimension_indexes_of_labels(
+            db, user, dataset, axis="sample", dimension_labels=dimensions_info.samples
+        )
+
+    if len(missing_samples) > 0:
+        log.warning(f"Could not find samples: {missing_samples}")
+
+    if strict:
+        num_missing_features = len(missing_features)
+        missing_features_msg = f"{num_missing_features} missing features: {missing_features[:20] + ['...'] if num_missing_features >= 20 else missing_features}"
+        num_missing_samples = len(missing_samples)
+        missing_samples_msg = f"{num_missing_samples} missing samples: {missing_samples[:20] + ['...'] if num_missing_samples >= 20 else missing_samples}"
+        if len(missing_features) > 0 or len(missing_samples) > 0:
+            raise UserError(f"{missing_features_msg} and {missing_samples_msg}")
+
+    # call sort on the indices because hdf5_read requires indices be in ascending order
+    if feature_indexes is not None:
+        feature_indexes = sorted(feature_indexes)
+    if sample_indexes is not None:
+        sample_indexes = sorted(sample_indexes)
+
+    df = get_slice(dataset, feature_indexes, sample_indexes, filestore_location)
+
+    # Re-index by label if applicable
+    if dimensions_info.feature_identifier == FeatureSampleIdentifier.label:
+        labels_by_id = metadata_service.get_dataset_feature_labels_by_id(
+            db, user, dataset
+        )
+        df = df.rename(columns=labels_by_id)
+
+    if dimensions_info.sample_identifier == FeatureSampleIdentifier.label:
+        label_by_id = metadata_service.get_dataset_sample_labels_by_id(
+            db, user, dataset
+        )
+        df = df.rename(index=label_by_id)
+
+    return df

--- a/breadbox/breadbox/service/dataset.py
+++ b/breadbox/breadbox/service/dataset.py
@@ -83,13 +83,13 @@ def get_subsetted_matrix_dataset_df(
 
     # Re-index by label if applicable
     if dimensions_info.feature_identifier == FeatureSampleIdentifier.label:
-        labels_by_id = metadata_service.get_dataset_feature_labels_by_id(
+        labels_by_id = metadata_service.get_matrix_dataset_feature_labels_by_id(
             db, user, dataset
         )
         df = df.rename(columns=labels_by_id)
 
     if dimensions_info.sample_identifier == FeatureSampleIdentifier.label:
-        label_by_id = metadata_service.get_dataset_sample_labels_by_id(
+        label_by_id = metadata_service.get_matrix_dataset_sample_labels_by_id(
             db, user, dataset
         )
         df = df.rename(index=label_by_id)

--- a/breadbox/breadbox/service/metadata.py
+++ b/breadbox/breadbox/service/metadata.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from breadbox.crud import dataset as dataset_crud
 from breadbox.crud import types as types_crud
@@ -37,6 +37,46 @@ def get_tabular_dataset_metadata_annotations(
     return filtered_metadata_vals
 
 
+def get_matrix_dataset_feature_metadata(
+    db: SessionWithUser, dataset: MatrixDataset, metadata_col_name: str,
+) -> dict[str, Any]:
+    """
+    For the given matrix dataset, load a column from the associated metadata.
+    The result will only include given ids which exist in both the dataset and the metadata.
+    """
+    full_metadata_col = types_crud.get_dimension_type_metadata_col(
+        db, dimension_type_name=dataset.feature_type_name, col_name=metadata_col_name
+    )
+    # Filter the metadata to only include the given IDs belonging to this dataset
+    dataset_features = dataset_crud.get_dataset_features(db, dataset)
+    filtered_metadata_vals = {}
+    for feature in dataset_features:
+        metadata_val = full_metadata_col.get(feature.given_id)
+        if metadata_val is not None:
+            filtered_metadata_vals[feature.given_id] = metadata_val
+    return filtered_metadata_vals
+
+
+def get_matrix_dataset_sample_metadata(
+    db: SessionWithUser, dataset: MatrixDataset, metadata_col_name: str,
+) -> dict[str, Any]:
+    """
+    For the given matrix dataset, load a column from the associated metadata.
+    The result will only include given ids which exist in both the dataset and the metadata.
+    """
+    full_metadata_col = types_crud.get_dimension_type_metadata_col(
+        db, dimension_type_name=dataset.sample_type_name, col_name=metadata_col_name
+    )
+    # Filter the metadata to only include the given IDs belonging to this dataset
+    dataset_samples = dataset_crud.get_dataset_samples(db, dataset)
+    filtered_metadata_vals = {}
+    for sample in dataset_samples:
+        metadata_val = full_metadata_col.get(sample.given_id)
+        if metadata_val is not None:
+            filtered_metadata_vals[sample.given_id] = metadata_val
+    return filtered_metadata_vals
+
+
 def get_dataset_feature_labels_by_id(
     db: SessionWithUser, user: str, dataset: MatrixDataset,
 ) -> dict[str, str]:
@@ -44,16 +84,14 @@ def get_dataset_feature_labels_by_id(
     Try loading feature labels from metadata.
     If there are no labels in the metadata or there is no metadata, then just return the feature names.
     """
-    metadata_labels_by_given_id = dataset_crud.get_dataset_feature_annotations(  # TODO: replace this
-        db=db, user=user, dataset=dataset, metadata_col_name="label"
+    metadata_labels_by_given_id = get_matrix_dataset_feature_metadata(
+        db=db, dataset=dataset, metadata_col_name="label"
     )
 
     if metadata_labels_by_given_id:
         return metadata_labels_by_given_id
     else:
-        all_dataset_features = dataset_crud.get_dataset_features(
-            db=db, dataset=dataset, user=user
-        )
+        all_dataset_features = dataset_crud.get_dataset_features(db, dataset)
         return {feature.given_id: feature.given_id for feature in all_dataset_features}
 
 
@@ -64,13 +102,13 @@ def get_dataset_sample_labels_by_id(
     Try loading sample labels from metadata.
     If there are no labels in the metadata or there is no metadata, then just return the sample names.
     """
-    metadata_labels = dataset_crud.get_dataset_sample_annotations(  # TODO: replace this
-        db=db, user=user, dataset=dataset, metadata_col_name="label"
+    metadata_labels = get_matrix_dataset_sample_metadata(
+        db=db, dataset=dataset, metadata_col_name="label"
     )
     if metadata_labels:
         return metadata_labels
     else:
-        samples = dataset_crud.get_dataset_samples(db=db, dataset=dataset, user=user)
+        samples = dataset_crud.get_dataset_samples(db=db, dataset=dataset)
         return {sample.given_id: sample.given_id for sample in samples}
 
 

--- a/breadbox/breadbox/service/metadata.py
+++ b/breadbox/breadbox/service/metadata.py
@@ -5,7 +5,12 @@ from breadbox.crud import dataset as dataset_crud
 from breadbox.crud import types as types_crud
 from breadbox.db.session import SessionWithUser
 from breadbox.schemas.custom_http_exception import ResourceNotFoundError
-from breadbox.models.dataset import MatrixDataset, TabularDataset
+from breadbox.models.dataset import (
+    DatasetFeature,
+    DatasetSample,
+    MatrixDataset,
+    TabularDataset,
+)
 from breadbox.service import metadata as metadata_service
 
 from depmap_compute.slice import SliceQuery
@@ -154,3 +159,51 @@ def get_labels_for_slice_type(
         raise ResourceNotFoundError(
             f"Unknown identifier type: '{slice_query.identifier_type}'"
         )
+
+
+def get_dataset_feature_by_label(
+    db: SessionWithUser, dataset_id: str, feature_label: str
+) -> DatasetFeature:
+    """Load the dataset feature corresponding to the given dataset ID and feature label"""
+
+    dataset = dataset_crud.get_dataset(db, db.user, dataset_id)
+    if dataset is None:
+        raise ResourceNotFoundError(f"Dataset '{dataset_id}' not found.")
+    assert isinstance(dataset, MatrixDataset)
+
+    labels_by_given_id = metadata_service.get_dataset_feature_labels_by_id(
+        db, db.user, dataset
+    )
+    given_ids_by_label = {label: id for id, label in labels_by_given_id.items()}
+    feature_given_id = given_ids_by_label.get(feature_label)
+    if feature_given_id is None:
+        raise ResourceNotFoundError(
+            f"Feature label '{feature_label}' not found in dataset '{dataset_id}'."
+        )
+
+    return dataset_crud.get_dataset_feature_by_given_id(
+        db, dataset_id, feature_given_id
+    )
+
+
+def get_dataset_sample_by_label(
+    db: SessionWithUser, dataset_id: str, sample_label: str
+) -> DatasetSample:
+    """Load the dataset sample corresponding to the given dataset ID and sample label"""
+
+    dataset = dataset_crud.get_dataset(db, db.user, dataset_id)
+    if dataset is None:
+        raise ResourceNotFoundError(f"Dataset '{dataset_id}' not found.")
+    assert isinstance(dataset, MatrixDataset)
+
+    labels_by_given_id = metadata_service.get_dataset_sample_labels_by_id(
+        db, db.user, dataset
+    )
+    given_ids_by_label = {label: id for id, label in labels_by_given_id.items()}
+    sample_given_id = given_ids_by_label.get(sample_label)
+    if sample_given_id is None:
+        raise ResourceNotFoundError(
+            f"Sample label '{sample_label}' not found in dataset '{dataset_id}'."
+        )
+
+    return dataset_crud.get_dataset_sample_by_given_id(db, dataset_id, sample_given_id)

--- a/breadbox/breadbox/service/metadata.py
+++ b/breadbox/breadbox/service/metadata.py
@@ -89,15 +89,16 @@ def get_dataset_feature_labels_by_id(
     Try loading feature labels from metadata.
     If there are no labels in the metadata or there is no metadata, then just return the feature names.
     """
-    metadata_labels_by_given_id = get_matrix_dataset_feature_metadata(
-        db=db, dataset=dataset, metadata_col_name="label"
-    )
+    if dataset.feature_type_name is not None:
+        metadata_labels_by_given_id = get_matrix_dataset_feature_metadata(
+            db=db, dataset=dataset, metadata_col_name="label"
+        )
+        if metadata_labels_by_given_id:
+            return metadata_labels_by_given_id
 
-    if metadata_labels_by_given_id:
-        return metadata_labels_by_given_id
-    else:
-        all_dataset_features = dataset_crud.get_dataset_features(db, dataset)
-        return {feature.given_id: feature.given_id for feature in all_dataset_features}
+    # If there are no labels or there is no feature type, return the given IDs
+    all_dataset_features = dataset_crud.get_dataset_features(db, dataset)
+    return {feature.given_id: feature.given_id for feature in all_dataset_features}
 
 
 def get_dataset_sample_labels_by_id(

--- a/breadbox/breadbox/service/slice.py
+++ b/breadbox/breadbox/service/slice.py
@@ -12,6 +12,7 @@ from breadbox.io.filestore_crud import (
     get_feature_slice,
     get_sample_slice,
 )
+from breadbox.service import metadata as metadata_service
 
 from depmap_compute.slice import SliceQuery
 
@@ -57,7 +58,7 @@ def get_slice_data(
         slice_data = get_feature_slice(dataset, [feature.index], filestore_location)
 
     elif slice_query.identifier_type == "feature_label":
-        feature = dataset_crud.get_dataset_feature_by_label(
+        feature = metadata_service.get_dataset_feature_by_label(
             db, dataset_id, feature_label=slice_query.identifier,
         )
         slice_data = get_feature_slice(dataset, [feature.index], filestore_location)
@@ -69,7 +70,7 @@ def get_slice_data(
         slice_data = get_sample_slice(dataset, [sample.index], filestore_location)
 
     elif slice_query.identifier_type == "sample_label":
-        sample = dataset_crud.get_dataset_sample_by_label(
+        sample = metadata_service.get_dataset_sample_by_label(
             db, dataset_id, sample_label=slice_query.identifier
         )
         slice_data = get_sample_slice(dataset, [sample.index], filestore_location)

--- a/breadbox/tests/api/test_datasets.py
+++ b/breadbox/tests/api/test_datasets.py
@@ -165,7 +165,7 @@ class TestGet:
         assert_status_ok(given_id_response)
         assert given_id_response.json() == response.json()
 
-    def test_get_dataset_samples(
+    def test_get_matrix_dataset_samples(
         self, client: TestClient, minimal_db: SessionWithUser, settings
     ):
         given_id = "some_matrix_dataset"

--- a/breadbox/tests/crud/test_dataset.py
+++ b/breadbox/tests/crud/test_dataset.py
@@ -1,16 +1,13 @@
 import numpy as np
 import pandas as pd
-import pytest
 
 from breadbox.db.session import SessionWithUser
 from breadbox.crud.dataset import (
-    get_dataset_feature_by_label,
     get_dataset,
     get_dataset_feature_by_given_id,
     get_tabular_dataset_index_given_ids,
 )
 from breadbox.models.dataset import AnnotationType
-from breadbox.schemas.custom_http_exception import ResourceNotFoundError
 from breadbox.schemas.dataset import ColumnMetadata
 
 from tests import factories
@@ -38,84 +35,6 @@ def test_get_dataset(minimal_db, settings):
 
     # Lastly, test that None is returned when the dataset doesn't exist
     assert get_dataset(minimal_db, minimal_db.user, "foo") is None
-
-
-def test_get_dataset_feature_by_label(minimal_db: SessionWithUser, settings):
-
-    # Test the case where there is no metadata (where labels are given_ids)
-    example_matrix_values = factories.matrix_csv_data_file_with_values(
-        feature_ids=["featureID1", "featureID2", "featureID3"],
-        sample_ids=["sampleID1", "sampleID2", "sampleID3"],
-        values=np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
-    )
-    dataset_with_generic_features = factories.matrix_dataset(
-        minimal_db, settings, feature_type=None, data_file=example_matrix_values
-    )
-    minimal_db.reset_user(settings.default_user)
-    feature = get_dataset_feature_by_label(
-        minimal_db,
-        dataset_id=dataset_with_generic_features.id,
-        feature_label="featureID1",
-    )
-    assert feature.dataset_id == dataset_with_generic_features.id
-    assert feature.given_id == "featureID1"
-
-    # Test the case where metadata does exist
-    minimal_db.reset_user(settings.admin_users[0])
-    factories.add_dimension_type(
-        minimal_db,
-        settings,
-        user=settings.admin_users[0],
-        name="feature-with-metadata",
-        display_name="Feature With Metadata",
-        id_column="ID",
-        annotation_type_mapping={
-            "ID": AnnotationType.text,
-            "label": AnnotationType.text,
-        },
-        axis="feature",
-        metadata_df=pd.DataFrame(
-            {
-                "ID": ["featureID1", "featureID2", "featureID3"],
-                "label": ["featureLabel1", "featureLabel2", "featureLabel3"],
-            }
-        ),
-    )
-    example_matrix_values = factories.matrix_csv_data_file_with_values(
-        feature_ids=["featureID1", "featureID2", "featureID3"],
-        sample_ids=["sampleID1", "sampleID2", "sampleID3"],
-        values=np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
-    )
-    dataset_with_metadata = factories.matrix_dataset(
-        minimal_db,
-        settings,
-        feature_type="feature-with-metadata",
-        data_file=example_matrix_values,
-    )
-
-    # Query with the non-admin user
-    minimal_db.reset_user(settings.default_user)
-    feature = get_dataset_feature_by_label(
-        minimal_db, dataset_id=dataset_with_metadata.id, feature_label="featureLabel1",
-    )
-    assert feature.dataset_id == dataset_with_metadata.id
-    assert feature.given_id == "featureID1"
-
-    # When the dataset does not exist, a clear error should be raised
-    with pytest.raises(ResourceNotFoundError):
-        get_dataset_feature_by_label(
-            minimal_db,
-            dataset_id="Undefined-dataset",
-            feature_label="someFeatureLabel",
-        )
-
-    # When the featureLabel does not exist within the dataset, a clear error should be raised
-    with pytest.raises(ResourceNotFoundError):
-        get_dataset_feature_by_label(
-            minimal_db,
-            dataset_id=dataset_with_generic_features.id,
-            feature_label="Undefined_Feature_Label",
-        )
 
 
 def test_get_dataset_feature_by_given_id(minimal_db: SessionWithUser, settings):

--- a/breadbox/tests/service/test_metadata.py
+++ b/breadbox/tests/service/test_metadata.py
@@ -1,10 +1,15 @@
+import numpy as np
 import pandas as pd
+import pytest
 
 from breadbox.db.session import SessionWithUser
-from breadbox.service.metadata import get_tabular_dataset_labels_by_id
+from breadbox.service.metadata import (
+    get_tabular_dataset_labels_by_id,
+    get_dataset_feature_by_label,
+)
 from breadbox.models.dataset import AnnotationType
+from breadbox.schemas.custom_http_exception import ResourceNotFoundError
 from breadbox.schemas.dataset import ColumnMetadata
-
 from tests import factories
 
 
@@ -59,3 +64,81 @@ def test_get_tabular_dataset_labels_by_id(minimal_db: SessionWithUser, settings)
         "2": "featureLabel2",
         "5": "featureLabel5",
     }
+
+
+def test_get_dataset_feature_by_label(minimal_db: SessionWithUser, settings):
+
+    # Test the case where there is no metadata (where labels are given_ids)
+    example_matrix_values = factories.matrix_csv_data_file_with_values(
+        feature_ids=["featureID1", "featureID2", "featureID3"],
+        sample_ids=["sampleID1", "sampleID2", "sampleID3"],
+        values=np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+    )
+    dataset_with_generic_features = factories.matrix_dataset(
+        minimal_db, settings, feature_type=None, data_file=example_matrix_values
+    )
+    minimal_db.reset_user(settings.default_user)
+    feature = get_dataset_feature_by_label(
+        minimal_db,
+        dataset_id=dataset_with_generic_features.id,
+        feature_label="featureID1",
+    )
+    assert feature.dataset_id == dataset_with_generic_features.id
+    assert feature.given_id == "featureID1"
+
+    # Test the case where metadata does exist
+    minimal_db.reset_user(settings.admin_users[0])
+    factories.add_dimension_type(
+        minimal_db,
+        settings,
+        user=settings.admin_users[0],
+        name="feature-with-metadata",
+        display_name="Feature With Metadata",
+        id_column="ID",
+        annotation_type_mapping={
+            "ID": AnnotationType.text,
+            "label": AnnotationType.text,
+        },
+        axis="feature",
+        metadata_df=pd.DataFrame(
+            {
+                "ID": ["featureID1", "featureID2", "featureID3"],
+                "label": ["featureLabel1", "featureLabel2", "featureLabel3"],
+            }
+        ),
+    )
+    example_matrix_values = factories.matrix_csv_data_file_with_values(
+        feature_ids=["featureID1", "featureID2", "featureID3"],
+        sample_ids=["sampleID1", "sampleID2", "sampleID3"],
+        values=np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+    )
+    dataset_with_metadata = factories.matrix_dataset(
+        minimal_db,
+        settings,
+        feature_type="feature-with-metadata",
+        data_file=example_matrix_values,
+    )
+
+    # Query with the non-admin user
+    minimal_db.reset_user(settings.default_user)
+    feature = get_dataset_feature_by_label(
+        minimal_db, dataset_id=dataset_with_metadata.id, feature_label="featureLabel1",
+    )
+    assert feature.dataset_id == dataset_with_metadata.id
+    assert feature.given_id == "featureID1"
+
+    # When the dataset does not exist, a clear error should be raised
+    with pytest.raises(ResourceNotFoundError):
+        get_dataset_feature_by_label(
+            minimal_db,
+            dataset_id="Undefined-dataset",
+            feature_label="someFeatureLabel",
+        )
+
+    # When the featureLabel does not exist within the dataset, a clear error should be raised
+    with pytest.raises(ResourceNotFoundError):
+        get_dataset_feature_by_label(
+            minimal_db,
+            dataset_id=dataset_with_generic_features.id,
+            feature_label="Undefined_Feature_Label",
+        )

--- a/breadbox/tests/service/test_slice.py
+++ b/breadbox/tests/service/test_slice.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 
 from breadbox.db.session import SessionWithUser
-from breadbox.crud.slice import get_slice_data
+from breadbox.service.slice import get_slice_data
 from breadbox.models.dataset import AnnotationType
 from breadbox.schemas.dataset import ColumnMetadata
 


### PR DESCRIPTION
[Asana](https://app.asana.com/0/1165651979405609/1208651997719944/f)

**I am breaking these changes into two parts so I can more quickly unblock Jessica. This PR includes:**
1. Redefining a couple of methods to remove duplicate SQLAlchemy queries: 
    * For example, `crud.dataset.get_dataset_sample_annotations` (which has a complicated SQLAlchemy query) was replaced by `service.metadata.get_matrix_dataset_sample_metadata` (which calls existing crud functions instead of re-implementing queries) 
3. Moving some methods to the service layer (both because they belong there and because I was getting circular import errors from keeping them in the crud) 
    * `get_dataset_feature_labels_by_id`
    * `get_dataset_sample_labels_by_id`
    * `test_get_dataset_feature_by_label`
    * `test_get_dataset_sample_by_label`
    * `get_subsetted_matrix_dataset_df`


**Part 2** will be replacing some other duplicate crud functions with calls to these new more-reusable methods (I'm guessing this second part shouldn't impact any of Jessica's work)