### PR TITLE
Fix sorting performance in getDatasets endpoint

### DIFF
--- a/portal-backend/depmap/interactive/views.py
+++ b/portal-backend/depmap/interactive/views.py
@@ -135,16 +135,14 @@ def get_cell_line_url_root():
 
 @blueprint.route("/api/getDatasets")
 def get_datasets():
-    """Return all matrix datasets (both breadbox and legacy datasets)."""
+    """Return all matrix datasets (both breadbox and legacy datasets) sorted alphabetically."""
     combined_datasets = []
     for dataset in data_access.get_all_matrix_datasets():
         if dataset.is_continuous:
             combined_datasets.append(dict(label=dataset.label, value=dataset.id,))
     combined_datasets = sorted(
-        combined_datasets,
-        key=lambda dataset: data_access.get_sort_key(dataset["value"]),
+        combined_datasets, key=lambda dataset: dataset.get("label"),
     )
-
     return jsonify(combined_datasets)
 
 


### PR DESCRIPTION
Fixing an issue where [getDatasets](https://dev.cds.team/depmap-istaging/interactive/api/getDatasets) was taking >17 seconds to load on istaging because it was making an enormous number of requests to breadbox when trying to sort the list of datasets (`data_access.get_sort_key` makes a request to breadbox). This was making custom analysis very difficult to use.

I'm not sure our old sorting method really makes sense for this anymore anyway. As far as I can tell it was essentially just:
1. Lists all breadbox datasets first, in alphabetical order
2. Then lists other datasets according to the older vector catalog sorting method 

Since we're moving all of these datasets to breadbox soon anyway, I thought it might make more sense to just have this endpoint sort alphabetically. This completely fixed the performance issue for me locally. 