### PR TITLE
Add dataset manager simple mode

### DIFF
--- a/frontend/packages/@depmap/dataset-manager/src/components/DatasetForm.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/DatasetForm.tsx
@@ -18,49 +18,7 @@ import {
 } from "@depmap/types";
 import ChunkedFileUploader from "./ChunkedFileUploader";
 
-const initDatasetForm = (format: "table" | "matrix") => {
-  const initForm: { [key: string]: any } = {};
-  if (format === "matrix") {
-    Object.keys(matrixFormSchema.properties)
-      .concat("allowed_values")
-      .forEach((key) => {
-        if (
-          typeof matrixFormSchema.properties[key] === "object" &&
-          // @ts-ignore
-          "default" in matrixFormSchema.properties[key]
-        ) {
-          // @ts-ignore
-          initForm[key] = matrixFormSchema.properties[key].default;
-        } else {
-          initForm[key] = null;
-        }
-      });
-    return initForm;
-  }
-  if (format === "table") {
-    Object.keys(tableFormSchema.properties).forEach((key) => {
-      if (
-        typeof tableFormSchema.properties[key] === "object" &&
-        // @ts-ignore
-        "default" in tableFormSchema.properties[key]
-      ) {
-        // @ts-ignore
-        initForm[key] = tableFormSchema.properties[key].default;
-      } else {
-        initForm[key] = null;
-      }
-    });
-    return initForm;
-  }
-  return initForm;
-};
-
 interface DatasetFormProps {
-  // onSubmitDatasetEdit: (
-  //   args: any,
-  //   clear_state_callback: (isSuccessfulSubmit: boolean) => void
-  // ) => void;
-  // datasetSubmissionError: string | null;
   getDimensionTypes: () => Promise<DimensionType[]>;
   getDataTypesAndPriorities: () => Promise<InvalidPrioritiesByDataType>;
   getGroups: () => Promise<Group[]>;
@@ -78,6 +36,49 @@ export default function DatasetForm(props: DatasetFormProps) {
     uploadDataset,
     isAdvancedMode,
   } = props;
+
+  const initDatasetForm = React.useCallback(
+    (format: "table" | "matrix") => {
+      const initForm: { [key: string]: any } = {};
+      if (format === "matrix") {
+        Object.keys(matrixFormSchema.properties)
+          .concat("allowed_values")
+          .forEach((key) => {
+            if (!isAdvancedMode && key === "value_type") {
+              initForm[key] = "continuous";
+            } else if (
+              typeof matrixFormSchema.properties[key] === "object" &&
+              // @ts-ignore
+              "default" in matrixFormSchema.properties[key]
+            ) {
+              // @ts-ignore
+              initForm[key] = matrixFormSchema.properties[key].default;
+            } else {
+              initForm[key] = null;
+            }
+          });
+        return initForm;
+      }
+      if (format === "table") {
+        Object.keys(tableFormSchema.properties).forEach((key) => {
+          if (
+            typeof tableFormSchema.properties[key] === "object" &&
+            // @ts-ignore
+            "default" in tableFormSchema.properties[key]
+          ) {
+            // @ts-ignore
+            initForm[key] = tableFormSchema.properties[key].default;
+          } else {
+            initForm[key] = null;
+          }
+        });
+        return initForm;
+      }
+      return initForm;
+    },
+    [isAdvancedMode]
+  );
+
   const [selectedFormat, setSelectedFormat] = useState<
     "matrix" | "table" | null
   >(isAdvancedMode ? null : "matrix");
@@ -177,6 +178,7 @@ export default function DatasetForm(props: DatasetFormProps) {
             });
           }}
           onSubmitForm={onSubmitForm}
+          isAdvancedMode={isAdvancedMode}
         />
       );
     }
@@ -216,6 +218,7 @@ export default function DatasetForm(props: DatasetFormProps) {
     formContent,
     fileIds,
     md5Hash,
+    isAdvancedMode,
   ]);
 
   const handleOnChange = (e: any) => {

--- a/frontend/packages/@depmap/dataset-manager/src/components/DatasetForm.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/DatasetForm.tsx
@@ -66,8 +66,7 @@ interface DatasetFormProps {
   getGroups: () => Promise<Group[]>;
   uploadFile: (fileArgs: { file: File | Blob }) => Promise<UploadFileResponse>;
   uploadDataset: (datasetParams: DatasetParams) => Promise<any>;
-  // selectedDataset: Dataset | null;
-  // isEditMode: boolean;
+  isAdvancedMode: boolean;
 }
 
 export default function DatasetForm(props: DatasetFormProps) {
@@ -77,10 +76,11 @@ export default function DatasetForm(props: DatasetFormProps) {
     getDataTypesAndPriorities,
     uploadFile,
     uploadDataset,
+    isAdvancedMode,
   } = props;
   const [selectedFormat, setSelectedFormat] = useState<
     "matrix" | "table" | null
-  >(null);
+  >(isAdvancedMode ? null : "matrix");
   const [formContent, setFormContent] = useState({
     table: initDatasetForm("table"),
     matrix: initDatasetForm("matrix"),
@@ -248,27 +248,42 @@ export default function DatasetForm(props: DatasetFormProps) {
 
   return (
     <>
-      <legend>Step 1: Upload A File</legend>
-      <ChunkedFileUploader
-        uploadFile={uploadFile}
-        forwardFileIdsAndHash={forwardFileIdsAndHash}
-      />
-      <legend>Step 2: Choose Dataset Format</legend>
-      <FormGroup controlId="format" required>
-        <Radio
-          name="radioGroup"
-          inline
-          onChange={handleOnChange}
-          value="matrix"
-        >
-          Matrix
-        </Radio>
-        <Radio name="radioGroup" inline onChange={handleOnChange} value="table">
-          Table
-        </Radio>
-      </FormGroup>
+      <div>
+        <legend>Step 1: Upload A File</legend>
+        <ChunkedFileUploader
+          uploadFile={uploadFile}
+          forwardFileIdsAndHash={forwardFileIdsAndHash}
+        />
+      </div>
+
+      {isAdvancedMode ? (
+        <div>
+          <legend>Step 2: Choose Dataset Format</legend>
+          <FormGroup controlId="format" required>
+            <Radio
+              name="radioGroup"
+              inline
+              onChange={handleOnChange}
+              value="matrix"
+            >
+              Matrix
+            </Radio>
+            <Radio
+              name="radioGroup"
+              inline
+              onChange={handleOnChange}
+              value="table"
+            >
+              Table
+            </Radio>
+          </FormGroup>
+        </div>
+      ) : null}
+
       {formComponent ? (
-        <legend>Step 3: Fill Out Dataset Information</legend>
+        <legend>
+          {isAdvancedMode ? "Step 3:" : "Step 2:"} Fill Out Dataset Information
+        </legend>
       ) : null}
       {formComponent}
     </>

--- a/frontend/packages/@depmap/dataset-manager/src/components/MatrixDatasetForm.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/MatrixDatasetForm.tsx
@@ -159,48 +159,6 @@ const fields: RegistryFieldsType = {
   TagInputAllowedValues: CustomAllowedValues,
 };
 
-const uiSchema: UiSchema = {
-  "ui:title": "", // removes the title <legend> html element
-  "ui:order": [
-    "name",
-    "file_ids",
-    "dataset_md5",
-    "units",
-    "feature_type",
-    "sample_type",
-    "group_id",
-    "value_type",
-    "allowed_values",
-    "data_type",
-    "priority",
-    "dataset_metadata",
-    "is_transient",
-    "format",
-  ],
-  dataset_metadata: {
-    "ui:field": "TagInputMetadata",
-  },
-  allowed_values: {
-    "ui:field": "TagInputAllowedValues",
-    // "ui:emptyValue": null // This doesn't make default val 'null'. BUG: (see: https://github.com/rjsf-team/react-jsonschema-form/issues/1581                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             )
-  },
-  format: {
-    "ui:widget": "hidden",
-  },
-  file_ids: {
-    "ui:widget": "hidden",
-  },
-  dataset_md5: {
-    "ui:widget": "hidden",
-  },
-  is_transient: {
-    "ui:widget": "hidden",
-  },
-  group_id: {
-    "ui:title": "Group", // override original title from schema
-  },
-};
-
 interface MatrixDatasetFormProps {
   featureTypes: FeatureDimensionType[];
   sampleTypes: SampleDimensionType[];
@@ -210,6 +168,7 @@ interface MatrixDatasetFormProps {
   fileIds?: string[] | null;
   md5Hash?: string | null;
   initFormData: any;
+  isAdvancedMode: boolean;
   onSubmitForm: (formData: { [key: string]: any }) => void;
   forwardFormData?: (formData: { [key: string]: any }) => void;
 }
@@ -223,11 +182,64 @@ export function MatrixDatasetForm({
   fileIds = null,
   md5Hash = null,
   initFormData,
+  isAdvancedMode,
   onSubmitForm,
   forwardFormData = undefined,
 }: MatrixDatasetFormProps) {
   const [formData, setFormData] = React.useState(initFormData);
   const [schema, setSchema] = React.useState<RJSFSchema | null>(null);
+
+  const uiSchema = React.useMemo(() => {
+    const formUiSchema: UiSchema = {
+      "ui:title": "", // removes the title <legend> html element
+      "ui:order": [
+        "name",
+        "file_ids",
+        "dataset_md5",
+        "units",
+        "feature_type",
+        "sample_type",
+        "group_id",
+        "value_type",
+        "allowed_values",
+        "data_type",
+        "priority",
+        "dataset_metadata",
+        "is_transient",
+        "format",
+      ],
+      dataset_metadata: {
+        "ui:field": "TagInputMetadata",
+      },
+      allowed_values: {
+        "ui:field": "TagInputAllowedValues",
+        // "ui:emptyValue": null // This doesn't make default val 'null'. BUG: (see: https://github.com/rjsf-team/react-jsonschema-form/issues/1581                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             )
+      },
+      format: {
+        "ui:widget": "hidden",
+      },
+      file_ids: {
+        "ui:widget": "hidden",
+      },
+      dataset_md5: {
+        "ui:widget": "hidden",
+      },
+      is_transient: {
+        "ui:widget": "hidden",
+      },
+      group_id: {
+        "ui:title": "Group", // override original title from schema
+      },
+    };
+    if (!isAdvancedMode) {
+      ["feature_type", "value_type", "priority", "dataset_metadata"].forEach(
+        (key) => {
+          formUiSchema[key] = { "ui:widget": "hidden" };
+        }
+      );
+    }
+    return formUiSchema;
+  }, [isAdvancedMode]);
 
   React.useEffect(() => {
     const featureTypeOptions = featureTypes.map((option) => {

--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -179,6 +179,7 @@ export default function Datasets() {
             getDataTypesAndPriorities={getDataTypesAndPriorities}
             uploadFile={postFileUpload}
             uploadDataset={postDatasetUpload}
+            isAdvancedMode={isAdvancedMode}
           />
         );
       }
@@ -206,6 +207,7 @@ export default function Datasets() {
     postFileUpload,
     showDatasetModal,
     updateDataset,
+    isAdvancedMode,
   ]);
 
   if (!datasets || !dimensionTypes) {

--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -9,7 +9,7 @@ import {
   DimensionTypeUpdateArgs,
 } from "@depmap/types";
 
-import { FormModal, Spinner } from "@depmap/common-components";
+import { FormModal, Spinner, ToggleSwitch } from "@depmap/common-components";
 import WideTable from "@depmap/wide-table";
 import Button from "react-bootstrap/lib/Button";
 
@@ -30,6 +30,7 @@ export default function Datasets() {
   // const [datasetSubmissionError, setDatasetSubmissionError] = useState<
   //   string | null
   // >(null);
+  const [isAdvancedMode, setIsAdvancedMode] = useState(false);
   const [selectedDatasetIds, setSelectedDatasetIds] = useState<Set<string>>(
     new Set()
   );
@@ -412,6 +413,16 @@ export default function Datasets() {
     <>
       <div className="container-fluid">
         <h1>Datasets</h1>
+        <ToggleSwitch
+          value={isAdvancedMode}
+          onChange={(newValue: boolean) => {
+            setIsAdvancedMode(newValue);
+          }}
+          options={[
+            { label: "Advanced", value: true },
+            { label: "Simple", value: false },
+          ]}
+        />
         <div className={styles.primaryButtons}>
           <Button bsStyle="primary" onClick={() => setShowDatasetModal(true)}>
             Upload New Dataset

--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -412,92 +412,94 @@ export default function Datasets() {
   return (
     <>
       <div className="container-fluid">
-        <h1>Datasets</h1>
-        <ToggleSwitch
-          value={isAdvancedMode}
-          onChange={(newValue: boolean) => {
-            setIsAdvancedMode(newValue);
-          }}
-          options={[
-            { label: "Advanced", value: true },
-            { label: "Simple", value: false },
-          ]}
-        />
-        <div className={styles.primaryButtons}>
-          <Button bsStyle="primary" onClick={() => setShowDatasetModal(true)}>
-            Upload New Dataset
-          </Button>
-          <Button
-            bsStyle="default"
-            onClick={() => handleEditDatasetButtonClick()}
-            disabled={selectedDatasetIds.size !== 1 || datasets.length === 1}
-          >
-            Edit Selected Dataset
-          </Button>
-          <Button
-            bsStyle="danger"
-            onClick={() => deleteDatasetButtonAction()}
-            disabled={selectedDatasetIds.size === 0 || datasets.length === 0}
-          >
-            Delete Selected Dataset
-          </Button>
-        </div>
-        <div className={styles.tableView}>
-          <WideTable
-            rowHeight={40}
-            idProp="id"
-            onChangeSelections={(selections) => {
-              setSelectedDatasetIds(new Set(selections));
-              // If only one dataset is selected, assign that as the dataset to edit
-              if (selections.length === 1) {
-                const selectedDataset = datasets.find(
-                  (dataset) => dataset.id === selections[0]
-                );
-                setDatasetToEdit(selectedDataset || null);
-              }
+        <div>
+          <h1>Datasets</h1>
+          <ToggleSwitch
+            value={isAdvancedMode}
+            onChange={(newValue: boolean) => {
+              setIsAdvancedMode(newValue);
             }}
-            data={formatDatasetTableData(datasets)}
-            columns={[
-              {
-                accessor: "name",
-                Header: "Name",
-                minWidth: 200,
-                maxWidth: 800,
-              },
-              {
-                accessor: "featureType",
-                Header: "Feature Type",
-                minWidth: 100,
-                maxWidth: 300,
-              },
-              {
-                accessor: "sampleType",
-                Header: "Sample Type",
-                minWidth: 100,
-                maxWidth: 300,
-              },
-              { accessor: "groupName", Header: "Group Name", maxWidth: 300 },
-              {
-                accessor: "dataType",
-                Header: "Data Type",
-                minWidth: 100,
-                maxWidth: 200,
-              },
-              {
-                accessor: "datasetMetadata",
-                Header: "Dataset Metadata",
-                width: 20,
-                disableFilters: true,
-                disableSortBy: true,
-              },
+            options={[
+              { label: "Simple", value: false },
+              { label: "Advanced", value: true },
             ]}
           />
+          <div className={styles.primaryButtons}>
+            <Button bsStyle="primary" onClick={() => setShowDatasetModal(true)}>
+              Upload New Dataset
+            </Button>
+            <Button
+              bsStyle="default"
+              onClick={() => handleEditDatasetButtonClick()}
+              disabled={selectedDatasetIds.size !== 1 || datasets.length === 1}
+            >
+              Edit Selected Dataset
+            </Button>
+            <Button
+              bsStyle="danger"
+              onClick={() => deleteDatasetButtonAction()}
+              disabled={selectedDatasetIds.size === 0 || datasets.length === 0}
+            >
+              Delete Selected Dataset
+            </Button>
+          </div>
+          <div className={styles.tableView}>
+            <WideTable
+              rowHeight={40}
+              idProp="id"
+              onChangeSelections={(selections) => {
+                setSelectedDatasetIds(new Set(selections));
+                // If only one dataset is selected, assign that as the dataset to edit
+                if (selections.length === 1) {
+                  const selectedDataset = datasets.find(
+                    (dataset) => dataset.id === selections[0]
+                  );
+                  setDatasetToEdit(selectedDataset || null);
+                }
+              }}
+              data={formatDatasetTableData(datasets)}
+              columns={[
+                {
+                  accessor: "name",
+                  Header: "Name",
+                  minWidth: 200,
+                  maxWidth: 800,
+                },
+                {
+                  accessor: "featureType",
+                  Header: "Feature Type",
+                  minWidth: 100,
+                  maxWidth: 300,
+                },
+                {
+                  accessor: "sampleType",
+                  Header: "Sample Type",
+                  minWidth: 100,
+                  maxWidth: 300,
+                },
+                { accessor: "groupName", Header: "Group Name", maxWidth: 300 },
+                {
+                  accessor: "dataType",
+                  Header: "Data Type",
+                  minWidth: 100,
+                  maxWidth: 200,
+                },
+                {
+                  accessor: "datasetMetadata",
+                  Header: "Dataset Metadata",
+                  width: 20,
+                  disableFilters: true,
+                  disableSortBy: true,
+                },
+              ]}
+            />
+          </div>
         </div>
 
         {datasetForm()}
         {datasetMetadataToShowForm(datasetMetadataToShow)}
 
-        {dimensionTypes ? (
+        {dimensionTypes && isAdvancedMode ? (
           <FormModal
             title={
               isEditDimensionTypeMode
@@ -513,66 +515,70 @@ export default function Datasets() {
           />
         ) : null}
 
-        <h1>Dimension Types</h1>
+        {isAdvancedMode ? (
+          <div>
+            <h1>Dimension Types</h1>
 
-        {showDeleteError && (
-          <Alert bsStyle="danger">
-            <strong>
-              Delete &quot;{selectedDimensionType.name}&quot; Failed!
-            </strong>{" "}
-            Make sure &quot;{selectedDimensionType.name}&quot; has no datasets
-            with its dimension type.
-          </Alert>
-        )}
+            {showDeleteError && (
+              <Alert bsStyle="danger">
+                <strong>
+                  Delete &quot;{selectedDimensionType.name}&quot; Failed!
+                </strong>{" "}
+                Make sure &quot;{selectedDimensionType.name}&quot; has no
+                datasets with its dimension type.
+              </Alert>
+            )}
 
-        <div className={styles.primaryButtons}>
-          <Button
-            bsStyle="primary"
-            onClick={() => setShowDimensionTypeModal(true)}
-          >
-            Create New Dimension Type
-          </Button>
-          <Button
-            bsStyle="default"
-            onClick={() => handleEditDimensionTypeButtonClick()}
-            disabled={!selectedDimensionType}
-          >
-            Edit Selected Dimension Type
-          </Button>
-          <Button
-            bsStyle="danger"
-            onClick={() => deleteDimensionType()}
-            disabled={!selectedDimensionType}
-          >
-            Delete Selected Dimension Type
-          </Button>
-        </div>
+            <div className={styles.primaryButtons}>
+              <Button
+                bsStyle="primary"
+                onClick={() => setShowDimensionTypeModal(true)}
+              >
+                Create New Dimension Type
+              </Button>
+              <Button
+                bsStyle="default"
+                onClick={() => handleEditDimensionTypeButtonClick()}
+                disabled={!selectedDimensionType}
+              >
+                Edit Selected Dimension Type
+              </Button>
+              <Button
+                bsStyle="danger"
+                onClick={() => deleteDimensionType()}
+                disabled={!selectedDimensionType}
+              >
+                Delete Selected Dimension Type
+              </Button>
+            </div>
 
-        <div className={styles.tableView}>
-          <WideTable
-            idProp="name"
-            onChangeSelections={(selections) => {
-              if (selections.length > 0) {
-                const selectedDimType = dimensionTypes.find(
-                  (dt) => dt.name === selections[0]
-                );
-                setSelectedDimensionType(selectedDimType || null);
-              } else {
-                setSelectedDimensionType(null);
-              }
-              setShowDeleteError(false);
-            }}
-            rowHeight={40}
-            columns={[
-              { accessor: "name", Header: "Name" },
-              { accessor: "display_name", Header: "Display Name" },
-              { accessor: "axis", Header: "Type" },
-              { accessor: "datasetsCount", Header: "Datasets" },
-            ]}
-            data={dimensionTypes}
-            singleSelectionMode
-          />
-        </div>
+            <div className={styles.tableView}>
+              <WideTable
+                idProp="name"
+                onChangeSelections={(selections) => {
+                  if (selections.length > 0) {
+                    const selectedDimType = dimensionTypes.find(
+                      (dt) => dt.name === selections[0]
+                    );
+                    setSelectedDimensionType(selectedDimType || null);
+                  } else {
+                    setSelectedDimensionType(null);
+                  }
+                  setShowDeleteError(false);
+                }}
+                rowHeight={40}
+                columns={[
+                  { accessor: "name", Header: "Name" },
+                  { accessor: "display_name", Header: "Display Name" },
+                  { accessor: "axis", Header: "Type" },
+                  { accessor: "datasetsCount", Header: "Datasets" },
+                ]}
+                data={dimensionTypes}
+                singleSelectionMode
+              />
+            </div>
+          </div>
+        ) : null}
       </div>
     </>
   );


### PR DESCRIPTION
[Addresses this task](https://app.asana.com/0/1188486168213297/1208479911500435)

- Add toggle to switch between "advanced" and "simple" mode
- In "simple mode" don't show dimension type table
- In "simple mode" the dataset upload form only shows fields for a matrix dataset and hides the option for tabular dataset
- In "simple mode" only show a limited matrix dataset fields user can edit

TBD: @pgm The task assumes `feature_type` is null but there is no default for `sample_type`. Is that actually the case?



https://github.com/user-attachments/assets/f067011c-a7bc-4101-8fc1-084cd3d03292


![Screenshot 2024-11-22 at 4 48 35 PM](https://github.com/user-attachments/assets/9e8e61a7-82d7-4b74-aaae-f1d53a965fb7)

![Screenshot 2024-11-22 at 4 55 44 PM](https://github.com/user-attachments/assets/29ecbb12-5ab6-44c7-b3c7-76074fdc7b6f)
