### PR TITLE
improve Elara feature selection

### DIFF
--- a/frontend/packages/@depmap/common-components/src/components/Highlighter.tsx
+++ b/frontend/packages/@depmap/common-components/src/components/Highlighter.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export const colors = [
-  "yellow",
+  "#FFEE00",
   "#FF8152",
   "#32CD32",
   "#03A9F4",

--- a/frontend/packages/@depmap/data-explorer-2/package.json
+++ b/frontend/packages/@depmap/data-explorer-2/package.json
@@ -16,6 +16,7 @@
     "@depmap/globals": "1.0.0",
     "@depmap/interactive": "1.0.0",
     "@depmap/types": "1.0.0",
+    "@depmap/utils": "1.0.0",
     "classnames": "^2.3.1",
     "js-base64": "^3.7.2",
     "json-beautify": "^1.1.1",

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Variable.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Variable.tsx
@@ -114,7 +114,7 @@ function Variable({
       (datasets || []).reduce(
         (memo, dataset) => ({
           ...memo,
-          [makePartialSliceId(dataset.dataset_id)]: dataset.label,
+          [makePartialSliceId(dataset.id)]: dataset.name,
         }),
         {}
       ),
@@ -156,8 +156,7 @@ function Variable({
 
   const varDatasetId = extractDatasetIdFromSlice(value, variables);
 
-  const varSliceType = datasets?.find((d) => d.dataset_id === varDatasetId)
-    ?.slice_type;
+  const varSliceType = datasets?.find((d) => d.id === varDatasetId)?.slice_type;
 
   return (
     <div>

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/Variable/DataSourceSelect.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/Variable/DataSourceSelect.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from "react";
 import { DataExplorerContextVariable } from "@depmap/types";
 import PlotConfigSelect from "../../../../../PlotConfigSelect";
 import { useContextBuilderState } from "../../../../state/ContextBuilderState";
+import useTabularDatasets from "../../../../hooks/useTabularDatasets";
 import { scrollParentIntoView } from "../../../../utils/domUtils";
 
 interface Props {
@@ -12,9 +13,34 @@ interface Props {
 function DataSourceSelect({ expr, path }: Props) {
   const ref = useRef<HTMLDivElement>(null);
   const { dispatch, vars, setVar } = useContextBuilderState();
+  const {
+    metadataDataset,
+    otherTabularDatasets,
+    isLoadingTabularDatasets,
+  } = useTabularDatasets();
+
   const varName = expr ? expr.var : null;
   const slice = varName ? vars[varName] : null;
   const source = slice?.source || null;
+
+  const options = isLoadingTabularDatasets
+    ? []
+    : [
+        {
+          label: "Annotation",
+          value: "metadata_column",
+          isDisabled: !metadataDataset,
+        },
+        {
+          label: "Tabular Dataset",
+          value: "tabular_dataset",
+          isDisabled: otherTabularDatasets.length === 0,
+        },
+        {
+          label: "Matrix Dataset",
+          value: "matrix_dataset",
+        },
+      ];
 
   return (
     <PlotConfigSelect
@@ -23,11 +49,8 @@ function DataSourceSelect({ expr, path }: Props) {
       label="Data Source"
       innerRef={ref}
       value={source}
-      options={{
-        metadata_column: "Annotation",
-        tabular_dataset: "Tabular Dataset",
-        matrix_dataset: "Matrix Dataset",
-      }}
+      options={options}
+      isLoading={isLoadingTabularDatasets}
       onChange={(nextSource) => {
         let nextVarName = varName;
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/Variable/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/Variable/index.tsx
@@ -10,24 +10,23 @@ interface Props {
   path: (string | number)[];
 }
 
+const Selects = {
+  metadata_column: MetadataColumnSelect,
+  tabular_dataset: TabularDataSelect,
+  matrix_dataset: MatrixDataSelect,
+};
+
 function Variable({ expr, path }: Props) {
   const { vars } = useContextBuilderState();
   const varName = expr?.var || null;
   const slice = varName ? vars[varName] : null;
   const source = slice?.source || null;
+  const SliceQuerySelect = source ? Selects[source] : () => null;
 
   return (
     <>
       <DataSourceSelect expr={expr} path={path} />
-      {source === "metadata_column" && (
-        <MetadataColumnSelect varName={varName as string} />
-      )}
-      {source === "tabular_dataset" && (
-        <TabularDataSelect varName={varName as string} />
-      )}
-      {source === "matrix_dataset" && (
-        <MatrixDataSelect varName={varName as string} />
-      )}
+      <SliceQuerySelect varName={varName as string} />
     </>
   );
 }

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/state/ContextBuilderState.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/state/ContextBuilderState.tsx
@@ -12,6 +12,7 @@ import {
   isValidSliceQuery,
 } from "@depmap/types";
 import { isCompleteExpression } from "../../../utils/misc";
+import simplifyVarNames from "../utils/simplifyVarNames";
 import expressionReducer, { ExprReducerAction } from "./expressionReducer";
 
 const DEFAULT_EMPTY_EXPR = { and: [{ "==": [null, null] }] };
@@ -92,12 +93,14 @@ export const ContextBuilderStateProvider = ({
       return;
     }
 
-    onChangeContext({
+    const nextContext = simplifyVarNames({
       name,
       dimension_type: contextToEdit.dimension_type as string,
       expr: mainExpr,
       vars: vars as Record<string, DataExplorerContextVariable>,
     });
+
+    onChangeContext(nextContext);
   }, [
     contextToEdit,
     fullySpecifiedVars,

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/utils/simplifyVarNames.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/utils/simplifyVarNames.ts
@@ -1,0 +1,31 @@
+import {
+  DataExplorerContextV2,
+  DataExplorerContextVariable,
+} from "@depmap/types";
+
+// Replaces UUIDs with integers. This isn't strictly necessary but it prevents
+// otherwise identical contexts from being hashed differently.
+function simplifyVarNames(context: DataExplorerContextV2) {
+  const nextVars: Record<string, DataExplorerContextVariable> = {};
+  let i = 0;
+
+  const nextExpr = JSON.parse(
+    JSON.stringify(context.expr, (key, value) => {
+      if (key === "var") {
+        const newVarName = `${i++}`;
+        nextVars[newVarName] = context.vars[value];
+        return newVarName;
+      }
+
+      return value;
+    })
+  );
+
+  return {
+    ...context,
+    expr: nextExpr,
+    vars: nextVars,
+  };
+}
+
+export default simplifyVarNames;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/useDimensionStateManager/errors.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/useDimensionStateManager/errors.ts
@@ -25,7 +25,7 @@ export function handleError(
 ) {
   if (error instanceof MismatchedSliceTypeError) {
     const slice_type = datasets.find(
-      (d) => d.dataset_id === prevState.dimension.dataset_id
+      (d) => d.id === prevState.dimension.dataset_id
     )?.slice_type;
 
     window.console.error(error);

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/useDimensionStateManager/resolveNextState.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/useDimensionStateManager/resolveNextState.ts
@@ -113,7 +113,7 @@ export default function resolveNextState({
     const ds = filterDatasets(datasets, { slice_type, dataType });
 
     if (ds.length === 1) {
-      dataset_id = ds[0].dataset_id;
+      dataset_id = ds[0].id;
     }
   }
 
@@ -145,7 +145,7 @@ export default function resolveNextState({
 
       const enabledDataTypes = new Set(
         datasets
-          .filter((d) => datasetIdsWithSelectedLabel.has(d.dataset_id))
+          .filter((d) => datasetIdsWithSelectedLabel.has(d.id))
           .map((d) => d.data_type)
       );
 
@@ -157,7 +157,7 @@ export default function resolveNextState({
 
   if ("dataset_id" in changes && dataset_id !== changes.dataset_id) {
     dataset_id = changes.dataset_id || undefined;
-    const dataset = datasets.find((d) => d.dataset_id === dataset_id);
+    const dataset = datasets.find((d) => d.id === dataset_id);
 
     if (dataset) {
       slice_type = dataset.slice_type;
@@ -177,7 +177,7 @@ export default function resolveNextState({
   }
 
   if (dataset_id) {
-    const dataset = datasets.find((d) => d.dataset_id === dataset_id);
+    const dataset = datasets.find((d) => d.id === dataset_id);
     if (!dataset) {
       throw new UnknownDatasetError(`Unknown dataset_id "${dataset_id}"`);
     }
@@ -230,7 +230,7 @@ export default function resolveNextState({
   // obscure an exceptional condition where a slice label is now missing from
   // the selected dataset.
   if (!dataType && dataset_id) {
-    const dataset = datasets.find((d) => d.dataset_id === dataset_id);
+    const dataset = datasets.find((d) => d.id === dataset_id);
 
     if (!dataset) {
       throw new UnknownDatasetError(`Unknown dataset_id "${dataset_id}"`);

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/useDimensionStateManager/resolveNextState.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/useDimensionStateManager/resolveNextState.ts
@@ -157,7 +157,10 @@ export default function resolveNextState({
 
   if ("dataset_id" in changes && dataset_id !== changes.dataset_id) {
     dataset_id = changes.dataset_id || undefined;
-    const dataset = datasets.find((d) => d.id === dataset_id);
+
+    const dataset = datasets.find((d) => {
+      return d.id === dataset_id || d.given_id === dataset_id;
+    });
 
     if (dataset) {
       slice_type = dataset.slice_type;
@@ -177,7 +180,10 @@ export default function resolveNextState({
   }
 
   if (dataset_id) {
-    const dataset = datasets.find((d) => d.id === dataset_id);
+    const dataset = datasets.find((d) => {
+      return d.id === dataset_id || d.given_id === dataset_id;
+    });
+
     if (!dataset) {
       throw new UnknownDatasetError(`Unknown dataset_id "${dataset_id}"`);
     }
@@ -230,7 +236,9 @@ export default function resolveNextState({
   // obscure an exceptional condition where a slice label is now missing from
   // the selected dataset.
   if (!dataType && dataset_id) {
-    const dataset = datasets.find((d) => d.id === dataset_id);
+    const dataset = datasets.find((d) => {
+      return d.id === dataset_id || d.given_id === dataset_id;
+    });
 
     if (!dataset) {
       throw new UnknownDatasetError(`Unknown dataset_id "${dataset_id}"`);

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/useDimensionStateManager/utils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/useDimensionStateManager/utils.ts
@@ -55,12 +55,12 @@ export function findHighestPriorityDatasetId(
 
   filterDatasets(datasets, { slice_type, dataType, units }).forEach((d) => {
     if (
-      enabledDatasetIds.has(d.dataset_id) &&
+      enabledDatasetIds.has(d.id) &&
       d.priority !== null &&
       d.priority < bestPriority
     ) {
       bestPriority = d.priority;
-      bestId = d.dataset_id;
+      bestId = d.id;
     }
   });
 
@@ -83,7 +83,7 @@ function isHighestPriorityDataset(
     units
   );
 
-  return dataset.dataset_id === bestId;
+  return dataset.id === bestId;
 }
 
 export function getEnabledDatasetIds(
@@ -100,7 +100,7 @@ export function getEnabledDatasetIds(
     return new Set(
       datasets
         .filter((d) => !dataType || dataType === d.data_type)
-        .map((d) => d.dataset_id)
+        .map((d) => d.id)
     );
   }
 
@@ -114,9 +114,7 @@ export function getEnabledDatasetIds(
     datasets
       .filter((d) => d.units !== units)
       .forEach((d) => {
-        const index = sliceLabelMap.dataset_ids.findIndex(
-          (id) => id === d.dataset_id
-        );
+        const index = sliceLabelMap.dataset_ids.findIndex((id) => id === d.id);
         validDsIndices.delete(index);
       });
   }
@@ -279,7 +277,7 @@ export function computeOptions(
 
       const noEntities = !datasets
         .filter((d) => d.units === units)
-        .some((d) => enabledDatasetIds.has(d.dataset_id));
+        .some((d) => enabledDatasetIds.has(d.id));
 
       if (noEntities) {
         isDisabled = true;
@@ -358,7 +356,7 @@ export function computeOptions(
         ].join(" ");
       }
 
-      if (selectedContext && !enabledDatasetIds.has(dataset.dataset_id)) {
+      if (selectedContext && !enabledDatasetIds.has(dataset.id)) {
         isDisabled = true;
 
         if (selectedAxisType === "aggregated_slice") {
@@ -386,8 +384,8 @@ export function computeOptions(
       }
 
       return {
-        label: dataset.label,
-        value: dataset.dataset_id,
+        label: dataset.name,
+        value: dataset.id,
         isDefault: isHighestPriorityDataset(
           dataset,
           datasets,

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/AllSelects.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/AllSelects.tsx
@@ -93,7 +93,9 @@ function AllSelects({
       <SliceSelect
         show={Boolean(slice_type) && axis_type === "raw_slice"}
         index_type={index_type}
+        dataType={dataType}
         slice_type={slice_type as string}
+        dataset_id={dataset_id || null}
         value={context || null}
         onChange={onChangeContext}
       />

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/SliceSelect/convertSearchResultToOptions.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/SliceSelect/convertSearchResultToOptions.ts
@@ -1,0 +1,200 @@
+import { SearchDimenionsResponse } from "@depmap/types";
+import { useDataExplorerApi } from "../../../contexts/DataExplorerApiContext";
+
+async function fetchDataTypeCompatibleIds(
+  api: ReturnType<typeof useDataExplorerApi>,
+  slice_type: string,
+  dataType: string | null
+) {
+  const ids = await api.fetchDimensionIdentifiers(
+    slice_type,
+    dataType || undefined
+  );
+
+  return new Set(ids.map(({ id }) => id));
+}
+
+async function fetchDataVersionCompatibleIds(
+  api: ReturnType<typeof useDataExplorerApi>,
+  slice_type: string,
+  dataset_id: string | null
+) {
+  if (!dataset_id) {
+    return null;
+  }
+
+  const ids = await api.fetchDatasetIdentifiers(slice_type, dataset_id);
+  return new Set(ids.map(({ id }) => id));
+}
+
+async function fetchDimensionTypeDisplayName(
+  api: ReturnType<typeof useDataExplorerApi>,
+  dimensionTypeName: string
+) {
+  const dimensionTypes = await api.fetchDimensionTypes();
+  const dimType = dimensionTypes.find((t) => t.name === dimensionTypeName);
+
+  if (!dimType) {
+    throw new Error(`Unrecognized dimension type "${dimensionTypeName}"!`);
+  }
+
+  return dimType.display_name || dimType.name;
+}
+
+async function fetchDatasetName(
+  api: ReturnType<typeof useDataExplorerApi>,
+
+  dataset_id: string | null
+) {
+  if (!dataset_id) {
+    return "";
+  }
+
+  const datasets = await api.fetchDatasets();
+  const dataset = datasets.find((d) => d.id === dataset_id);
+
+  if (!dataset) {
+    throw new Error(`Unknown dataset "${dataset_id}".`);
+  }
+
+  return dataset.name;
+}
+
+const chainLength = (str: string) => str.split(".").length;
+
+async function convertSearchResultToOptions(
+  tokens: string[],
+  result: SearchDimenionsResponse,
+  api: ReturnType<typeof useDataExplorerApi>,
+  slice_type: string,
+  dataType: string | null,
+  dataset_id: string | null
+) {
+  const [
+    dataTypeCompatibleIds,
+    dataVersionCompatibleIds,
+    dimesionTypeDisplayName,
+    datasetName,
+  ] = await Promise.all([
+    fetchDataTypeCompatibleIds(api, slice_type, dataType),
+    fetchDataVersionCompatibleIds(api, slice_type, dataset_id),
+    fetchDimensionTypeDisplayName(api, slice_type),
+    fetchDatasetName(api, dataset_id),
+  ]);
+
+  return result
+    .map(({ id, label, matching_properties }) => {
+      let isDisabled = false;
+      let disabledReason = "";
+
+      if (!dataTypeCompatibleIds.has(id)) {
+        isDisabled = true;
+
+        disabledReason = [
+          `The data type “${dataType}”`,
+          "has no data versions with this",
+          dimesionTypeDisplayName,
+        ].join(" ");
+      } else if (
+        dataVersionCompatibleIds &&
+        !dataVersionCompatibleIds.has(id)
+      ) {
+        isDisabled = true;
+
+        disabledReason = [
+          "The data version",
+          `“${datasetName}”`,
+          "doesn’t include this",
+          dimesionTypeDisplayName,
+        ].join(" ");
+      }
+
+      const groupedProps: Record<string, Set<string>> = {};
+
+      const tokenMatches = tokens
+        .map((token) => {
+          const lowercaseToken = token.toLowerCase();
+
+          return matching_properties
+            .filter(({ property }) => property !== "label")
+            .filter(({ value }) => {
+              return value.toLowerCase().includes(lowercaseToken);
+            })
+            .sort((a, b) => {
+              return chainLength(a.property) - chainLength(b.property);
+            })[0];
+        })
+        .filter(Boolean);
+
+      tokenMatches.forEach(({ property, value }) => {
+        const prop = property
+          // no underscores
+          .replace(/_/g, " ")
+          // capitalize "ID"
+          .replace(/\bids?\b/gi, "ID")
+          // Never use "label" as a nested property (it doesn't give the user
+          // any real information)
+          .replace(/\.label$/, "")
+          // Now return only the last member of the property chain (this
+          // assumes that's the most meaningful info we can show the user).
+          .split(".")
+          .slice(-1)[0];
+
+        groupedProps[prop] ||= new Set();
+        groupedProps[prop].add(value);
+      });
+
+      const nonLabelProperties = Object.keys(groupedProps)
+        .filter((property) => property !== "label")
+        .map((property) => ({
+          property,
+          values: [...groupedProps[property]],
+        }));
+
+      return {
+        value: id,
+        label,
+        isDisabled,
+        disabledReason,
+        nonLabelProperties,
+      };
+    })
+    .sort((a, b) => {
+      if (a.isDisabled && !b.isDisabled) {
+        return 1;
+      }
+
+      if (!a.isDisabled && b.isDisabled) {
+        return -1;
+      }
+
+      const labelA = (
+        a.nonLabelProperties[0]?.values[0] || a.label
+      )?.toLowerCase();
+
+      const labelB = (
+        b.nonLabelProperties[0]?.values[0] || b.label
+      )?.toLowerCase();
+
+      if (tokens.length === 0) {
+        return labelA < labelB ? -1 : 1;
+      }
+
+      const indexA = tokens.reduce(
+        (sum, token) => labelA.indexOf(token) + sum,
+        0
+      );
+      const indexB = tokens.reduce(
+        (sum, token) => labelB.indexOf(token) + sum,
+        0
+      );
+
+      if (indexA === indexB) {
+        return labelA < labelB ? -1 : 1;
+      }
+
+      return indexA < indexB ? -1 : 1;
+    });
+}
+
+export default convertSearchResultToOptions;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/SliceSelect/convertSearchResultToOptions.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/SliceSelect/convertSearchResultToOptions.ts
@@ -51,7 +51,9 @@ async function fetchDatasetName(
   }
 
   const datasets = await api.fetchDatasets();
-  const dataset = datasets.find((d) => d.id === dataset_id);
+  const dataset = datasets.find((d) => {
+    return d.id === dataset_id || d.given_id === dataset_id;
+  });
 
   if (!dataset) {
     throw new Error(`Unknown dataset "${dataset_id}".`);

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/SliceSelect/formatOptionLabel.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/SliceSelect/formatOptionLabel.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { Highlighter, Tooltip, WordBreaker } from "@depmap/common-components";
+import { tokenize } from "./utils";
+import styles from "../../../styles/DimensionSelect.scss";
+
+interface Option {
+  value: string;
+  label: string;
+  nonLabelProperties: {
+    property: string;
+    values: string[];
+  }[];
+  isDisabled: boolean;
+  disabledReason: string;
+}
+
+function formatOptionLabel(
+  option: { label: string },
+  { context, inputValue }: { context: "menu" | "value"; inputValue: string }
+) {
+  if (context === "value") {
+    return option.label;
+  }
+
+  const nonLabelProperties = (option as Option).nonLabelProperties;
+  const disabledReason = (option as Option).disabledReason;
+
+  const MaybeTooltip = ({ children }: { children: React.ReactNode }) => {
+    if (!disabledReason) {
+      return <div>{children}</div>;
+    }
+
+    return (
+      <Tooltip
+        id={`disabled-option-${option.label}`}
+        className={styles.unblockable}
+        content={<WordBreaker text={disabledReason} />}
+        placement="top"
+      >
+        <span className={styles.disabledOption}>{children}</span>
+      </Tooltip>
+    );
+  };
+
+  const tokens = tokenize(inputValue);
+
+  return (
+    <div>
+      <MaybeTooltip>
+        <div
+          style={{
+            fontWeight: nonLabelProperties?.length ? "bold" : "normal",
+          }}
+        >
+          <Highlighter
+            text={option.label}
+            style={{ color: disabledReason ? "inherit" : "black" }}
+            termToHiglight={tokens}
+            matchPartialTerms
+          />
+        </div>
+      </MaybeTooltip>
+      {nonLabelProperties?.map((match, i) => {
+        return (
+          // eslint-disable-next-line react/no-array-index-key
+          <div key={i}>
+            <MaybeTooltip>
+              {match.property.replace(/^(.)/, (c: string) => c.toUpperCase())}:{" "}
+              <Highlighter
+                text={match.values.join(", ")}
+                termToHiglight={tokens}
+                matchPartialTerms
+                style={{ color: disabledReason ? "inherit" : "black" }}
+              />
+            </MaybeTooltip>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default formatOptionLabel;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/SliceSelect/hooks.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/SliceSelect/hooks.ts
@@ -1,0 +1,113 @@
+import { useCallback, useContext, useEffect, useState } from "react";
+import { ApiContext } from "@depmap/api";
+import { useDataExplorerApi } from "../../../contexts/DataExplorerApiContext";
+import { useDimensionType } from "../../../utils/misc";
+import convertSearchResultToOptions from "./convertSearchResultToOptions";
+import { tokenize } from "./utils";
+
+export const useLabel = (index_type: string | null) => {
+  const { dimensionType, isDimensionTypeLoading } = useDimensionType(
+    index_type
+  );
+
+  if (isDimensionTypeLoading) {
+    return "...";
+  }
+
+  if (!dimensionType) {
+    return "Dimension";
+  }
+
+  return dimensionType.axis === "sample" ? "Feature" : "Sample";
+};
+
+export const useDefaultOptions = (
+  slice_type: string,
+  dataType: string | null,
+  dataset_id: string | null
+) => {
+  const api = useDataExplorerApi();
+  const [defaultOptions, setDefaultOptions] = useState<
+    { value: string; label: string }[]
+  >([]);
+  const [isLoadingDefaultOptions, setIsLoadingDefaultOptions] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const identifiers = await api.fetchDimensionIdentifiers(slice_type);
+
+      // Make this look like a search result so we can reuse the logic of
+      // `convertSearchResultToOptions`.
+      const result = identifiers.map((identifier) => {
+        return {
+          type_name: slice_type,
+          id: identifier.id,
+          label: identifier.label,
+          matching_properties: [
+            {
+              property: "label",
+              value: identifier.label,
+            },
+          ],
+        };
+      });
+
+      const options = await convertSearchResultToOptions(
+        [],
+        result,
+        api,
+        slice_type,
+        dataType,
+        dataset_id
+      );
+
+      setDefaultOptions(options);
+      setIsLoadingDefaultOptions(false);
+    })();
+  }, [api, slice_type, dataType, dataset_id]);
+
+  return { defaultOptions, isLoadingDefaultOptions };
+};
+
+export const useSearch = (
+  slice_type: string,
+  dataType: string | null,
+  dataset_id: string | null
+) => {
+  const deApi = useDataExplorerApi();
+  const sharedApi = useContext(ApiContext);
+
+  return useCallback(
+    async (input: string) => {
+      const tokens = tokenize(input);
+
+      const result = await sharedApi.getApi().searchDimensions({
+        substring: tokens,
+        type_name: slice_type,
+        limit: 100,
+      });
+
+      return convertSearchResultToOptions(
+        tokens,
+        result,
+        deApi,
+        slice_type,
+        dataType,
+        dataset_id
+      );
+    },
+    [deApi, sharedApi, slice_type, dataType, dataset_id]
+  );
+};
+
+export const usePlaceholder = (slice_type: string) => {
+  const { dimensionType, isDimensionTypeLoading } = useDimensionType(
+    slice_type
+  );
+
+  if (isDimensionTypeLoading || !dimensionType) {
+    return "Select…";
+  }
+
+  return `Choose ${dimensionType.display_name}…`;
+};

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/SliceSelect/utils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/SliceSelect/utils.ts
@@ -1,8 +1,4 @@
-import { useCallback, useContext, useEffect, useState } from "react";
-import { ApiContext } from "@depmap/api";
 import { DataExplorerContextV2 } from "@depmap/types";
-import { useDataExplorerApi } from "../../../contexts/DataExplorerApiContext";
-import { useDimensionType } from "../../../utils/misc";
 
 export const getIdentifier = (context: DataExplorerContextV2 | null) => {
   if (!context?.expr) {
@@ -16,78 +12,13 @@ export const getIdentifier = (context: DataExplorerContextV2 | null) => {
   return context.expr["=="]?.[1] || null;
 };
 
-export const useLabel = (index_type: string | null) => {
-  const { dimensionType, isDimensionTypeLoading } = useDimensionType(
-    index_type
-  );
-
-  if (isDimensionTypeLoading) {
-    return "...";
-  }
-
-  if (!dimensionType) {
-    return "Dimension";
-  }
-
-  return dimensionType.axis === "sample" ? "Feature" : "Sample";
-};
-
-export const useDefaultOptions = (slice_type: string) => {
-  const api = useDataExplorerApi();
-  const [defaultOptions, setDefaultOptions] = useState<
-    { value: string; label: string }[]
-  >([]);
-  const [isLoadingDefaultOptions, setIsLoadingDefaultOptions] = useState(true);
-
-  useEffect(() => {
-    api.fetchDimensionIdentifiers(slice_type).then((identifiers) => {
-      const options = identifiers.map(({ id, label }) => ({
-        value: id,
-        label,
-      }));
-
-      setDefaultOptions(options);
-      setIsLoadingDefaultOptions(false);
-    });
-  }, [api, slice_type]);
-
-  return { defaultOptions, isLoadingDefaultOptions };
-};
-
-function tokenize(input: string | null) {
+export function tokenize(input: string | null) {
   const str = input || "";
   const tokens = str.split(/\s+/g).filter(Boolean);
   const uniqueTokens = new Set(tokens);
 
   return [...uniqueTokens];
 }
-
-export const useSearch = () => {
-  const apiContext = useContext(ApiContext);
-
-  return useCallback(
-    (input: string, type_name: string) => {
-      return apiContext.getApi().searchDimensions({
-        substring: tokenize(input),
-        type_name,
-        limit: 100,
-      });
-    },
-    [apiContext]
-  );
-};
-
-export const usePlaceholder = (slice_type: string) => {
-  const { dimensionType, isDimensionTypeLoading } = useDimensionType(
-    slice_type
-  );
-
-  if (isDimensionTypeLoading || !dimensionType) {
-    return "Select…";
-  }
-
-  return `Choose ${dimensionType.display_name}…`;
-};
 
 export const toOutputValue = (
   slice_type: string,

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/utils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/utils.ts
@@ -65,7 +65,9 @@ export async function inferTypesFromDatasetId(
   }
 
   const ds = await api.fetchDatasetsByIndexType();
-  const dataset = ds[index_type].find((d) => d.id === dataset_id);
+  const dataset = ds[index_type].find((d) => {
+    return d.id === dataset_id || d.given_id === dataset_id;
+  });
 
   if (!dataset) {
     window.console.warn(`Unknown dataset "${dataset_id}"!`);
@@ -108,7 +110,9 @@ export async function findDataType(
   dataset_id: string | null
 ) {
   const datasets = await api.fetchDatasets();
-  const dataset = datasets.find((d) => d.id === dataset_id);
+  const dataset = datasets.find((d) => {
+    return d.id === dataset_id || d.given_id === dataset_id;
+  });
 
   return dataset?.data_type || null;
 }

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/utils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/utils.ts
@@ -51,3 +51,90 @@ export async function inferDataType(
 
   return dataTypes.size === 1 ? [...dataTypes][0] : null;
 }
+
+export async function inferTypesFromDatasetId(
+  api: ReturnType<typeof useDataExplorerApi>,
+  index_type: string | null,
+  dataset_id: string
+) {
+  if (!index_type || !dataset_id) {
+    return {
+      inferredSliceType: undefined,
+      inferredDataType: null,
+    };
+  }
+
+  const ds = await api.fetchDatasetsByIndexType();
+  const dataset = ds[index_type].find((d) => d.id === dataset_id);
+
+  if (!dataset) {
+    window.console.warn(`Unknown dataset "${dataset_id}"!`);
+    return {
+      inferredSliceType: undefined,
+      inferredDataType: null,
+    };
+  }
+
+  return {
+    inferredSliceType: dataset.slice_type,
+    inferredDataType: dataset.data_type,
+  };
+}
+
+export async function inferDatasetId(
+  api: ReturnType<typeof useDataExplorerApi>,
+  index_type: string | null,
+  slice_type: string | null,
+  dataType: string | null
+) {
+  if (!index_type || !slice_type || !dataType) {
+    return undefined;
+  }
+
+  const datasets = await api.fetchDatasetsByIndexType();
+  const ids = new Set<string>();
+
+  datasets[index_type].forEach((dataset) => {
+    if (dataset.slice_type === slice_type && dataset.data_type === dataType) {
+      ids.add(dataset.id);
+    }
+  });
+
+  return ids.size === 1 ? [...ids][0] : undefined;
+}
+
+export async function findDataType(
+  api: ReturnType<typeof useDataExplorerApi>,
+  dataset_id: string | null
+) {
+  const datasets = await api.fetchDatasets();
+  const dataset = datasets.find((d) => d.id === dataset_id);
+
+  return dataset?.data_type || null;
+}
+
+export async function findHighestPriorityDataset(
+  api: ReturnType<typeof useDataExplorerApi>,
+  index_type: string | null,
+  slice_type: string,
+  dataType: string
+) {
+  if (!index_type) {
+    return undefined;
+  }
+
+  const datasets = await api.fetchDatasetsByIndexType();
+  const dataset = datasets[index_type]
+    .filter((d) => {
+      return (
+        d.slice_type === slice_type &&
+        d.data_type === dataType &&
+        d.priority !== null
+      );
+    })
+    .sort((a, b) => {
+      return (a.priority as number) - (b.priority as number);
+    })[0];
+
+  return dataset?.id;
+}

--- a/frontend/packages/@depmap/data-explorer-2/src/contexts/DataExplorerApiContext.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/contexts/DataExplorerApiContext.tsx
@@ -140,8 +140,15 @@ const defaultValue = {
     throw new Error("Not implemented");
   },
 
-  fetchDatasets: (): Promise<Dataset[]> => {
-    window.console.log("fetchDatasets()");
+  fetchDatasets: (
+    options?: Partial<{
+      feature_id: string;
+      feature_type: string;
+      sample_id: string;
+      sample_type: string;
+    }>
+  ): Promise<Dataset[]> => {
+    window.console.log("fetchDatasets:", { options });
     throw new Error("Not implemented");
   },
 
@@ -151,9 +158,24 @@ const defaultValue = {
   },
 
   fetchDimensionIdentifiers: (
-    dimensionTypeName: string
+    dimensionTypeName: string,
+    dataType?: string
   ): Promise<{ id: string; label: string }[]> => {
-    window.console.log("fetchDimensionIdentifiers:", { dimensionTypeName });
+    window.console.log("fetchDimensionIdentifiers:", {
+      dimensionTypeName,
+      dataType,
+    });
+    throw new Error("Not implemented");
+  },
+
+  fetchDatasetIdentifiers: (
+    dimensionTypeName: string,
+    dataset_id: string
+  ): Promise<{ id: string; label: string }[]> => {
+    window.console.log("fetchDatasetIdentifiers:", {
+      dimensionTypeName,
+      dataset_id,
+    });
     throw new Error("Not implemented");
   },
 };

--- a/frontend/packages/@depmap/data-explorer-2/src/styles/ExtendedSelect.scss
+++ b/frontend/packages/@depmap/data-explorer-2/src/styles/ExtendedSelect.scss
@@ -12,19 +12,6 @@
   }
 }
 
-.swatch {
-  display: inline-block;
-  position: relative;
-  top: 0;
-  left: -10px;
-  margin-right: 0;
-  min-width: 10px;
-  min-height: 38px;
-  border: 1px solid #ccc;
-  border-right: none;
-  border-radius: 4px 0 0 4px;
-}
-
 .selectorLabel {
   text-align: start;
   font-size: 12px;
@@ -39,14 +26,27 @@
   }
 }
 
+.swatchContainer {
+  position: absolute;
+}
+
+.swatch {
+  display: inline-block;
+  width: 10px;
+  height: 38px;
+  left: -10px;
+  position: relative;
+  border: 1px solid #ccc;
+  border-right: none;
+  border-radius: 4px 0 0 4px;
+}
+
 .Select {
   display: inline-block;
   width: 162px;
   font-size: 12px;
 
   &.withSwatch {
-    margin-left: -10px;
-
     & > div {
       border-radius: 0 4px 4px 0;
     }

--- a/frontend/packages/@depmap/data-explorer-2/src/utils/extend-react-select.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/extend-react-select.tsx
@@ -302,13 +302,18 @@ export default function extendReactSelect(
 
     return (
       <div ref={innerRef} className={styles.container} {...dataProps}>
-        {swatchColor && (
-          <span
-            className={styles.swatch}
-            style={{ backgroundColor: swatchColor }}
-          />
-        )}
         <span className={styles.ExtendedSelect} ref={ref}>
+          {swatchColor && (
+            <span className={styles.swatchContainer}>
+              <span
+                className={styles.swatch}
+                style={{
+                  backgroundColor: swatchColor,
+                  top: label ? 22 : 0,
+                }}
+              />
+            </span>
+          )}
           {label && (
             <div
               className={cx(styles.selectorLabel, {

--- a/frontend/packages/@depmap/data-explorer-2/src/utils/misc.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/misc.ts
@@ -98,12 +98,21 @@ export const isSampleType = (
   }
 
   if (dimensionTypes) {
-    // ...
+    const dimensionType = dimensionTypes.find(
+      (d) => d.name === dimensionTypeName
+    );
+
+    if (dimensionType) {
+      return dimensionType.axis === "sample";
+    }
   }
 
-  return ["depmap_model", "screen", "model_condition"].includes(
-    dimensionTypeName
-  );
+  return [
+    "depmap_model",
+    "screen",
+    "Screen metadata",
+    "model_condition",
+  ].includes(dimensionTypeName);
 };
 
 export const useDimensionType = (dimensionTypeName: string | null) => {

--- a/frontend/packages/@depmap/data-explorer-2/tsconfig.json
+++ b/frontend/packages/@depmap/data-explorer-2/tsconfig.json
@@ -9,6 +9,7 @@
     { "path": "../downloads" },
     { "path": "../globals" },
     { "path": "../interactive" },
-    { "path": "../types" }
+    { "path": "../types" },
+    { "path": "../utils" }
   ]
 }

--- a/frontend/packages/@depmap/types/src/data-explorer-2.ts
+++ b/frontend/packages/@depmap/types/src/data-explorer-2.ts
@@ -164,12 +164,13 @@ export type ContextPath =
 
 export interface DataExplorerDatasetDescriptor {
   data_type: string;
-  dataset_id: string;
+  id: string;
   index_type: string;
-  slice_type: string;
-  label: string;
-  units: string;
+  given_id: string | null;
+  name: string;
   priority: number | null;
+  slice_type: string;
+  units: string;
 }
 
 type ContextWithoutExprOrVars = {

--- a/frontend/packages/@depmap/utils/index.ts
+++ b/frontend/packages/@depmap/utils/index.ts
@@ -24,3 +24,5 @@ export {
   mutationNumToColor,
   setSelectedCellLineListName,
 } from "./src/colorAndHighlights";
+
+export * from "./src/sort";

--- a/frontend/packages/@depmap/utils/src/sort.ts
+++ b/frontend/packages/@depmap/utils/src/sort.ts
@@ -1,0 +1,24 @@
+const collator = new Intl.Collator("en", { sensitivity: "base" });
+
+export const compareCaseInsensitive = collator.compare;
+
+export const compareDisabledLast = (
+  a: { isDisabled: boolean },
+  b: { isDisabled: boolean }
+) => {
+  if (a.isDisabled && !b.isDisabled) {
+    return 1;
+  }
+
+  if (!a.isDisabled && b.isDisabled) {
+    return -1;
+  }
+
+  return 0;
+};
+
+export const getSortProp = <T>(key: keyof T) => {
+  return (compare: (x: string, y: string) => number) => {
+    return (a: T, b: T): number => compare(String(a[key]), String(b[key]));
+  };
+};

--- a/frontend/packages/elara-frontend/src/api.ts
+++ b/frontend/packages/elara-frontend/src/api.ts
@@ -271,7 +271,7 @@ export class ElaraApi {
       params.groupBy = groupBy;
     }
     return this._fetchWithJsonBody<BreadboxPlotFeatures>(
-      `/api/get-features?${encodeParams(params)}`,
+      `/api/get-features/?${encodeParams(params)}`,
       "POST",
       features
     );
@@ -282,7 +282,7 @@ export class ElaraApi {
   }
 
   getCellLineUrlRoot(): Promise<string> {
-    return this._fetch<string>(`/metadata/cellLineUrlRoot`);
+    return this._fetch<string>(`/metadata/cellLineUrlRoot/`);
   }
 
   getFeedbackUrl(): Promise<string> {
@@ -292,17 +292,17 @@ export class ElaraApi {
   // TODO: Need to move to bbAPI.ts?
   getCitationUrl(datasetId: string): Promise<string> {
     return this._fetch<string>(
-      `/download/citationUrl?${encodeParams({ dataset_id: datasetId })}`
+      `/download/citationUrl/?${encodeParams({ dataset_id: datasetId })}`
     );
   }
 
   exportData(query: ExportDataQuery): Promise<any> {
-    return this._fetchWithJsonBody<any>("/downloads/custom", "POST", query);
+    return this._fetchWithJsonBody<any>("/downloads/custom/", "POST", query);
   }
 
   exportDataForMerge(query: ExportMergedDataQuery): Promise<any> {
     return this._fetchWithJsonBody<any>(
-      "/downloads/custom_merged",
+      "/downloads/custom_merged/",
       "POST",
       query
     );
@@ -312,7 +312,7 @@ export class ElaraApi {
     query: FeatureValidationQuery
   ): Promise<ValidationResult> {
     return this._fetchWithJsonBody<any>(
-      "/downloads/data_slicer/validate_data_slicer_features",
+      "/downloads/data_slicer/validate_data_slicer_features/",
       "POST",
       query
     );
@@ -327,11 +327,11 @@ export class ElaraApi {
   }
 
   getDatasetsList(): Promise<DatasetDownloadMetadata[]> {
-    return this._fetch<DatasetDownloadMetadata[]>("/datasets");
+    return this._fetch<DatasetDownloadMetadata[]>("/datasets/");
   }
 
   getDatasets(): Promise<any> {
-    return this._fetch<Dataset[]>("/datasets").then((datasets) =>
+    return this._fetch<Dataset[]>("/datasets/").then((datasets) =>
       datasets.map(({ id, name }) => ({ label: name, value: id }))
     );
   }
@@ -344,7 +344,7 @@ export class ElaraApi {
   }
 
   postFileUpload(fileArgs: { file: File | Blob }): Promise<UploadFileResponse> {
-    return this._postMultipart<UploadFileResponse>("/uploads/file", fileArgs);
+    return this._postMultipart<UploadFileResponse>("/uploads/file/", fileArgs);
   }
 
   postDatasetUpload(datasetParams: DatasetParams): Promise<any> {
@@ -367,11 +367,11 @@ export class ElaraApi {
   }
 
   getBreadboxDatasets(): Promise<Dataset[]> {
-    return this._fetch<Dataset[]>("/datasets");
+    return this._fetch<Dataset[]>("/datasets/");
   }
 
   deleteDatasets(id: string) {
-    return this._delete("/datasets", id);
+    return this._delete("/datasets/", id);
   }
 
   patchDataset(datasetToUpdate: DatasetUpdateArgs): Promise<Dataset> {
@@ -522,7 +522,7 @@ export class ElaraApi {
   }
 
   deleteFeatureType(name: string) {
-    return this._delete("/types/feature", name);
+    return this._delete("/types/feature/", name);
   }
 
   searchDimensions({
@@ -552,15 +552,15 @@ export class ElaraApi {
   }
 
   getGroups(): Promise<Group[]> {
-    return this._fetch<Group[]>("/groups");
+    return this._fetch<Group[]>("/groups/");
   }
 
   postGroup(groupArgs: GroupArgs): Promise<Group> {
-    return this._fetchWithJsonBody<Group>("/groups", "POST", groupArgs);
+    return this._fetchWithJsonBody<Group>("/groups/", "POST", groupArgs);
   }
 
   deleteGroup(id: string) {
-    return this._delete("/groups", id);
+    return this._delete("/groups/", id);
   }
 
   postGroupEntry(
@@ -568,7 +568,7 @@ export class ElaraApi {
     groupEntryArgs: GroupEntryArgs
   ): Promise<GroupEntry> {
     return this._fetchWithJsonBody<GroupEntry>(
-      `/groups/${groupId}/addAccess`,
+      `/groups/${groupId}/addAccess/`,
       "POST",
       groupEntryArgs
     );
@@ -718,7 +718,7 @@ export class ElaraApi {
       prefix,
     };
     return this._fetch<any>(
-      `/datasets/vector_catalog/data/catalog/children?${encodeParams(params)}`
+      `/datasets/vector_catalog/data/catalog/children/?${encodeParams(params)}`
     ).then((res) => {
       // FIXME: This is a workaround for the case where the response is empty.
       // The existing Data Explorer logic tries to rename properties of a
@@ -737,7 +737,7 @@ export class ElaraApi {
     // chances are, you shouldn't be using this. use getVectorCatalogPath in vectorCatalogApi, which wraps around this
     const params = { catalog, id };
     return this._fetch<Array<any>>(
-      `/datasets/vector_catalog/data/catalog/path?${encodeParams(params)}`
+      `/datasets/vector_catalog/data/catalog/path/?${encodeParams(params)}`
     );
   }
 
@@ -745,7 +745,7 @@ export class ElaraApi {
     // The Portal uses a dedicated endpoint to get a single feature. Here we're
     // using /api/get-features instead and re-formatting the response.
     return this._fetchWithJsonBody<BreadboxPlotFeatures>(
-      `/api/get-features`,
+      `/api/get-features/`,
       "POST",
       [featureCatalogNodeId]
     ).then((res) => {
@@ -764,7 +764,7 @@ export class ElaraApi {
     config: UnivariateAssociationsParams
   ): Promise<ComputeResponse> {
     return this._fetchWithJsonBody<ComputeResponse>(
-      "/compute/compute_univariate_associations",
+      "/compute/compute_univariate_associations/",
       "POST",
       config
     );

--- a/frontend/packages/elara-frontend/src/modals/ElaraContextManager.tsx
+++ b/frontend/packages/elara-frontend/src/modals/ElaraContextManager.tsx
@@ -10,6 +10,7 @@ import {
   evaluateContext,
   fetchDatasets,
   fetchDatasetsByIndexType,
+  fetchDatasetIdentifiers,
   fetchDimensionIdentifiers,
   fetchDimensionTypes,
   fetchVariableDomain,
@@ -41,6 +42,7 @@ function ElaraContextManager({ onHide }: Props) {
         fetchVariableDomain={fetchVariableDomain}
         fetchDatasets={fetchDatasets}
         fetchDimensionTypes={fetchDimensionTypes}
+        fetchDatasetIdentifiers={fetchDatasetIdentifiers}
         fetchDimensionIdentifiers={fetchDimensionIdentifiers}
       >
         <ContextManager

--- a/frontend/packages/elara-frontend/src/pages/DataExplorer/api.ts
+++ b/frontend/packages/elara-frontend/src/pages/DataExplorer/api.ts
@@ -134,7 +134,9 @@ export async function fetchVariableDomain(
   let value_type: AnnotationType | undefined;
 
   const datasets = await fetchDatasets();
-  const dataset = datasets.find((d) => d.id === dataset_id);
+  const dataset = datasets.find((d) => {
+    return d.id === dataset_id || d.given_id === dataset_id;
+  });
 
   if (dataset && dataset.format === "matrix_dataset") {
     value_type = dataset.value_type as AnnotationType;

--- a/frontend/packages/elara-frontend/src/pages/DataExplorer/api.ts
+++ b/frontend/packages/elara-frontend/src/pages/DataExplorer/api.ts
@@ -1,3 +1,4 @@
+import qs from "qs";
 import {
   AnnotationType,
   DataExplorerContextV2,
@@ -7,6 +8,7 @@ import {
   DimensionType,
   MatrixDataset,
 } from "@depmap/types";
+import { compareCaseInsensitive } from "@depmap/utils";
 
 let urlPrefix = "";
 
@@ -107,8 +109,21 @@ export async function evaluateContext(
   }>("/temp/context", contextToEval);
 }
 
-export function fetchDatasets() {
-  return fetchJson<Dataset[]>("/datasets/");
+export function fetchDatasets(
+  options?: Partial<{
+    feature_id: string;
+    feature_type: string;
+    sample_id: string;
+    sample_type: string;
+  }>
+) {
+  let url = "/datasets/";
+
+  if (options) {
+    url += `?${qs.stringify(options)}`;
+  }
+
+  return fetchJson<Dataset[]>(url);
 }
 
 export async function fetchVariableDomain(
@@ -164,7 +179,7 @@ export async function fetchVariableDomain(
     ) as string[];
 
     return Promise.resolve({
-      unique_values: [...new Set(stringValues)].sort(),
+      unique_values: [...new Set(stringValues)].sort(compareCaseInsensitive),
       value_type,
     });
   }
@@ -198,40 +213,56 @@ export async function fetchDatasetsByIndexType() {
   datasetsByIndexType = {};
 
   datasets.forEach((dataset) => {
+    // TODO: add support for tabular datasets
     if (dataset.format !== "matrix_dataset") {
       return;
     }
 
+    // TODO: add support for other value types
     if (dataset.value_type !== "continuous") {
       return;
     }
 
-    const md = dataset as MatrixDataset;
+    // TODO: add support for `null` dimension types
+    if (!dataset.sample_type_name || !dataset.feature_type_name) {
+      return;
+    }
+
+    const {
+      data_type,
+      id,
+      given_id,
+      name,
+      priority,
+      units,
+      sample_type_name,
+      feature_type_name,
+    } = dataset as MatrixDataset;
 
     const commonProperties = {
-      data_type: md.data_type,
-      dataset_id: md.id,
-      given_id: md.given_id,
-      label: md.name,
-      priority: md.priority,
-      units: md.units,
+      data_type,
+      given_id,
+      id,
+      name,
+      priority,
+      units,
     };
 
-    datasetsByIndexType![md.sample_type_name] = [
-      ...(datasetsByIndexType![md.sample_type_name] || []),
+    datasetsByIndexType![sample_type_name] = [
+      ...(datasetsByIndexType![sample_type_name] || []),
       {
         ...commonProperties,
-        index_type: md.sample_type_name,
-        slice_type: md.feature_type_name,
+        index_type: sample_type_name,
+        slice_type: feature_type_name,
       },
     ];
 
-    datasetsByIndexType![md.feature_type_name] = [
-      ...(datasetsByIndexType![md.feature_type_name] || []),
+    datasetsByIndexType![feature_type_name] = [
+      ...(datasetsByIndexType![feature_type_name] || []),
       {
         ...commonProperties,
-        index_type: md.feature_type_name,
-        slice_type: md.sample_type_name,
+        index_type: feature_type_name,
+        slice_type: sample_type_name,
       },
     ];
   });
@@ -243,8 +274,12 @@ export function fetchDimensionTypes() {
   return fetchJson<DimensionType[]>("/types/dimensions");
 }
 
-// TODO: Rewrite this to use /types/dimensions/{name}/identifiers
-export async function fetchDimensionIdentifiers(dimensionTypeName: string) {
+type Identifiers = { id: string; label: string }[];
+
+export async function fetchDimensionIdentifiers(
+  dimensionTypeName: string,
+  dataType?: string
+) {
   const dimensionTypes = await fetchDimensionTypes();
   const dimType = dimensionTypes.find((t) => t.name === dimensionTypeName);
 
@@ -252,19 +287,27 @@ export async function fetchDimensionIdentifiers(dimensionTypeName: string) {
     throw new Error(`Unrecognized dimension type "${dimensionTypeName}"!`);
   }
 
-  const data = await postJson<{
-    ids: string[];
-    // labels: string[];
-    values: string[];
-  }>("/datasets/dimension/data/", {
-    dataset_id: dimType.metadata_dataset_id,
-    // HACK: There's a bug where the labels we get are actually ids! We'll
-    // request "label" as the identifier instead.
-    identifier: "label",
-    identifier_type: "column",
-  });
+  const url = [
+    `/types/dimensions/${dimensionTypeName}/identifiers`,
+    "?show_only_dimensions_in_datasets=true",
+    dataType ? `&data_type=${dataType}` : "",
+  ].join("");
 
-  return data.ids
-    .map((id, index) => ({ id, label: data.values[index] }))
-    .sort((a, b) => (a.label.toLowerCase() < b.label.toLowerCase() ? -1 : 1));
+  return fetchJson<Identifiers>(url);
+}
+
+export async function fetchDatasetIdentifiers(
+  dimensionTypeName: string,
+  dataset_id: string
+) {
+  const dimensionTypes = await fetchDimensionTypes();
+  const dimType = dimensionTypes.find((t) => t.name === dimensionTypeName);
+
+  if (!dimType) {
+    throw new Error(`Unrecognized dimension type "${dimensionTypeName}"!`);
+  }
+
+  const featuresOrSamples = dimType.axis === "feature" ? "features" : "samples";
+
+  return fetchJson<Identifiers>(`/datasets/${featuresOrSamples}/${dataset_id}`);
 }

--- a/frontend/packages/portal-frontend/src/data-explorer-2/__tests__/query-string-parser.test.ts
+++ b/frontend/packages/portal-frontend/src/data-explorer-2/__tests__/query-string-parser.test.ts
@@ -1,14 +1,19 @@
 import qs from "qs";
+import { DataExplorerDatasetDescriptor } from "@depmap/types";
 import { parseShorthandParams } from "src/data-explorer-2/query-string-parser";
 
-const MOCK_DATASETS_BY_INDEX_TYPE = {
+const MOCK_DATASETS_BY_INDEX_TYPE: Record<
+  string,
+  DataExplorerDatasetDescriptor[]
+> = {
   depmap_model: [
     {
       data_type: "CRISPR",
-      dataset_id: "Chronos_Combined",
+      id: "1",
+      given_id: "Chronos_Combined",
       slice_type: "gene",
       index_type: "depmap_model",
-      label: "CRISPR (DepMap Internal 23Q2+Score, Chronos)",
+      name: "CRISPR (DepMap Internal 23Q2+Score, Chronos)",
       units: "Gene effect",
       priority: 42,
     },
@@ -16,10 +21,11 @@ const MOCK_DATASETS_BY_INDEX_TYPE = {
   gene: [
     {
       data_type: "CRISPR",
-      dataset_id: "Chronos_Combined",
+      id: "1",
+      given_id: "Chronos_Combined",
       slice_type: "depmap_model",
       index_type: "gene",
-      label: "CRISPR (DepMap Internal 23Q2+Score, Chronos)",
+      name: "CRISPR (DepMap Internal 23Q2+Score, Chronos)",
       units: "Gene effect",
       priority: 42,
     },

--- a/frontend/packages/portal-frontend/src/data-explorer-2/query-string-parser.ts
+++ b/frontend/packages/portal-frontend/src/data-explorer-2/query-string-parser.ts
@@ -42,7 +42,9 @@ const makeFeatureParser = (dimensionKey: DimensionKey) => (
     return partialPlot;
   }
 
-  const dataset = datasets.depmap_model.find((d) => d.id === dataset_id);
+  const dataset = datasets.depmap_model.find((d) => {
+    return d.id === dataset_id || d.given_id === dataset_id;
+  });
 
   const slice_type = dataset ? dataset.slice_type : "custom";
 
@@ -189,7 +191,9 @@ const inferIndexType = (
     return "depmap_model";
   }
 
-  const dataset = datasets[slice_type].find((d) => d.id === dataset_id);
+  const dataset = datasets[slice_type].find((d) => {
+    return d.id === dataset_id || d.given_id === dataset_id;
+  });
 
   return dataset?.slice_type || null;
 };

--- a/frontend/packages/portal-frontend/src/data-explorer-2/query-string-parser.ts
+++ b/frontend/packages/portal-frontend/src/data-explorer-2/query-string-parser.ts
@@ -42,9 +42,7 @@ const makeFeatureParser = (dimensionKey: DimensionKey) => (
     return partialPlot;
   }
 
-  const dataset = datasets.depmap_model.find(
-    (d) => d.dataset_id === dataset_id
-  );
+  const dataset = datasets.depmap_model.find((d) => d.id === dataset_id);
 
   const slice_type = dataset ? dataset.slice_type : "custom";
 
@@ -191,7 +189,7 @@ const inferIndexType = (
     return "depmap_model";
   }
 
-  const dataset = datasets[slice_type].find((d) => d.dataset_id === dataset_id);
+  const dataset = datasets[slice_type].find((d) => d.id === dataset_id);
 
   return dataset?.slice_type || null;
 };

--- a/frontend/packages/portal-frontend/src/secretDataViewer/components/Stats/DataTypes.tsx
+++ b/frontend/packages/portal-frontend/src/secretDataViewer/components/Stats/DataTypes.tsx
@@ -37,11 +37,9 @@ function DataTypes({
             featureType: selectedEntityType,
           })
             .filter((d) => {
-              return (
-                !contextDatasetIds || contextDatasetIds.includes(d.dataset_id)
-              );
+              return !contextDatasetIds || contextDatasetIds.includes(d.id);
             })
-            .map((d) => d.dataset_id)
+            .map((d) => d.id)
         );
 
         return (
@@ -51,9 +49,7 @@ function DataTypes({
             className={cx({
               [styles.disabled]:
                 (selectedDataType && dataType !== selectedDataType) ||
-                relevantDatasets.every(
-                  (d) => !viableDatasets.has(d.dataset_id)
-                ),
+                relevantDatasets.every((d) => !viableDatasets.has(d.id)),
             })}
             tooltip={
               <div>
@@ -75,7 +71,7 @@ function DataTypes({
                         <b>{featureType}</b>
                         <ul>
                           {ds.map((d) => (
-                            <li key={d.dataset_id}>{d.label}</li>
+                            <li key={d.id}>{d.name}</li>
                           ))}
                         </ul>
                       </li>

--- a/frontend/packages/portal-frontend/src/secretDataViewer/components/Stats/Datasets.tsx
+++ b/frontend/packages/portal-frontend/src/secretDataViewer/components/Stats/Datasets.tsx
@@ -59,7 +59,7 @@ function Datasets({
               (selectedDataType && d.data_type !== selectedDataType) ||
               (selectedEntityType && d.slice_type !== selectedEntityType) ||
               (contextDatasetIds && !contextDatasetIds.includes(d.id)),
-            [styles.selected]: d.id === dataset_id,
+            [styles.selected]: d.id === dataset_id || d.given_id === dataset_id,
           })}
           key={d.id}
           value={

--- a/frontend/packages/portal-frontend/src/secretDataViewer/components/Stats/Datasets.tsx
+++ b/frontend/packages/portal-frontend/src/secretDataViewer/components/Stats/Datasets.tsx
@@ -32,7 +32,7 @@ function isHighestPriorityOfDataType(
       if (
         d.priority !== null &&
         d.priority < best &&
-        (!contextDatasetIds || contextDatasetIds.includes(d.dataset_id))
+        (!contextDatasetIds || contextDatasetIds.includes(d.id))
       ) {
         best = d.priority;
       }
@@ -58,13 +58,13 @@ function Datasets({
             [styles.disabled]:
               (selectedDataType && d.data_type !== selectedDataType) ||
               (selectedEntityType && d.slice_type !== selectedEntityType) ||
-              (contextDatasetIds && !contextDatasetIds.includes(d.dataset_id)),
-            [styles.selected]: d.dataset_id === dataset_id,
+              (contextDatasetIds && !contextDatasetIds.includes(d.id)),
+            [styles.selected]: d.id === dataset_id,
           })}
-          key={d.dataset_id}
+          key={d.id}
           value={
             <span>
-              {d.label}{" "}
+              {d.name}{" "}
               <span className={styles.star}>
                 {isHighestPriorityOfDataType(
                   datasets,
@@ -87,7 +87,7 @@ function Datasets({
                     selectedDataType && d.data_type !== selectedDataType,
                 })}
               >
-                {getDataType(datasets, d.dataset_id)}
+                {getDataType(datasets, d.id)}
               </div>
               <br />
               <h3>Feature Type</h3>
@@ -97,12 +97,12 @@ function Datasets({
                     selectedEntityType && d.slice_type !== selectedEntityType,
                 })}
               >
-                {getFeatureType(datasets, d.dataset_id)}
+                {getFeatureType(datasets, d.id)}
               </div>
               <br />
               <h3>Dataset ID</h3>
               <div>
-                <WordBreaker text={d.dataset_id} />
+                <WordBreaker text={d.id} />
               </div>
               <br />
               <h3>Priority</h3>

--- a/frontend/packages/portal-frontend/src/secretDataViewer/components/Stats/FeatureTypes.tsx
+++ b/frontend/packages/portal-frontend/src/secretDataViewer/components/Stats/FeatureTypes.tsx
@@ -55,7 +55,7 @@ function FeatureTypes({
                       <b>{dataType}</b>
                       <ul>
                         {ds.map((d) => (
-                          <li key={d.dataset_id}>{d.label}</li>
+                          <li key={d.id}>{d.name}</li>
                         ))}
                       </ul>
                     </li>

--- a/frontend/packages/portal-frontend/src/secretDataViewer/components/Stats/utils.ts
+++ b/frontend/packages/portal-frontend/src/secretDataViewer/components/Stats/utils.ts
@@ -16,7 +16,7 @@ export function getDataType(
   datasets: DataExplorerDatasetDescriptor[],
   dataset_id: string
 ) {
-  return datasets.find((d) => d.dataset_id === dataset_id)!.data_type;
+  return datasets.find((d) => d.id === dataset_id)!.data_type;
 }
 
 export function getDataTypes(
@@ -38,7 +38,7 @@ export function getFeatureType(
   datasets: DataExplorerDatasetDescriptor[],
   dataset_id: string
 ) {
-  return datasets.find((d) => d.dataset_id === dataset_id)!.slice_type;
+  return datasets.find((d) => d.id === dataset_id)!.slice_type;
 }
 
 export function getFeatureTypes(

--- a/frontend/packages/portal-frontend/src/secretDataViewer/components/Stats/utils.ts
+++ b/frontend/packages/portal-frontend/src/secretDataViewer/components/Stats/utils.ts
@@ -16,7 +16,8 @@ export function getDataType(
   datasets: DataExplorerDatasetDescriptor[],
   dataset_id: string
 ) {
-  return datasets.find((d) => d.id === dataset_id)!.data_type;
+  return datasets.find((d) => d.id === dataset_id || d.given_id === dataset_id)!
+    .data_type;
 }
 
 export function getDataTypes(
@@ -38,7 +39,8 @@ export function getFeatureType(
   datasets: DataExplorerDatasetDescriptor[],
   dataset_id: string
 ) {
-  return datasets.find((d) => d.id === dataset_id)!.slice_type;
+  return datasets.find((d) => d.id === dataset_id || d.given_id === dataset_id)!
+    .slice_type;
 }
 
 export function getFeatureTypes(

--- a/portal-backend/depmap/data_explorer_2/views.py
+++ b/portal-backend/depmap/data_explorer_2/views.py
@@ -337,9 +337,9 @@ def datasets_by_index_type():
     for dataset in get_all_supported_continuous_datasets():
         common_props = {
             "data_type": dataset.data_type,
-            "dataset_id": dataset.id,
+            "id": dataset.id,
             "given_id": dataset.given_id,
-            "label": dataset.label,
+            "name": dataset.label,
             "units": dataset.units,
             "priority": dataset.priority,
         }
@@ -361,7 +361,7 @@ def datasets_by_index_type():
         )
 
     for index_type, dataset in output.items():
-        output[index_type] = sorted(dataset, key=lambda dataset: dataset["label"],)
+        output[index_type] = sorted(dataset, key=lambda dataset: dataset["name"])
 
     return make_gzipped_json_response(output)
 
@@ -479,7 +479,7 @@ def evaluate_v2_context():
 
     matching_ids, matching_labels = get_ids_and_labels_matching_context(context)
 
-    return make_gzipped_json_response({"ids": matching_ids, "labels": matching_labels,})
+    return make_gzipped_json_response({"ids": matching_ids, "labels": matching_labels})
 
 
 @blueprint.route("/v2/context/summary", methods=["POST"])


### PR DESCRIPTION
This brings the new feature selection component (DimensionSelectV2) closer to the behavior of the original. It leverages some new Breadbox APIs to implement auto-selection and tooltips to help you figure out which features are compatible with which datasets.

It now works well enough to be suitable for many use cases but it does not yet allow you to select a context or get details about the selected data version.