### PR TITLE
Fix breadbox feature selection in Custom Analysis

### DIFF
--- a/portal-backend/depmap/breadbox_shim/breadbox_shim.py
+++ b/portal-backend/depmap/breadbox_shim/breadbox_shim.py
@@ -56,7 +56,7 @@ class BreadboxVectorCatalogChildNode(Node):
 
 
 class BreadboxVectorCatalogNodeInfo:
-    """ TODO: Could remove this. BB datasets don't need to appear in Vector Catalog at this point. 
+    """ 
     Vector Catalog endpoints return a specific dictionary structure for each parent node 
     in the vector catalog tree. This class reflects that same structure and contains
     some defaults specific to breadbox.

--- a/portal-backend/depmap/breadbox_shim/breadbox_shim.py
+++ b/portal-backend/depmap/breadbox_shim/breadbox_shim.py
@@ -243,10 +243,10 @@ def run_custom_analysis(
         # Hack part 2: Custom analysis in Breadbox was set up to take a feature's given ID.
         # We have the label here and need to use that to load the given ID.
         query_dataset_id = parse_breadbox_slice_id(slice_query.dataset_id).dataset_id
-        feature_id = None
         all_dataset_features = extensions.breadbox.client.get_dataset_features(
-            slice_query.dataset_id
+            query_dataset_id
         )
+        feature_id = None
         for bb_feature in all_dataset_features:
             if bb_feature["label"] == slice_query.identifier:
                 feature_id = bb_feature["id"]

--- a/portal-backend/depmap/breadbox_shim/breadbox_shim.py
+++ b/portal-backend/depmap/breadbox_shim/breadbox_shim.py
@@ -5,12 +5,11 @@ from typing import Any, Optional, Union
 from breadbox_client.models.compute_response import ComputeResponse
 from breadbox_client.models import (
     MatrixDatasetResponse,
-    MatrixDatasetResponseFormat,
     TabularDatasetResponse,
     FeatureResponse,
     ValueType,
 )
-
+from depmap import data_access
 from depmap.data_access.response_parsing import (
     format_breadbox_task_status,
     get_breadbox_slice_id,
@@ -21,6 +20,7 @@ from depmap.vector_catalog.models import Node, NodeType
 from depmap.vector_catalog.trees import Trees
 from depmap.partials.matrix.models import CellLineSeries
 from depmap import extensions
+from depmap_compute.slice import SliceQuery
 
 # Since breadbox and the legacy backend contain different datasets, we need to combine
 # values from each of their responses before returning a value.
@@ -56,7 +56,7 @@ class BreadboxVectorCatalogChildNode(Node):
 
 
 class BreadboxVectorCatalogNodeInfo:
-    """
+    """ TODO: Could remove this. BB datasets don't need to appear in Vector Catalog at this point. 
     Vector Catalog endpoints return a specific dictionary structure for each parent node 
     in the vector catalog tree. This class reflects that same structure and contains
     some defaults specific to breadbox.
@@ -222,7 +222,7 @@ def _get_feature_node_info_with_siblings(
 def run_custom_analysis(
     analysis_type: str,
     dataset_slice_id: str,
-    query_feature_slice_id: str,
+    slice_query: Optional[SliceQuery],
     vector_variable_type: str,
     query_cell_lines: Optional[list[str]],
     query_values: Optional[list[Any]],
@@ -234,12 +234,26 @@ def run_custom_analysis(
     Return a task status.
     """
     dataset_uuid = parse_breadbox_slice_id(dataset_slice_id).dataset_id
-    if query_feature_slice_id:
-        feature_id = parse_breadbox_slice_id(query_feature_slice_id).feature_id
-        query_dataset_id = parse_breadbox_slice_id(query_feature_slice_id).dataset_id
+    if slice_query:
+        # Temporary hack: for now, this slice query ALWAYS specifies a feature by label.
+        # This should always be true for our current feature selection component.
+        # Soon, this "breadbox_shim" should be removed entirely, along with this hack.
+        assert slice_query.identifier_type == "feature_label"
+
+        # Hack part 2: Custom analysis in Breadbox was set up to take a feature's given ID.
+        # We have the label here and need to use that to load the given ID.
+        query_dataset_id = parse_breadbox_slice_id(slice_query.dataset_id).dataset_id
+        feature_id = None
+        all_dataset_features = extensions.breadbox.client.get_dataset_features(
+            slice_query.dataset_id
+        )
+        for bb_feature in all_dataset_features:
+            if bb_feature["label"] == slice_query.identifier:
+                feature_id = bb_feature["id"]
         assert (
             feature_id is not None
-        ), "query_feature_slice_id must contain a feature ID"
+        ), f"Unexpected feature label passed to breadbox custom analysis: '{slice_query.identifier}'"
+
     else:
         feature_id = ""
         query_dataset_id = ""

--- a/portal-backend/depmap/data_access/response_parsing.py
+++ b/portal-backend/depmap/data_access/response_parsing.py
@@ -24,7 +24,7 @@ def parse_breadbox_slice_id(slice_id: str) -> ParsedBreadboxSliceId:
     """
     Parse the breadbox dataset ID and feature ID from the given slice ID. If the given 
     slice ID is malformed, throw a Bad Request error. Slice IDs should be formatted like 
-    'breadbox/<dataset-uuid>/<feature-uuid>' or 'breadbox/<dataset-uuid>'.
+    'breadbox/<dataset-uuid>/<feature-given-id>' or 'breadbox/<dataset-uuid>'.
     """
     match = re.match(BREADBOX_SLICE_ID_REGEX, slice_id)
     assert match, f"Breadbox slice id '{slice_id}' does not match the expected format."

--- a/portal-backend/pyright-ratchet-errors.txt
+++ b/portal-backend/pyright-ratchet-errors.txt
@@ -667,7 +667,6 @@ views.py: error: Argument of type "Literal['url']" cannot be assigned to paramet
 views.py: error: Argument of type "Literal['user_id']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 views.py: error: Argument of type "Literal['value']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 views.py: error: Argument of type "Literal[DependencyEnum.Avana]" cannot be assigned to parameter "dependency_dataset_name" of type "str" in function "get_dataset_by_name"
-views.py: error: Argument of type "Unknown | Any | None" cannot be assigned to parameter "query_feature_slice_id" of type "str" in function "run_custom_analysis"
 views.py: error: Argument of type "Unknown | FileStorage" cannot be assigned to parameter "filepath_or_buffer" of type "FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str]" in function "read_csv" (reportArgumentType)
 views.py: error: Argument of type "Unknown | Hashable" cannot be assigned to parameter "group_name" of type "str" in function "__init__"
 views.py: error: Argument of type "Unknown | None" cannot be assigned to parameter "cell_line_col_index" of type "int" in function "get_all_cell_line_compound_sensitivity"
@@ -675,7 +674,6 @@ views.py: error: Argument of type "Unknown | None" cannot be assigned to paramet
 views.py: error: Argument of type "Unknown | int | list[Unknown]" cannot be assigned to parameter "color_num" of type "str | int" in function "__init__" (reportArgumentType)
 views.py: error: Argument of type "list[BreadboxVectorCatalogNodeInfo]" cannot be assigned to parameter "__iterable" of type "Iterable[dict[Unknown, Unknown]]" in function "extend"
 views.py: error: Argument of type "list[CellLineSeries]" cannot be assigned to parameter "breadbox_feature_data" of type "list[Series]" in function "get_df_from_feature_list"
-views.py: error: Argument of type "list[Unknown] | Any | list[int] | Unknown" cannot be assigned to parameter "query_cell_lines" of type "list[str] | None" in function "run_custom_analysis" (reportArgumentType)
 views.py: error: Argument of type "list[list[Unknown]] | None" cannot be assigned to parameter "compound_experiment_and_datasets" of type "List[Tuple[CompoundExperiment, DependencyDataset]]" in function "format_dep_dist_caption"
 views.py: error: Argument of type "str | Any" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 views.py: error: Argument of type "str | None" cannot be assigned to parameter "s" of type "str | bytes | bytearray" in function "loads" (reportArgumentType)

--- a/portal-backend/tests/depmap/compute/test_views.py
+++ b/portal-backend/tests/depmap/compute/test_views.py
@@ -376,31 +376,21 @@ def test_compute_univariate_associations_with_breadbox_feature(
     empty_db_mock_downloads.session.flush()
     interactive_test_utils.reload_interactive_config()
 
-    # Mock the breadbox client response
-    mock_breadbox_feature_data = [
-        FeatureResponse(
-            feature_id="foo",
-            dataset_id="bar",
-            values=FeatureResponseValues.from_dict(
-                {
-                    cell_lines[0].depmap_id: 0.1,
-                    cell_lines[1].depmap_id: 0.2,
-                    cell_lines[2].depmap_id: 0.3,
-                }
-            ),
-            label="feature_foo",
-            units="inches",
-            dataset_label="dataset_bar",
+    mock_breadbox_client.get_dataset_data = MagicMock(
+        return_value=pd.DataFrame(
+            data={"foo": [0.1, 0.2, 0.3]},
+            index=[
+                cell_lines[0].depmap_id,
+                cell_lines[1].depmap_id,
+                cell_lines[2].depmap_id,
+            ],
         )
-    ]
-    mock_breadbox_client.get_feature_data = MagicMock(
-        return_value=mock_breadbox_feature_data
     )
 
     with app.test_client() as c:
         # assemble query parameters
         dataset_id = gene_dataset.name.name
-        breadbox_slice_id = "breadbox/foo/bar"
+        breadbox_slice_id = "slice/breadbox%2Ffoo/feature_foo/label"
 
         parameters = {
             "analysisType": "pearson",

--- a/portal-backend/tests/depmap/interactive/views/test_get_associations.py
+++ b/portal-backend/tests/depmap/interactive/views/test_get_associations.py
@@ -71,7 +71,7 @@ def test_get_breadbox_associations(empty_db_mock_downloads):
     empty_db_mock_downloads.session.flush()
     interactive_test_utils.reload_interactive_config()
 
-    params = {"x": "slice/breadbox%2F2e99edbc-30a5-445c-baa1-4be22ca8f31f/A2M/label"}
+    params = {"x": "breadbox%2F2e99edbc-30a5-445c-baa1-4be22ca8f31f/A2M/label"}
 
     with empty_db_mock_downloads.app.test_client() as c:
         r = c.get("/interactive/api/associations?" + urllib.parse.urlencode(params))

--- a/portal-backend/tests/depmap/interactive/views/test_get_associations.py
+++ b/portal-backend/tests/depmap/interactive/views/test_get_associations.py
@@ -71,7 +71,7 @@ def test_get_breadbox_associations(empty_db_mock_downloads):
     empty_db_mock_downloads.session.flush()
     interactive_test_utils.reload_interactive_config()
 
-    params = {"x": "breadbox%2F2e99edbc-30a5-445c-baa1-4be22ca8f31f/A2M/label"}
+    params = {"x": "slice/breadbox%2F2e99edbc-30a5-445c-baa1-4be22ca8f31f/A2M/label"}
 
     with empty_db_mock_downloads.app.test_client() as c:
         r = c.get("/interactive/api/associations?" + urllib.parse.urlencode(params))


### PR DESCRIPTION
[Asana](https://app.asana.com/0/1165651979405609/1208751102503933/f)

**Source of the problem:**
* In custom analysis, the feature selection component was recently replaced. The new feature selection uses a different format for breadbox feature slice IDs. 
* Vector catalog used to output a slice ID formatted like: `breadbox/<dataset-uuid>/<feature-given-id>` . This format was unique to the `breadbox_shim`, which was the first integration of breadbox into the portal backend.
* The DE2 feature selector outputs a slice ID formatted like `slice/breadbox%2<dataset-uuid>/<feature-label>/label` This is the more standard slice ID format

**The solution:** I updated the `breadbox_shim` to use the new slice ID format for custom analysis. 

**Notes:**
* Custom analysis requires a lot of manual testing whenever changes are made. I'm still working on testing this. 
* I added a couple of temporary "hacks" since the breadbox_shim will be removed soon anyway. It was mostly set up to support vector catalog and data explorer 1 which use older methods outside of the `data_access` interface for loading data. 