### PR TITLE
Changed PRISM Portal -> DepMap portal to redirect users to DE2

### DIFF
--- a/portal-backend/depmap/interactive/views.py
+++ b/portal-backend/depmap/interactive/views.py
@@ -864,6 +864,7 @@ def download_csv_and_view_interactive():
     display_name = request.args["display_name"]
     units = request.args["units"]
     file_url = request.args["url"]
+    use_de2 = request.args.get("de2", "T") == "T"
 
     url_upload_whitelist = flask.current_app.config["URL_UPLOAD_WHITELIST"]
 
@@ -882,7 +883,7 @@ def download_csv_and_view_interactive():
         abort(400)
 
     result = upload_transient_csv.apply(
-        args=[display_name, units, True, csv_path, False]
+        args=[display_name, units, True, csv_path, False, use_de2]
     )
 
     if result.state == TaskState.SUCCESS.value:


### PR DESCRIPTION
Code to direct users to DE2 was in place, but there was a flag determining whether users were directed to DE1 or DE2. Added a url parameter and changed the default to DE2.