### PR TITLE
allow contexts to be persisted in Elara

### DIFF
--- a/frontend/packages/@depmap/cell-line-selector/src/components/CellLineListsDropdown.tsx
+++ b/frontend/packages/@depmap/cell-line-selector/src/components/CellLineListsDropdown.tsx
@@ -4,6 +4,7 @@ import {
   fetchContextLabels,
   fetchContext,
   isNegatedContext,
+  isV2Context,
   negateContext,
   persistLegacyListAsContext,
   PlotConfigSelect,
@@ -86,6 +87,10 @@ const ContextEnabledDropdown = ({
         const hashWithoutPrefix = selectedContextHash.replace("not_", "");
         try {
           const context = await fetchContext(hashWithoutPrefix);
+
+          if (isV2Context(context)) {
+            throw new Error("V2 contexts not supported!");
+          }
 
           handleChange(
             selectedContextHash.startsWith("not_")

--- a/frontend/packages/@depmap/data-explorer-2/index.ts
+++ b/frontend/packages/@depmap/data-explorer-2/index.ts
@@ -50,8 +50,9 @@ export {
   initializeDevContexts,
   isContextAll,
   isNegatedContext,
+  isV2Context,
   negateContext,
-  saveContextToLocalStorage,
+  saveContextToLocalStorageAndPersist,
 } from "./src/utils/context";
 
 export {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderModal.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderModal.tsx
@@ -11,6 +11,7 @@ interface Props {
   backdrop: "static" | boolean;
   context: { dimension_type: string } | DataExplorerContextV2;
   isExistingContext: boolean;
+  onClickSave: (newContext: DataExplorerContextV2) => void;
   onHide: () => void;
   show: boolean;
 }
@@ -19,16 +20,14 @@ function ContextBuilderModal({
   backdrop,
   context,
   isExistingContext,
+  onClickSave,
   onHide,
   show,
 }: Props) {
   return (
     <ContextBuilderStateProvider
       contextToEdit={context}
-      onChangeContext={(nextContext) => {
-        const json = JSON.stringify(nextContext, null, 2);
-        window.alert(`TODO: Save context\n${json}`);
-      }}
+      onChangeContext={onClickSave}
     >
       <Modal
         className={styles.ContextBuilder}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/index.tsx
@@ -19,8 +19,6 @@ interface Props {
 function ContextBuilderV2({
   show,
   context,
-  // FIXME
-  // eslint-disable-next-line
   onClickSave,
   onHide,
   backdrop = "static",
@@ -43,6 +41,7 @@ function ContextBuilderV2({
     <ContextBuilderModal
       key={`${show}`}
       show={show}
+      onClickSave={onClickSave}
       onHide={onHide}
       backdrop={backdrop}
       context={contextToEdit}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextManager/DownloadContextModal.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextManager/DownloadContextModal.tsx
@@ -6,8 +6,8 @@ import {
   fetchContext,
   fetchMetadataColumn,
 } from "../../api";
-
 import { getDimensionTypeLabel, pluralize } from "../../utils/misc";
+import { isV2Context } from "../../utils/context";
 import styles from "../../styles/ContextManager.scss";
 
 interface Props {
@@ -32,7 +32,13 @@ function DownloadContextModal({
 
   // Pre-fetch the context so it downloads faster (these requests are cached).
   useEffect(() => {
-    fetchContext(contextHash).then(fetchContextLabels);
+    fetchContext(contextHash).then((context) => {
+      if (isV2Context(context)) {
+        throw new Error("V2 contexts not supported!");
+      }
+
+      return fetchContextLabels(context);
+    });
   }, [contextHash]);
 
   const handleClickDownload = () => {
@@ -42,7 +48,13 @@ function DownloadContextModal({
     }
 
     fetchContext(contextHash)
-      .then(fetchContextLabels)
+      .then((context) => {
+        if (isV2Context(context)) {
+          throw new Error("V2 contexts not supported!");
+        }
+
+        return fetchContextLabels(context);
+      })
       .then(async (contextLabels) => {
         let labels = contextLabels;
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextManager/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextManager/index.tsx
@@ -10,7 +10,7 @@ import ContextBuilderV2 from "../ContextBuilderV2";
 import {
   deleteContextFromLocalStorage,
   loadContextsFromLocalStorage,
-  saveContextToLocalStorage,
+  saveContextToLocalStorageAndPersist,
 } from "../../utils/context";
 import { persistLegacyListAsContext } from "../ContextSelector/context-selector-utils";
 import Welcome from "./Welcome";
@@ -78,7 +78,10 @@ function ContextManager({
 
     onClickSave.current = async (editedContext: DataExplorerContext) => {
       try {
-        const nextHash = await saveContextToLocalStorage(editedContext, hash);
+        const nextHash = await saveContextToLocalStorageAndPersist(
+          editedContext,
+          hash
+        );
         setShowContextModal(false);
         window.dispatchEvent(new Event("dx2_contexts_updated"));
 
@@ -139,7 +142,7 @@ function ContextManager({
       name: `Copy of ${context.name}`,
     };
 
-    await saveContextToLocalStorage(duplicateContext);
+    await saveContextToLocalStorageAndPersist(duplicateContext);
     window.dispatchEvent(new Event("dx2_contexts_updated"));
     forceRender({});
 
@@ -174,7 +177,7 @@ function ContextManager({
           return null;
         }
 
-        return saveContextToLocalStorage({
+        return saveContextToLocalStorageAndPersist({
           name: contextName,
           context_type: "depmap_model",
           expr: {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextSelector/context-selector-utils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextSelector/context-selector-utils.ts
@@ -6,6 +6,7 @@ import { fetchContext, fetchDimensionLabels, persistContext } from "../../api";
 import {
   isContextAll,
   isNegatedContext,
+  isV2Context,
   negateContext,
 } from "../../utils/context";
 import getContextHash from "../../utils/get-context-hash";
@@ -166,7 +167,13 @@ export const makeChangeHandler = (
           hashToFetch
         );
       } else {
-        context = await fetchContext(hashToFetch);
+        const fetchedContext = await fetchContext(hashToFetch);
+
+        if (isV2Context(fetchedContext)) {
+          throw new Error("V2 contexts not supported!");
+        }
+
+        context = fetchedContext;
       }
 
       if (negate && context) {

--- a/frontend/packages/@depmap/data-explorer-2/src/utils/context.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/context.ts
@@ -85,14 +85,25 @@ export function loadContextsFromLocalStorage(context_type: string) {
   return out;
 }
 
-const stripExprFromContext = (context: DataExplorerContext) => {
-  const { expr, ...rest } = context;
-  return rest;
+export function isV2Context(
+  context: DataExplorerContext | DataExplorerContextV2
+): context is DataExplorerContextV2 {
+  return "dimension_type" in context;
+}
+
+const toStoredContext = (
+  context: DataExplorerContext | DataExplorerContextV2
+): StoredContexts[string] => {
+  return {
+    name: context.name,
+    context_type: isV2Context(context)
+      ? context.dimension_type
+      : context.context_type,
+  };
 };
 
-// TODO: Rename this to communicate that it also persists it to a bucket.
-export async function saveContextToLocalStorage(
-  context: DataExplorerContext,
+export async function saveContextToLocalStorageAndPersist(
+  context: DataExplorerContext | DataExplorerContextV2,
   hashToReplace?: string | null
 ) {
   let nextHash;
@@ -106,7 +117,7 @@ export async function saveContextToLocalStorage(
 
         return {
           hash: nextHash,
-          value: stripExprFromContext(context),
+          value: toStoredContext(context),
         };
       }
 
@@ -119,7 +130,7 @@ export async function saveContextToLocalStorage(
 
     updates.push({
       hash: nextHash,
-      value: stripExprFromContext(context),
+      value: toStoredContext(context),
     });
   }
 

--- a/frontend/packages/@depmap/data-explorer-2/src/utils/get-context-hash.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/get-context-hash.ts
@@ -1,10 +1,12 @@
 import { Base64 } from "js-base64";
 import stableStringify from "json-stable-stringify";
-import { DataExplorerContext } from "@depmap/types";
+import { DataExplorerContext, DataExplorerContextV2 } from "@depmap/types";
 
 // This function needed to live in its own file to avoid a dependency cycle
 // ¯\_(ツ)_/¯
-export default async function getContextHash(context: DataExplorerContext) {
+export default async function getContextHash(
+  context: DataExplorerContext | DataExplorerContextV2
+) {
   const json = stableStringify(context);
   const encoded = new TextEncoder().encode(json);
   const buffer = await crypto.subtle.digest("SHA-256", encoded);

--- a/frontend/packages/elara-frontend/webpack.common.js
+++ b/frontend/packages/elara-frontend/webpack.common.js
@@ -30,6 +30,7 @@ module.exports = {
         linear_association: false,
         use_taiga_urls: false,
         precomputed_associations: false,
+        elara: true,
       }),
       "window.depmapContactUrl": JSON.stringify(
         "mailto:dmc-questions@broadinstitute.org"

--- a/frontend/packages/portal-frontend/src/data-explorer-2/components/StandaloneContextEditor.tsx
+++ b/frontend/packages/portal-frontend/src/data-explorer-2/components/StandaloneContextEditor.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ApiContext } from "@depmap/api";
 import {
   ContextBuilderModal,
-  saveContextToLocalStorage,
+  saveContextToLocalStorageAndPersist,
 } from "@depmap/data-explorer-2";
 import { DataExplorerContext } from "@depmap/types";
 import {
@@ -38,7 +38,10 @@ function StandaloneContextEditor({
   }
 
   const onClickSave = async (editedContext: DataExplorerContext) => {
-    const nextHash = await saveContextToLocalStorage(editedContext, hash);
+    const nextHash = await saveContextToLocalStorageAndPersist(
+      editedContext,
+      hash
+    );
     onSave(editedContext, nextHash);
     onHide();
 

--- a/frontend/packages/portal-frontend/src/data-explorer-2/hooks/useContextBuilder.tsx
+++ b/frontend/packages/portal-frontend/src/data-explorer-2/hooks/useContextBuilder.tsx
@@ -3,7 +3,7 @@ import { ApiContext } from "@depmap/api";
 import {
   ContextBuilderModal,
   negateContext,
-  saveContextToLocalStorage,
+  saveContextToLocalStorageAndPersist,
 } from "@depmap/data-explorer-2";
 import {
   DataExplorerContext,
@@ -68,7 +68,7 @@ export default function useContextBuilder(
       };
     }
 
-    await saveContextToLocalStorage(context);
+    await saveContextToLocalStorageAndPersist(context);
     const queryString = await plotToQueryString(nextPlot);
 
     setShowContextModal(false);

--- a/frontend/packages/portal-frontend/src/data-explorer-2/utils.ts
+++ b/frontend/packages/portal-frontend/src/data-explorer-2/utils.ts
@@ -11,6 +11,7 @@ import {
   isContextAll,
   isNegatedContext,
   isPartialSliceId,
+  isV2Context,
   negateContext,
   persistContext,
 } from "@depmap/data-explorer-2";
@@ -392,6 +393,10 @@ async function replaceHashesWithContexts(plot: DataExplorerPlotConfig | null) {
         if ("hash" in dimension.context) {
           const context = await fetchContext(dimension.context.hash);
 
+          if (isV2Context(context)) {
+            throw new Error("V2 contexts not supported!");
+          }
+
           nextDimensions[dimensionKey] = {
             ...dimension,
             context: dimension.context.negated
@@ -419,6 +424,10 @@ async function replaceHashesWithContexts(plot: DataExplorerPlotConfig | null) {
 
         if ("hash" in filter) {
           const context = await fetchContext(filter.hash);
+
+          if (isV2Context(context)) {
+            throw new Error("V2 contexts not supported!");
+          }
 
           nextFilters[filterKey] = filter.negated
             ? negateContext(context)


### PR DESCRIPTION
This updates the Elara version of Context Manager to save contexts to Breadbox. It takes advantage of the new `/temp/cas` and `/temp/cas/{key}` endpoints Phil added in PR #127

The list of contexts for each user is still saved in local storage.