### PR TITLE
fix(breadbox): Fix categorical datasets validation

### DIFF
--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -229,13 +229,6 @@ def add_matrix_dataset(
 
     allowed_values = dataset_in.allowed_values
 
-    def is_binary_category(allowed_values_list):
-        if allowed_values_list and len(allowed_values_list) == 2:
-            allowed_values_set = set(allowed_values_list)
-            return {"True", "False"} == allowed_values_set
-        else:
-            return False
-
     dataset = MatrixDataset(
         id=dataset_in.id,
         given_id=dataset_in.given_id,

--- a/breadbox/breadbox/schemas/dataset.py
+++ b/breadbox/breadbox/schemas/dataset.py
@@ -180,10 +180,12 @@ class MatrixDatasetParams(SharedDatasetParams):
 
     @field_validator("allowed_values", mode="after")
     @classmethod
-    def check_valid_allowed_values(cls, v: List[str]):
+    def check_valid_allowed_values(cls, v: Optional[List[str]]):
         """
         Checks there are no empty strings and no repeated allowed values. Values in allowed values list are not case-sensitive.
         """
+        if v is None:
+            return v
         # Decision to make allowed values not case-sensitive in case user error in accidental repeats
         allowed_values_list_lower = [str(x).lower() for x in v]
         allowed_values_set = set(allowed_values_list_lower)

--- a/breadbox/breadbox/schemas/dataset.py
+++ b/breadbox/breadbox/schemas/dataset.py
@@ -115,20 +115,6 @@ class SharedDatasetParams(BaseModel):
             raise ValueError("Must be hex string")
 
 
-def check_allowed_values_not_empty(v):
-    if v == "":
-        raise UserError("Empty strings are not allowed.")
-    allowed_values_list_lower = [str(x).lower() for x in v]
-    if len(set(allowed_values_list_lower)) != len(v):
-        raise UserError(
-            msg="Make sure there are no repeats in allowed_values. Values are not considered case-sensitive",
-        )
-    return v
-
-
-AllowedValue = Annotated[str, AfterValidator(check_allowed_values_not_empty)]
-
-
 class MatrixDatasetParams(SharedDatasetParams):
     format: Literal["matrix"]
     units: Annotated[
@@ -147,7 +133,7 @@ class MatrixDatasetParams(SharedDatasetParams):
         ),
     ]
     allowed_values: Annotated[
-        Optional[List[AllowedValue]],
+        Optional[List[str]],
         Field(
             description="Only provide if 'value_type' is 'categorical'. Must contain all possible categorical values",
         ),
@@ -191,6 +177,25 @@ class MatrixDatasetParams(SharedDatasetParams):
                 "Must include allowed_values for categorical value type datasets!"
             )
         return self
+
+    @field_validator("allowed_values", mode="after")
+    @classmethod
+    def check_valid_allowed_values(cls, v: List[str]):
+        """
+        Checks there are no empty strings and no repeated allowed values. Values in allowed values list are not case-sensitive.
+        """
+        # Decision to make allowed values not case-sensitive in case user error in accidental repeats
+        allowed_values_list_lower = [str(x).lower() for x in v]
+        allowed_values_set = set(allowed_values_list_lower)
+        print(allowed_values_set, allowed_values_list_lower)
+        if len(allowed_values_set) != len(v):
+            raise UserError(
+                msg="Make sure there are no repeats in allowed_values. Values are not considered case-sensitive",
+            )
+        for val in allowed_values_set:
+            if val == "":
+                raise UserError("Empty strings are not allowed!")
+        return v
 
 
 class ColumnMetadata(BaseModel):

--- a/frontend/packages/@depmap/dataset-manager/package.json
+++ b/frontend/packages/@depmap/dataset-manager/package.json
@@ -14,6 +14,7 @@
     "@depmap/common-components": "1.0.0",
     "@depmap/types": "1.0.0",
     "@depmap/wide-table": "1.0.0",
+    "@depmap/compute": "1.0.0",
     "@rjsf/core": "^5.18.3",
     "@rjsf/utils": "^5.18.3",
     "@rjsf/validator-ajv8": "^5.18.3",

--- a/frontend/packages/@depmap/dataset-manager/src/components/DatasetForm.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/DatasetForm.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { MatrixDatasetForm } from "./MatrixDatasetForm";
 import { TableDatasetForm } from "./TableDatasetForm";
 import { FormGroup, Radio } from "react-bootstrap";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useCallback } from "react";
 import { matrixFormSchema } from "../models/matrixDatasetFormSchema";
 import { tableFormSchema } from "../models/tableDatasetFormSchema";
 import {
@@ -15,8 +15,11 @@ import {
   DimensionType,
   SampleDimensionType,
   FeatureDimensionType,
+  Dataset,
 } from "@depmap/types";
 import ChunkedFileUploader from "./ChunkedFileUploader";
+import { CeleryTask } from "@depmap/compute";
+import progressTrackerStyles from "@depmap/common-components/src/styles/ProgressTracker.scss";
 
 interface DatasetFormProps {
   getDimensionTypes: () => Promise<DimensionType[]>;
@@ -24,6 +27,8 @@ interface DatasetFormProps {
   getGroups: () => Promise<Group[]>;
   uploadFile: (fileArgs: { file: File | Blob }) => Promise<UploadFileResponse>;
   uploadDataset: (datasetParams: DatasetParams) => Promise<any>;
+  getTaskStatus: (taskIds: string) => Promise<CeleryTask>;
+  onSuccess: (dataset: Dataset) => void;
   isAdvancedMode: boolean;
 }
 
@@ -34,6 +39,8 @@ export default function DatasetForm(props: DatasetFormProps) {
     getDataTypesAndPriorities,
     uploadFile,
     uploadDataset,
+    getTaskStatus,
+    onSuccess,
     isAdvancedMode,
   } = props;
 
@@ -102,6 +109,12 @@ export default function DatasetForm(props: DatasetFormProps) {
     setInvalidPrioritiesByDataType,
   ] = useState<InvalidPrioritiesByDataType>({});
   const [dataTypeOptions, setDataTypeOptions] = useState<DataType[]>([]);
+  const [isTaskRunning, setIsTaskRunning] = React.useState(false);
+  // Completed task (either failed or successful)
+  const [completedTask, setCompletedTask] = React.useState<
+    CeleryTask | undefined
+  >(undefined);
+
   console.log(selectedFormat);
   console.log(formContent);
 
@@ -136,13 +149,92 @@ export default function DatasetForm(props: DatasetFormProps) {
         setGroupsOptions(groups);
       } catch (e) {
         console.error(e);
-        // setInitFetchError(true);
       }
     })();
   }, [getDimensionTypes, getGroups, getDataTypesAndPriorities]);
 
+  /**
+    checkStatus and reject functions influenced by ProgressTracker.tsx
+
+    For normal, expected user input errors, the back end returns 200 with state failure
+    Caught errors still return 200 in task poll but task state reflects failure
+    For unexpected failure modes, the back end returns 500. This is so that the error gets sent to stackdriver
+    For these unexpected errors, we catch the 500, and mimic the response from a failed-gracefully-with-200
+  */
+  const reject = useCallback((res: any) => {
+    const isCeleryTask = (x: any): x is CeleryTask => x.state !== undefined;
+    if (!isCeleryTask(res)) {
+      setCompletedTask({
+        id: "",
+        state: "FAILURE",
+        percentComplete: undefined,
+        message:
+          "Unexpected error. If you get this error consistently, please contact us with a screenshot and the actions that lead to this error.",
+        result: null,
+      });
+    } else {
+      setCompletedTask(res);
+    }
+    setIsTaskRunning(false);
+  }, []);
+
+  const checkStatus = useCallback(
+    (response: CeleryTask) => {
+      console.log("Polled Response", response);
+      const later = (delay: number): Promise<any> => {
+        return new Promise((res) => {
+          setTimeout(res, delay);
+        });
+      };
+
+      if (response.state === "SUCCESS") {
+        setIsTaskRunning(false);
+        setCompletedTask(response);
+        onSuccess(response.result.dataset);
+      } else if (response.state === "FAILURE") {
+        setIsTaskRunning(false);
+        setCompletedTask(response);
+      } else {
+        const nextPollDelay = response.nextPollDelay;
+        later(nextPollDelay || 0)
+          .then(() => {
+            return getTaskStatus(response.id);
+          })
+          .then(checkStatus, reject);
+      }
+    },
+    [getTaskStatus, onSuccess, reject]
+  );
+
+  const submissionMessage = useMemo(() => {
+    if (completedTask?.state === "SUCCESS" && !isTaskRunning) {
+      return (
+        <div>
+          <div style={{ color: "green" }}>SUCCESS!</div>
+          {completedTask.result.unknownIDs.length > 0 ? (
+            <div style={{ color: "goldenrod" }}>
+              WARNING: Unknown IDS:{" "}
+              {JSON.parse(completedTask.result.unknownIDs)}
+            </div>
+          ) : null}
+        </div>
+      );
+    }
+    if (completedTask?.state === "FAILURE" && !isTaskRunning) {
+      return (
+        <div style={{ color: "red" }}>FAILED: {completedTask.message}!</div>
+      );
+    }
+    if (isTaskRunning) {
+      return (
+        <div className={progressTrackerStyles.loadingEllipsis}>LOADING</div>
+      );
+    }
+    return null;
+  }, [isTaskRunning, completedTask]);
+
   const formComponent = useMemo(() => {
-    const onSubmitForm = (formData: { [key: string]: any }) => {
+    const onSubmitForm = async (formData: { [key: string]: any }) => {
       // TODO: add callback to clear form? and try catch?
       let formToSubmit = { ...formData };
       if (
@@ -157,29 +249,35 @@ export default function DatasetForm(props: DatasetFormProps) {
         };
       }
       console.log("form submitted: ", formToSubmit);
-      uploadDataset(formToSubmit as DatasetParams);
+
+      setCompletedTask(undefined);
+      setIsTaskRunning(true);
+      uploadDataset(formToSubmit as DatasetParams).then(checkStatus, reject);
     };
 
     if (selectedFormat === "matrix") {
       return (
-        <MatrixDatasetForm
-          featureTypes={featureTypeOptions}
-          sampleTypes={sampleTypeOptions}
-          groups={groupOptions}
-          dataTypes={dataTypeOptions}
-          invalidDataTypePriorities={invalidPrioritiesByDataType}
-          initFormData={formContent.matrix}
-          fileIds={fileIds}
-          md5Hash={md5Hash}
-          forwardFormData={(formData: { [key: string]: string }) => {
-            setFormContent({
-              ...formContent,
-              matrix: formData,
-            });
-          }}
-          onSubmitForm={onSubmitForm}
-          isAdvancedMode={isAdvancedMode}
-        />
+        <>
+          <MatrixDatasetForm
+            featureTypes={featureTypeOptions}
+            sampleTypes={sampleTypeOptions}
+            groups={groupOptions}
+            dataTypes={dataTypeOptions}
+            invalidDataTypePriorities={invalidPrioritiesByDataType}
+            initFormData={formContent.matrix}
+            fileIds={fileIds}
+            md5Hash={md5Hash}
+            forwardFormData={(formData: { [key: string]: string }) => {
+              setFormContent({
+                ...formContent,
+                matrix: formData,
+              });
+            }}
+            onSubmitForm={onSubmitForm}
+            isAdvancedMode={isAdvancedMode}
+          />
+          {submissionMessage}
+        </>
       );
     }
     if (selectedFormat === "table") {
@@ -187,22 +285,25 @@ export default function DatasetForm(props: DatasetFormProps) {
         sampleTypeOptions
       );
       return (
-        <TableDatasetForm
-          dimensionTypes={dimensionTypeOptions}
-          groups={groupOptions}
-          dataTypes={dataTypeOptions}
-          invalidDataTypePriorities={invalidPrioritiesByDataType}
-          initFormData={formContent.table}
-          fileIds={fileIds}
-          md5Hash={md5Hash}
-          forwardFormData={(formData: { [key: string]: string }) => {
-            setFormContent({
-              ...formContent,
-              table: formData,
-            });
-          }}
-          onSubmitForm={onSubmitForm}
-        />
+        <>
+          <TableDatasetForm
+            dimensionTypes={dimensionTypeOptions}
+            groups={groupOptions}
+            dataTypes={dataTypeOptions}
+            invalidDataTypePriorities={invalidPrioritiesByDataType}
+            initFormData={formContent.table}
+            fileIds={fileIds}
+            md5Hash={md5Hash}
+            forwardFormData={(formData: { [key: string]: string }) => {
+              setFormContent({
+                ...formContent,
+                table: formData,
+              });
+            }}
+            onSubmitForm={onSubmitForm}
+          />
+          {submissionMessage}
+        </>
       );
     }
 
@@ -210,6 +311,8 @@ export default function DatasetForm(props: DatasetFormProps) {
   }, [
     selectedFormat,
     uploadDataset,
+    checkStatus,
+    reject,
     featureTypeOptions,
     sampleTypeOptions,
     groupOptions,
@@ -219,6 +322,7 @@ export default function DatasetForm(props: DatasetFormProps) {
     fileIds,
     md5Hash,
     isAdvancedMode,
+    submissionMessage,
   ]);
 
   const handleOnChange = (e: any) => {

--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -72,6 +72,11 @@ export default function Datasets() {
     [dapi]
   );
 
+  const getTaskStatus = useCallback(
+    (task_id: string) => dapi.getTaskStatus(task_id),
+    [dapi]
+  );
+
   const [dimensionTypes, setDimensionTypes] = useState<any[] | null>(null);
   const [selectedDimensionType, setSelectedDimensionType] = useState<
     any | null
@@ -180,6 +185,10 @@ export default function Datasets() {
             uploadFile={postFileUpload}
             uploadDataset={postDatasetUpload}
             isAdvancedMode={isAdvancedMode}
+            getTaskStatus={getTaskStatus}
+            onSuccess={(dataset: Dataset) =>
+              setDatasets([...datasets, dataset])
+            }
           />
         );
       }
@@ -197,17 +206,18 @@ export default function Datasets() {
     }
     return null;
   }, [
-    datasetToEdit,
     datasets,
-    getDataTypesAndPriorities,
-    getDimensionTypes,
-    getGroups,
     isEditDatasetMode,
-    postDatasetUpload,
-    postFileUpload,
+    datasetToEdit,
     showDatasetModal,
+    getGroups,
+    getDataTypesAndPriorities,
     updateDataset,
+    getDimensionTypes,
+    postFileUpload,
+    postDatasetUpload,
     isAdvancedMode,
+    getTaskStatus,
   ]);
 
   if (!datasets || !dimensionTypes) {

--- a/frontend/packages/@depmap/dataset-manager/tsconfig.json
+++ b/frontend/packages/@depmap/dataset-manager/tsconfig.json
@@ -5,6 +5,7 @@
     { "path": "../api" },
     { "path": "../common-components" },
     { "path": "../types" },
-    { "path": "../wide-table" }
+    { "path": "../wide-table" },
+    { "path": "../compute" }
   ]
 }


### PR DESCRIPTION
### Fixes:

- Validation for `allowed_values` field incorrect and broken since update to pydantic 2
- Add missing tests for dataset uploads of categorical datasets. Previous categorical dataset tests were for the old POST dataset endpoint
- Clean up some methods