### PR TITLE
fix(breadbox): Addressing common portal error logs

### DIFF
--- a/breadbox/breadbox/celery_task/utils.py
+++ b/breadbox/breadbox/celery_task/utils.py
@@ -180,7 +180,7 @@ def format_task_status(task):
         "id": task.id,
         "state": task.state,
         "message": message,
-        "percentComplete": int(percent_complete),
+        "percentComplete": int(percent_complete) if percent_complete else None,
         "nextPollDelay": 1000,  # units are miliseconds, this says once per second
         "result": result,
     }

--- a/breadbox/breadbox/celery_task/utils.py
+++ b/breadbox/breadbox/celery_task/utils.py
@@ -180,7 +180,7 @@ def format_task_status(task):
         "id": task.id,
         "state": task.state,
         "message": message,
-        "percentComplete": percent_complete,
+        "percentComplete": int(percent_complete),
         "nextPollDelay": 1000,  # units are miliseconds, this says once per second
         "result": result,
     }

--- a/portal-backend/depmap/cell_line/views.py
+++ b/portal-backend/depmap/cell_line/views.py
@@ -218,9 +218,12 @@ def get_pref_dep_data_for_data_type(data_type: str, model_id: str) -> dict:
 
 @blueprint.route("/compound_sensitivity/<model_id>")
 def get_compound_sensitivity_data(model_id: str) -> dict:
-    dataset_name = DependencyDataset.get_dataset_by_data_type_priority(
+    dataset = DependencyDataset.get_dataset_by_data_type_priority(
         DependencyDataset.DataTypeEnum.drug_screen
-    ).name.name
+    )
+    if dataset is None:
+        abort(404)
+    dataset_name = dataset.name.name
     labels_by_index = get_compound_labels_by_index(dataset_name)
 
     return get_rows_with_lowest_z_score(dataset_name, model_id, labels_by_index)


### PR DESCRIPTION
Fixing two errors that I noticed were appearing frequently in the portal error logs:
1.  FastAPI is occasionally throwing a validation error when trying to construct a task response ([logs](https://console.cloud.google.com/errors/detail/CIPrkoS7xfmJ2QE;time=P30D;locations=global?project=cds-logging)): 
    ```
    {'type': 'int_from_float', 'loc': ('response', 'percentComplete'), 'msg': 'Input should be a valid integer, got a number with a fractional part', 'input': 0.03921781645880805}
    ```
2. The public portal was running into a lot of 500 errors when trying to load the compound_sensitivity tile on the cell line page. This was happening about 2,000 times per day! (Logs [here](https://console.cloud.google.com/errors/detail/CMW7v4G48dvgaw;time=P30D;locations=global?inv=1&invt=Abkd9A&project=cds-logging)). I believe this was happening because we don't include drug screen data in the public release. This endpoint will now return a 404 error instead. The frontend is already catching these errors and defaults to hiding the tile when an error is thrown. 

The 1st issue is the only one that might actually be creating problems for users, although custom analysis does seem to be working whenever I've tried it out (this issue might just be happening infrequently). 