### PR TITLE
feat(breadbox): Get dimension identifiers

### DIFF
--- a/breadbox-client/breadbox_client/api/types/get_dimension_type_identifiers.py
+++ b/breadbox-client/breadbox_client/api/types/get_dimension_type_identifiers.py
@@ -1,0 +1,220 @@
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
+from ... import errors
+from ...client import AuthenticatedClient, Client
+from ...models.dimension_identifiers import DimensionIdentifiers
+from ...models.http_error import HTTPError
+from ...models.http_validation_error import HTTPValidationError
+from ...types import UNSET, Response, Unset
+
+
+def _get_kwargs(
+    name: str,
+    *,
+    data_type: Union[None, Unset, str] = UNSET,
+    show_only_dimensions_in_datasets: Union[Unset, bool] = False,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {}
+
+    json_data_type: Union[None, Unset, str]
+    if isinstance(data_type, Unset):
+        json_data_type = UNSET
+    else:
+        json_data_type = data_type
+    params["data_type"] = json_data_type
+
+    params["show_only_dimensions_in_datasets"] = show_only_dimensions_in_datasets
+
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    _kwargs: Dict[str, Any] = {
+        "method": "get",
+        "url": "/types/dimensions/{name}/identifiers".format(
+            name=name,
+        ),
+        "params": params,
+    }
+
+    return _kwargs
+
+
+def _parse_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Optional[Union[HTTPError, HTTPValidationError, List["DimensionIdentifiers"]]]:
+    if response.status_code == HTTPStatus.OK:
+        response_200 = []
+        _response_200 = response.json()
+        for response_200_item_data in _response_200:
+            response_200_item = DimensionIdentifiers.from_dict(response_200_item_data)
+
+            response_200.append(response_200_item)
+
+        return response_200
+    if response.status_code == HTTPStatus.BAD_REQUEST:
+        response_400 = HTTPError.from_dict(response.json())
+
+        return response_400
+    if response.status_code == HTTPStatus.FORBIDDEN:
+        response_403 = HTTPError.from_dict(response.json())
+
+        return response_403
+    if response.status_code == HTTPStatus.NOT_FOUND:
+        response_404 = HTTPError.from_dict(response.json())
+
+        return response_404
+    if response.status_code == HTTPStatus.CONFLICT:
+        response_409 = HTTPError.from_dict(response.json())
+
+        return response_409
+    if response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY:
+        response_422 = HTTPValidationError.from_dict(response.json())
+
+        return response_422
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(
+    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
+) -> Response[Union[HTTPError, HTTPValidationError, List["DimensionIdentifiers"]]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    data_type: Union[None, Unset, str] = UNSET,
+    show_only_dimensions_in_datasets: Union[Unset, bool] = False,
+) -> Response[Union[HTTPError, HTTPValidationError, List["DimensionIdentifiers"]]]:
+    """Get Dimension Type Identifiers
+
+    Args:
+        name (str):
+        data_type (Union[None, Unset, str]):
+        show_only_dimensions_in_datasets (Union[Unset, bool]):  Default: False.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPError, HTTPValidationError, List['DimensionIdentifiers']]]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+        data_type=data_type,
+        show_only_dimensions_in_datasets=show_only_dimensions_in_datasets,
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+
+def sync(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    data_type: Union[None, Unset, str] = UNSET,
+    show_only_dimensions_in_datasets: Union[Unset, bool] = False,
+) -> Optional[Union[HTTPError, HTTPValidationError, List["DimensionIdentifiers"]]]:
+    """Get Dimension Type Identifiers
+
+    Args:
+        name (str):
+        data_type (Union[None, Unset, str]):
+        show_only_dimensions_in_datasets (Union[Unset, bool]):  Default: False.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPError, HTTPValidationError, List['DimensionIdentifiers']]
+    """
+
+    return sync_detailed(
+        name=name,
+        client=client,
+        data_type=data_type,
+        show_only_dimensions_in_datasets=show_only_dimensions_in_datasets,
+    ).parsed
+
+
+async def asyncio_detailed(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    data_type: Union[None, Unset, str] = UNSET,
+    show_only_dimensions_in_datasets: Union[Unset, bool] = False,
+) -> Response[Union[HTTPError, HTTPValidationError, List["DimensionIdentifiers"]]]:
+    """Get Dimension Type Identifiers
+
+    Args:
+        name (str):
+        data_type (Union[None, Unset, str]):
+        show_only_dimensions_in_datasets (Union[Unset, bool]):  Default: False.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[HTTPError, HTTPValidationError, List['DimensionIdentifiers']]]
+    """
+
+    kwargs = _get_kwargs(
+        name=name,
+        data_type=data_type,
+        show_only_dimensions_in_datasets=show_only_dimensions_in_datasets,
+    )
+
+    response = await client.get_async_httpx_client().request(**kwargs)
+
+    return _build_response(client=client, response=response)
+
+
+async def asyncio(
+    name: str,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    data_type: Union[None, Unset, str] = UNSET,
+    show_only_dimensions_in_datasets: Union[Unset, bool] = False,
+) -> Optional[Union[HTTPError, HTTPValidationError, List["DimensionIdentifiers"]]]:
+    """Get Dimension Type Identifiers
+
+    Args:
+        name (str):
+        data_type (Union[None, Unset, str]):
+        show_only_dimensions_in_datasets (Union[Unset, bool]):  Default: False.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[HTTPError, HTTPValidationError, List['DimensionIdentifiers']]
+    """
+
+    return (
+        await asyncio_detailed(
+            name=name,
+            client=client,
+            data_type=data_type,
+            show_only_dimensions_in_datasets=show_only_dimensions_in_datasets,
+        )
+    ).parsed

--- a/breadbox-client/breadbox_client/models/__init__.py
+++ b/breadbox-client/breadbox_client/models/__init__.py
@@ -31,6 +31,7 @@ from .data_type import DataType
 from .dataset_metadata import DatasetMetadata
 from .dataset_metadata_dataset_metadata import DatasetMetadataDatasetMetadata
 from .dimension_data_response import DimensionDataResponse
+from .dimension_identifiers import DimensionIdentifiers
 from .dimension_search_index_response import DimensionSearchIndexResponse
 from .dimension_search_index_response_matching_properties_item import (
     DimensionSearchIndexResponseMatchingPropertiesItem,
@@ -136,6 +137,7 @@ __all__ = (
     "DatasetMetadataDatasetMetadata",
     "DataType",
     "DimensionDataResponse",
+    "DimensionIdentifiers",
     "DimensionSearchIndexResponse",
     "DimensionSearchIndexResponseMatchingPropertiesItem",
     "DimensionType",

--- a/breadbox-client/breadbox_client/models/dimension_identifiers.py
+++ b/breadbox-client/breadbox_client/models/dimension_identifiers.py
@@ -1,0 +1,66 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+T = TypeVar("T", bound="DimensionIdentifiers")
+
+
+@_attrs_define
+class DimensionIdentifiers:
+    """
+    Attributes:
+        id (str):
+        label (str):
+    """
+
+    id: str
+    label: str
+    additional_properties: Dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        id = self.id
+
+        label = self.label
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update(
+            {
+                "id": id,
+                "label": label,
+            }
+        )
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        id = d.pop("id")
+
+        label = d.pop("label")
+
+        dimension_identifiers = cls(
+            id=id,
+            label=label,
+        )
+
+        dimension_identifiers.additional_properties = d
+        return dimension_identifiers
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/breadbox-client/latest-breadbox-api.json
+++ b/breadbox-client/latest-breadbox-api.json
@@ -910,6 +910,24 @@
         "title": "DimensionDataResponse",
         "type": "object"
       },
+      "DimensionIdentifiers": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "label"
+        ],
+        "title": "DimensionIdentifiers",
+        "type": "object"
+      },
       "DimensionSearchIndexResponse": {
         "properties": {
           "id": {
@@ -2779,7 +2797,7 @@
   },
   "info": {
     "title": "Breadbox",
-    "version": "3.14.0"
+    "version": "3.13.0"
   },
   "openapi": "3.1.0",
   "paths": {
@@ -6655,6 +6673,118 @@
           }
         },
         "summary": "Update Dimension Type Endpoint",
+        "tags": [
+          "types"
+        ]
+      }
+    },
+    "/types/dimensions/{name}/identifiers": {
+      "get": {
+        "operationId": "get_dimension_type_identifiers",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "title": "Name",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "data_type",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Data Type"
+            }
+          },
+          {
+            "in": "query",
+            "name": "show_only_dimensions_in_datasets",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Show Only Dimensions In Datasets",
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/DimensionIdentifiers"
+                  },
+                  "title": "Response Get Dimension Type Identifiers",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPError"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPError"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPError"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPError"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Dimension Type Identifiers",
         "tags": [
           "types"
         ]

--- a/breadbox/breadbox/api/types.py
+++ b/breadbox/breadbox/api/types.py
@@ -603,21 +603,16 @@ def list_dimension_types_endpoint(db: SessionWithUser = Depends(get_db_with_user
 def get_dimension_type_identifiers(
     name: str,
     data_type: Annotated[Union[str, None], Query()] = None,
-    show_only_dimensions_in_datasets: Annotated[Union[bool, None], Query()] = None,
+    show_only_dimensions_in_datasets: Annotated[bool, Query()] = False,
     db: SessionWithUser = Depends(get_db_with_user),
 ):
     dim_type = type_crud.get_dimension_type(db, name)
     if dim_type is None:
         raise HTTPException(404, f"Dimension type {name} not found")
 
-    if show_only_dimensions_in_datasets is True:
-        dimension_ids_and_labels = metadata_service.get_dimension_type_identifiers(
-            db, dim_type, data_type, show_only_dimensions_in_datasets=True
-        )
-    else:
-        dimension_ids_and_labels = metadata_service.get_dimension_type_identifiers(
-            db, dim_type, data_type
-        )
+    dimension_ids_and_labels = metadata_service.get_dimension_type_identifiers(
+        db, dim_type, data_type, show_only_dimensions_in_datasets
+    )
 
     return [
         DimensionIdentifiers(id=id, label=label)

--- a/breadbox/breadbox/api/types.py
+++ b/breadbox/breadbox/api/types.py
@@ -24,7 +24,12 @@ from ..io.data_validation import validate_dimension_type_metadata
 from ..schemas.custom_http_exception import UserError, ResourceNotFoundError
 from breadbox.models.dataset import AnnotationType
 import breadbox.crud.dataset as dataset_crud
-from breadbox.schemas.types import DimensionType, UpdateDimensionType, AddDimensionType
+from breadbox.schemas.types import (
+    DimensionType,
+    UpdateDimensionType,
+    AddDimensionType,
+    DimensionIdentifiers,
+)
 from .settings import assert_is_admin_user
 from breadbox.db.util import transaction
 
@@ -578,6 +583,19 @@ def get_dimension_type_endpoint(
 def list_dimension_types_endpoint(db: SessionWithUser = Depends(get_db_with_user),):
     dim_types = type_crud.get_dimension_types(db)
     return [_dim_type_to_response(x) for x in dim_types]
+
+
+@router.get(
+    "/dimensions/{name}/identifiers", operation_id="get_dimension_type_identifiers"
+)
+def get_dimension_type_identifiers(
+    name: str, db: SessionWithUser = Depends(get_db_with_user)
+):
+    dim_type_ids_and_labels = type_crud.get_dimension_type_labels_by_id(db, name)
+    return [
+        DimensionIdentifiers(id=id, label=label)
+        for id, label in dim_type_ids_and_labels.items()
+    ]
 
 
 @router.patch(

--- a/breadbox/breadbox/api/types.py
+++ b/breadbox/breadbox/api/types.py
@@ -689,7 +689,7 @@ def delete_dimension_type_endpoint(
 
     # don't count datasets which are actually the metadata for this type
     datasets_with_using_type = [
-        x for x in datasets_with_using_type if x.id == dim_feature_type.dataset_id
+        x for x in datasets_with_using_type if x.id != dim_feature_type.dataset_id
     ]
 
     num_datasets = len(datasets_with_using_type)

--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -1,7 +1,7 @@
 import logging
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, List, Type, Union, Tuple
+from typing import Any, Dict, Optional, List, Type, Union, Tuple, Set
 from uuid import UUID, uuid4
 import warnings
 import json
@@ -1539,7 +1539,10 @@ def get_missing_tabular_columns_and_indices(
 
 def get_unique_dimension_ids_from_datasets(
     db: SessionWithUser, dataset_ids: List[str], dimension_type: DimensionType
-):
+) -> Set[str]:
+    """
+    Returns a unique set of dimension given ids from matrix and tabular datasets based on the given dimension type
+    """
     if dimension_type.axis == "feature":
         matrix_dimension_class = DatasetFeature
     else:
@@ -1547,6 +1550,7 @@ def get_unique_dimension_ids_from_datasets(
 
     unique_dims = set()
 
+    # Get all matrix dimensions for that dimension type
     matrix_dimensions = (
         db.query(matrix_dimension_class)
         .filter(
@@ -1557,7 +1561,7 @@ def get_unique_dimension_ids_from_datasets(
         )
         .all()
     )
-
+    # Get all tabular identifiers for that dimension type
     tabular_dimension_ids = (
         db.query(TabularCell)
         .join(TabularColumn)
@@ -1570,7 +1574,7 @@ def get_unique_dimension_ids_from_datasets(
         )
         .all()
     )
-
+    # Combine dimension type's dimension given ids from datasets
     for m_dim in matrix_dimensions:
         unique_dims.add(m_dim.given_id)
 

--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -88,7 +88,7 @@ def get_datasets(
     sample_id: Optional[str] = None,
     sample_type: Optional[str] = None,
     value_type: Optional[ValueType] = None,
-    data_type: str = None,
+    data_type: Optional[str] = None,
 ) -> list[Dataset]:
     assert (
         db.user == user

--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -116,12 +116,21 @@ def get_datasets(
     # Decide if should return for metadata when given feature id/type or sample id/type
     # TODO: feature type can be none. How should we filter those datasets?
     if feature_type is not None:
-        filter_clauses.append(
-            or_(
-                dataset_poly.MatrixDataset.feature_type_name == feature_type,
-                dataset_poly.TabularDataset.index_type_name == feature_type,
-            )
+        # Make sure that the `feature_type` dimension type is actually in the feature axis so tabular datasets are correctly filtered
+        feature_dimension_type = (
+            db.query(DimensionType).filter_by(name=feature_type).one_or_none()
         )
+        if feature_dimension_type and feature_dimension_type.axis == "feature":
+            filter_clauses.append(
+                or_(
+                    dataset_poly.MatrixDataset.feature_type_name == feature_type,
+                    dataset_poly.TabularDataset.index_type_name == feature_type,
+                )
+            )
+        else:
+            filter_clauses.append(
+                dataset_poly.MatrixDataset.feature_type_name == feature_type
+            )
 
         if feature_id is not None:
             dataset_ids = [
@@ -133,12 +142,21 @@ def get_datasets(
             filter_clauses.append(dataset_poly.MatrixDataset.id.in_(dataset_ids))
 
     if sample_type is not None:
-        filter_clauses.append(
-            or_(
-                dataset_poly.MatrixDataset.sample_type_name == sample_type,
-                dataset_poly.TabularDataset.index_type_name == sample_type,
-            )
+        # Make sure that the `sample_type` dimension type is actually in the sample axis so tabular datasets are correctly filtered
+        sample_dimension_type = (
+            db.query(DimensionType).filter_by(name=sample_type).one_or_none()
         )
+        if sample_dimension_type and sample_dimension_type.axis == "sample":
+            filter_clauses.append(
+                or_(
+                    dataset_poly.MatrixDataset.sample_type_name == sample_type,
+                    dataset_poly.TabularDataset.index_type_name == sample_type,
+                )
+            )
+        else:
+            filter_clauses.append(
+                dataset_poly.MatrixDataset.sample_type_name == sample_type
+            )
 
         if sample_id is not None:
             dataset_ids = [

--- a/breadbox/breadbox/schemas/types.py
+++ b/breadbox/breadbox/schemas/types.py
@@ -9,6 +9,11 @@ from pydantic_settings import SettingsConfigDict
 from typing import List, Optional, Dict, Annotated
 
 
+class DimensionIdentifiers(BaseModel):
+    id: str
+    label: str
+
+
 class IdAndName(BaseModel):
     id: str
     name: str

--- a/breadbox/breadbox/service/metadata.py
+++ b/breadbox/breadbox/service/metadata.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any
+from typing import Any, Optional
 
 from breadbox.crud import dataset as dataset_crud
 from breadbox.crud import types as types_crud
@@ -10,6 +10,7 @@ from breadbox.models.dataset import (
     DatasetSample,
     MatrixDataset,
     TabularDataset,
+    DimensionType,
 )
 
 from depmap_compute.slice import SliceQuery
@@ -203,3 +204,46 @@ def get_dataset_sample_by_label(
         )
 
     return dataset_crud.get_dataset_sample_by_given_id(db, dataset_id, sample_given_id)
+
+
+def get_dimension_type_identifiers(
+    db: SessionWithUser,
+    dimension_type: DimensionType,
+    data_type: Optional[str] = None,
+    show_only_dimensions_in_datasets: Optional[bool] = False,
+):
+    """
+    For the given dimension type,
+    1. Get datasets by dimension type and optionally data type
+    2. Get unique dimensions from above list of filtered datasets
+    If the `data_type` is given and/or `show_only_dimensions_in_datasets` is True, the dimension identifiers that are returned will only be those that are used within a dataset.
+    Additionally, the dimension identifiers returned will be from datasets that the user has access to.
+    Otherwise, if neither `data_type` is given nor `show_only_dimensions_in_datasets` is True, all dimension identifiers from the given dimension type are returned.
+    """
+    # Get all dimension identifiers in a dimension type
+    dim_type_ids_and_labels = types_crud.get_dimension_type_labels_by_id(
+        db, dimension_type.name
+    )
+
+    if data_type is None and not show_only_dimensions_in_datasets:
+        return dim_type_ids_and_labels
+
+    # Note that this also only returns datasets the user has access to as well
+    filtered_datasets = dataset_crud.get_datasets(
+        db,
+        db.user,
+        feature_type=dimension_type.name if dimension_type.axis == "feature" else None,
+        sample_type=dimension_type.name if dimension_type.axis == "sample" else None,
+        data_type=data_type,
+    )
+    filtered_dataset_ids = [dataset.id for dataset in filtered_datasets]
+    # Get all dimension given ids from list of filtered datasets
+    unique_dimension_given_ids = dataset_crud.get_unique_dimension_ids_from_datasets(
+        db, filtered_dataset_ids, dimension_type
+    )
+
+    # Further filters only dimensions that have identifiers that exist in the metadata
+    return {
+        given_id: dim_type_ids_and_labels[given_id]
+        for given_id in unique_dimension_given_ids
+    }

--- a/breadbox/breadbox/service/metadata.py
+++ b/breadbox/breadbox/service/metadata.py
@@ -217,6 +217,7 @@ def get_dimension_type_identifiers(
     1. Get datasets by dimension type and optionally data type
     2. Get unique dimensions from above list of filtered datasets
     If the `data_type` is given and/or `show_only_dimensions_in_datasets` is True, the dimension identifiers that are returned will only be those that are used within a dataset.
+    If `show_only_dimensions_in_datasets` is True, dimension identifiers within datasets, excluding the dimension type metadata, are returned
     Additionally, the dimension identifiers returned will be from datasets that the user has access to.
     Otherwise, if neither `data_type` is given nor `show_only_dimensions_in_datasets` is True, all dimension identifiers from the given dimension type are returned.
     """
@@ -236,7 +237,14 @@ def get_dimension_type_identifiers(
         sample_type=dimension_type.name if dimension_type.axis == "sample" else None,
         data_type=data_type,
     )
-    filtered_dataset_ids = [dataset.id for dataset in filtered_datasets]
+    # Additionally filter out metadata dataset if show_only_dimensions_in_datasets is True
+    filtered_dataset_ids = []
+    for dataset in filtered_datasets:
+        if show_only_dimensions_in_datasets:
+            if dataset.id != dimension_type.dataset_id:
+                filtered_dataset_ids.append(dataset.id)
+        else:
+            filtered_dataset_ids.append(dataset.id)
     # Get all dimension given ids from list of filtered datasets
     unique_dimension_given_ids = dataset_crud.get_unique_dimension_ids_from_datasets(
         db, filtered_dataset_ids, dimension_type
@@ -246,4 +254,5 @@ def get_dimension_type_identifiers(
     return {
         given_id: dim_type_ids_and_labels[given_id]
         for given_id in unique_dimension_given_ids
+        if given_id in dim_type_ids_and_labels
     }

--- a/breadbox/tests/api/test_types.py
+++ b/breadbox/tests/api/test_types.py
@@ -327,7 +327,7 @@ def test_add_sample_types(client: TestClient, settings, minimal_db):
     assert_status_ok(response)
 
 
-def test_get_dimension_type_dimension_identifiers(
+def test_get_all_dimension_type_dimension_identifiers(
     client: TestClient, minimal_db, settings
 ):
     db = minimal_db
@@ -397,6 +397,13 @@ def test_get_dimension_type_dimension_identifiers(
         {"id": "sample-1", "label": "Sample 1"},
         {"id": "sample-2", "label": "Sample 2"},
     ]
+
+    # test dim type doesn't exist
+    nonexistent_dim_type_res = client.get(
+        f"types/dimensions/nonexistentDimensionType/identifiers", headers=admin_headers,
+    )
+    assert_status_not_ok(nonexistent_dim_type_res)
+    assert nonexistent_dim_type_res.status_code == 404
 
 
 #### /types/sample and types/feature endpoints are deprecated!! ###

--- a/breadbox/tests/api/test_types.py
+++ b/breadbox/tests/api/test_types.py
@@ -364,9 +364,14 @@ def test_get_dimension_type_dimension_identifiers(
         "/types/dimensions", json=dim_type_fields, headers=admin_headers,
     )
     assert_status_ok(dim_type_res)
-    expected_dim_type_res = dim_type_fields.copy()
-    expected_dim_type_res["properties_to_index"] = []
-    expected_dim_type_res["metadata_dataset_id"] = None
+    expected_dim_type_res = {
+        "name": "sample_id_name",
+        "display_name": "Sample Name",
+        "axis": "sample",
+        "id_column": "sample_id",
+        "properties_to_index": [],
+        "metadata_dataset_id": None,
+    }
     assert dim_type_res.json() == expected_dim_type_res
 
     # Confirm dimension type has no dimension identifiers

--- a/breadbox/tests/crud/test_dataset.py
+++ b/breadbox/tests/crud/test_dataset.py
@@ -233,6 +233,22 @@ def test_get_datasets_by_dimension_types(minimal_db, settings):
             tabular_dataset_with_sample_type.id,
         ]
 
+    # test filter both feature and sample type
+    datasets_with_sample_and_feature_type = get_datasets(
+        minimal_db,
+        minimal_db.user,
+        feature_type="some_feature_type",
+        sample_type="depmap_model",
+    )
+    assert len(datasets_with_sample_and_feature_type) == 1
+    assert datasets_with_sample_and_feature_type[0].id == matrix_dataset_2.id
+
+    # test that when filtering a dimension type by the wrong axis, the datasets won't get returned
+    datasets_with_feature_type_as_sample_type = get_datasets(
+        minimal_db, minimal_db.user, sample_type="some_feature_type"
+    )
+    assert len(datasets_with_feature_type_as_sample_type) == 0
+
 
 def test_get_datasets_by_data_type(minimal_db, settings):
     factories.data_type(minimal_db, "Data Type 1")

--- a/breadbox/tests/crud/test_dataset.py
+++ b/breadbox/tests/crud/test_dataset.py
@@ -6,6 +6,7 @@ from breadbox.crud.dataset import (
     get_dataset,
     get_dataset_feature_by_given_id,
     get_tabular_dataset_index_given_ids,
+    get_datasets,
 )
 from breadbox.models.dataset import AnnotationType
 from breadbox.schemas.dataset import ColumnMetadata
@@ -128,3 +129,151 @@ def test_get_tabular_dataset_index_given_ids(minimal_db, settings):
         minimal_db, dimension_type.dataset
     )
     assert metadata_result == ["1", "2", "5"]
+
+
+def test_get_datasets_by_dimension_types(minimal_db, settings):
+    """
+    Test that this function works for tabular datasets and matrix datasets filtering by dimension type
+    """
+    # Define metadata
+    dimension_type = factories.add_dimension_type(
+        minimal_db,
+        settings,
+        user=settings.admin_users[0],
+        name="some_feature_type",
+        display_name="Feature With Metadata",
+        id_column="ID",
+        annotation_type_mapping={
+            "ID": AnnotationType.text,
+            "label": AnnotationType.text,
+        },
+        axis="feature",
+        metadata_df=pd.DataFrame(
+            {
+                "ID": ["1", "2", "5"],
+                "label": ["featureLabel1", "featureLabel2", "featureLabel3"],
+            }
+        ),
+    )
+    # Define tabular datasets
+    tabular_dataset_with_feature_type = factories.tabular_dataset(
+        minimal_db,
+        settings,
+        data_df=pd.DataFrame(
+            {"ID": ["1", "2", "3", "4"], "SomeOtherColumn": ["a", "b", "c", "d"]}
+        ),
+        index_type_name="some_feature_type",
+        columns_metadata={
+            "ID": ColumnMetadata(col_type=AnnotationType.text),
+            "SomeOtherColumn": ColumnMetadata(col_type=AnnotationType.text),
+        },
+    )
+    tabular_dataset_with_sample_type = factories.tabular_dataset(
+        minimal_db,
+        settings,
+        data_df=pd.DataFrame(
+            {
+                "depmap_id": ["sampleID1", "sampleID2", "sampleID3", "sampleID4"],
+                "SomeOtherColumn": ["a", "b", "c", "d"],
+            }
+        ),
+        index_type_name="depmap_model",
+        columns_metadata={
+            "depmap_id": ColumnMetadata(col_type=AnnotationType.text),
+            "SomeOtherColumn": ColumnMetadata(col_type=AnnotationType.text),
+        },
+    )
+    # Example matrix values with IDs corresponding to above feature type
+    example_matrix_values = factories.matrix_csv_data_file_with_values(
+        feature_ids=["1", "2", "3"],
+        sample_ids=["sampleID1", "sampleID2", "sampleID3"],
+        values=np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+    )
+    # Example matrix with no feature type
+    matrix_dataset_1 = factories.matrix_dataset(
+        minimal_db, settings, feature_type=None, data_file=example_matrix_values,
+    )
+
+    # Just copy the matrix values file without needing to reset pointer
+    example_matrix_values = factories.matrix_csv_data_file_with_values(
+        feature_ids=["1", "2", "3"],
+        sample_ids=["sampleID1", "sampleID2", "sampleID3"],
+        values=np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+    )
+    # Example matrix with feature type
+    matrix_dataset_2 = factories.matrix_dataset(
+        minimal_db,
+        settings,
+        feature_type="some_feature_type",
+        data_file=example_matrix_values,
+    )
+    # Test that tabular and matrix datasets returned for filtering by feature type
+    datasets_with_feature_type = get_datasets(
+        minimal_db, minimal_db.user, feature_type="some_feature_type"
+    )
+    assert len(datasets_with_feature_type) == 3
+    for dataset in datasets_with_feature_type:
+        assert dataset.id in [
+            dimension_type.dataset_id,
+            matrix_dataset_2.id,
+            tabular_dataset_with_feature_type.id,
+        ]
+
+    # Test that tabular and matrix datasets returned for filtering by sample type
+    datasets_with_sample_type = get_datasets(
+        minimal_db, minimal_db.user, sample_type="depmap_model"
+    )
+
+    assert len(datasets_with_sample_type) == 3
+    for dataset in datasets_with_sample_type:
+        assert dataset.id in [
+            matrix_dataset_1.id,
+            matrix_dataset_2.id,
+            tabular_dataset_with_sample_type.id,
+        ]
+
+
+def test_get_datasets_by_data_type(minimal_db, settings):
+    factories.data_type(minimal_db, "Data Type 1")
+    factories.data_type(minimal_db, "Data Type 2")
+    tabular_dataset = factories.tabular_dataset(
+        minimal_db,
+        settings,
+        data_df=pd.DataFrame(
+            {
+                "depmap_id": ["sampleID1", "sampleID2", "sampleID3", "sampleID4"],
+                "SomeOtherColumn": ["a", "b", "c", "d"],
+            }
+        ),
+        index_type_name="depmap_model",
+        columns_metadata={
+            "depmap_id": ColumnMetadata(col_type=AnnotationType.text),
+            "SomeOtherColumn": ColumnMetadata(col_type=AnnotationType.text),
+        },
+        data_type_="Data Type 1",
+    )
+    # Example matrix values with IDs corresponding to above feature type
+    example_matrix_values = factories.matrix_csv_data_file_with_values(
+        feature_ids=["1", "2", "3"],
+        sample_ids=["sampleID1", "sampleID2", "sampleID3"],
+        values=np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]]),
+    )
+    # Example matrix with no feature type
+    matrix_dataset = factories.matrix_dataset(
+        minimal_db,
+        settings,
+        feature_type=None,
+        data_file=example_matrix_values,
+        data_type="Data Type 2",
+    )
+    datasets_with_data_type_1 = get_datasets(
+        minimal_db, minimal_db.user, data_type="Data Type 1"
+    )
+    assert len(datasets_with_data_type_1) == 1
+    assert datasets_with_data_type_1[0].id == tabular_dataset.id
+
+    datasets_with_data_type_2 = get_datasets(
+        minimal_db, minimal_db.user, data_type="Data Type 2"
+    )
+    assert len(datasets_with_data_type_2) == 1
+    assert datasets_with_data_type_2[0].id == matrix_dataset.id


### PR DESCRIPTION
New endpoint as outlined in [proposal](https://docs.google.com/document/d/1vskDzpcl37hFELp-_fh8Af9PiJjeJO6tleK9cLQb5PM/edit?pli=1&tab=t.0)

@snwessel I considered using your new metadata lookup methods but decided against it bc I figured the performance for looking up each individual dataset would be far worse than a method that looks up the label metadata for multiple datasets in a single query

NOTE: This implementation makes changes to the crud function `get_datasets`. This appeared to have broken an existing test however and I'm looking into it
TBD: Write more comprehensive test for new endpoint