### PR TITLE
Compound dataset refactoring: cell line page 

### DIFF
--- a/portal-backend/.importlinter
+++ b/portal-backend/.importlinter
@@ -6,7 +6,6 @@ name=The portal backend should use data_access instead of directly referencing i
 type=forbidden
 source_modules=
     depmap.cell_line
-    depmap.compound
     depmap.data_explorer_2
     depmap.download
     depmap.predictability

--- a/portal-backend/depmap/cell_line/views.py
+++ b/portal-backend/depmap/cell_line/views.py
@@ -199,7 +199,7 @@ def get_compound_sensitivity_data(model_id: str) -> dict:
     if dataset is None:
         abort(404)
     dataset_name = dataset.name.name
-    df = data_access.get_dataset_data_indexed_by_compound_label(dataset_name)
+    df = data_access.get_subsetted_df_by_compound_labels(dataset_name)
 
     return get_lowest_z_scores_response(dataset_name, model_id, df)
 
@@ -330,7 +330,7 @@ def get_all_cell_line_compound_sensitivity(
 ) -> pd.DataFrame:
     """Get all compound sensitivity data related to the cell line. Include five columns:
         compound, compound_sensitivity, z_score, mean, stddev"""
-    sensitivity_df = data_access.get_dataset_data_indexed_by_compound_label(dataset_name)
+    sensitivity_df = data_access.get_subsetted_df_by_compound_labels(dataset_name)
     sensitivity_df = sensitivity_df[np.isfinite(sensitivity_df[model_id])]
 
     result_df = get_stats_for_dataframe(sensitivity_df, model_id)

--- a/portal-backend/depmap/cell_line/views.py
+++ b/portal-backend/depmap/cell_line/views.py
@@ -215,11 +215,10 @@ def get_lowest_z_scores_response(
     Returns: Top labels (ex. genes) and values (ex. gene effects) across all cell lines
     as well as index of the column containing data for the given cell line. 
 
-    TODO: After these datasets are migrated to breadbox, the performance of this method can be 
+    Note: After these datasets are migrated to breadbox, the performance of this method can be 
     subsantially improved by calling breadbox's aggregation endpoint instead of loading 
     the full matrix here. 
     """
-    # TODO: refactor the params here
     cell_line = DepmapModel.get_by_model_id(model_id, must=False)
     result = {
         "model_id": cell_line.model_id,

--- a/portal-backend/depmap/cell_line/views.py
+++ b/portal-backend/depmap/cell_line/views.py
@@ -15,7 +15,6 @@ from flask import (
 )
 import numpy as np
 import pandas as pd
-import sqlalchemy as sa
 
 from depmap import data_access
 from depmap.partials.matrix.models import ColMatrixIndex
@@ -32,7 +31,6 @@ from depmap.download.utils import get_download_url
 from depmap.extensions import csrf_protect
 from depmap.metmap.models import MetMap500
 from depmap.utilities.sign_bucket_url import sign_url
-from depmap.partials.matrix.models import Matrix, RowMatrixIndex
 from depmap.partials.data_table.factories import (
     get_mutation_by_cell_line_table,
     get_fusion_by_cell_line_table,

--- a/portal-backend/depmap/cell_line/views.py
+++ b/portal-backend/depmap/cell_line/views.py
@@ -189,8 +189,7 @@ def get_pref_dep_data_for_data_type(data_type: str, model_id: str) -> dict:
         abort(404)
     # dataset_name is dataset enum name
     dataset_name = dataset.name.name
-    labels_by_index = get_gene_labels_by_index(dataset_name)
-    rows = get_rows_with_lowest_z_score(dataset_name, model_id, labels_by_index)
+    rows = get_rows_with_lowest_z_score(dataset_name, model_id)
     return rows
 
 
@@ -202,13 +201,13 @@ def get_compound_sensitivity_data(model_id: str) -> dict:
     if dataset is None:
         abort(404)
     dataset_name = dataset.name.name
-    labels_by_index = get_compound_labels_by_index(dataset_name)
+    labels_by_exp_id = get_compound_labels_by_experiment_id(dataset_name) # TODO: use
 
-    return get_rows_with_lowest_z_score(dataset_name, model_id, labels_by_index)
+    return get_rows_with_lowest_z_score(dataset_name, model_id)
 
 
 def get_rows_with_lowest_z_score(
-    dataset_name: str, model_id: str, labels_by_row_index: pd.DataFrame
+    dataset_name: str, model_id: str
 ):
     """Gets data for the top 10 rows of the given dataset, where top values have the 
     lowest z-scores for the cell line (matching the given depmap id). For example, 
@@ -224,20 +223,19 @@ def get_rows_with_lowest_z_score(
         "dataset_label": data_access.get_dataset_label(dataset_name),
     }
 
-    cell_line_col_index = get_cell_line_col_index(dataset_name, model_id)
-    if cell_line_col_index is not None:
-        # Get the full matrix of gene effect data
-        df = get_all_labeled_values(dataset_name, labels_by_row_index)
-        df = df[np.isfinite(df[cell_line_col_index])]  # filter nulls
+    df = data_access.get_subsetted_df_by_labels(dataset_name)
+    if model_id in df.columns: # TODO: confirm that the depmap ids would be columns
+        # Get the full matrix of gene effect dat        
+        df = df[np.isfinite(df[model_id])]  # filter nulls
         # sort the matrix using cell line z-scores
-        cell_line_z_scores = convert_to_z_score_matrix(df)[cell_line_col_index]
+        cell_line_z_scores = convert_to_z_score_matrix(df)[model_id]
         sorted_index = cell_line_z_scores.sort_values().index
         sorted_df = df.loc[sorted_index]
         result_df = sorted_df.head(10)  # return data for the top 10 genes
         # Construct result
         result["labels"] = result_df.index.values.tolist()
         result["data"] = result_df.replace({np.nan: None}).values.tolist()
-        result["cell_line_col_index"] = cell_line_col_index
+        result["cell_line_col_index"] = result_df.columns.get_loc(model_id)
     return result
 
 
@@ -273,12 +271,11 @@ def download_gene_effects(dataset_type: str, model_id: str):
     else:
         abort(404)
 
-    cell_line_col_index = get_cell_line_col_index(dataset_name, model_id)
-    if cell_line_col_index is None:
-        abort(404)
-
     # Get the gene effect data that relates to this cell line
-    df = get_all_cell_line_gene_effects(dataset_name, cell_line_col_index)
+    df = get_all_cell_line_gene_effects(dataset_name, model_id)
+
+    if model_id not in df.columns:
+        abort(404)
 
     # return the dataframe as a CSV
     response = make_response(df.to_csv())
@@ -290,15 +287,14 @@ def download_gene_effects(dataset_type: str, model_id: str):
 
 
 def get_all_cell_line_gene_effects(
-    dataset_name: str, cell_line_col_index: int
+    dataset_name: str, model_id: int
 ) -> pd.DataFrame:
     """Get all gene effect data related to the cell line. Include five columns:
         gene, gene_effect, z_score, mean, stddev"""
-    gene_labels_by_index = get_gene_labels_by_index(dataset_name)
-    gene_effect_df = get_all_labeled_values(dataset_name, gene_labels_by_index)
-    gene_effect_df = gene_effect_df[np.isfinite(gene_effect_df[cell_line_col_index])]
+    gene_effect_df = data_access.get_subsetted_df_by_labels(dataset_name)
+    gene_effect_df = gene_effect_df[np.isfinite(gene_effect_df[model_id])]
 
-    result_df = get_stats_for_dataframe(gene_effect_df, cell_line_col_index)
+    result_df = get_stats_for_dataframe(gene_effect_df, model_id)
 
     result_df = result_df.rename(columns={"val": "gene_effect"})
     result_df.index.rename("gene", inplace=True)
@@ -316,7 +312,7 @@ def download_compound_sensitivities(model_id: str):
         abort(404)
 
     # Get the gene effect data that relates to this cell line
-    df = get_all_cell_line_compound_sensitivity(dataset_name, cell_line_col_index)
+    df = get_all_cell_line_compound_sensitivity(dataset_name, model_id)
 
     # return the dataframe as a CSV
     response = make_response(df.to_csv())
@@ -328,27 +324,30 @@ def download_compound_sensitivities(model_id: str):
 
 
 def get_all_cell_line_compound_sensitivity(
-    dataset_name: str, cell_line_col_index: int
+    dataset_name: str, model_id: str
 ) -> pd.DataFrame:
     """Get all compound sensitivity data related to the cell line. Include five columns:
         compound, compound_sensitivity, z_score, mean, stddev"""
-    compound_labels_by_index = get_compound_labels_by_index(dataset_name)
-    sensitivity_df = get_all_labeled_values(dataset_name, compound_labels_by_index)
-    sensitivity_df = sensitivity_df[np.isfinite(sensitivity_df[cell_line_col_index])]
+    sensitivity_df = data_access.get_subsetted_df_by_ids(dataset_name)
+    sensitivity_df = sensitivity_df[np.isfinite(sensitivity_df[model_id])]
 
-    result_df = get_stats_for_dataframe(sensitivity_df, cell_line_col_index)
+    # The dataframe is currently indexed by compound experiment. Re-index by compound.
+    labels_by_exp_id = get_compound_labels_by_experiment_id(dataset_name)
+    sensitivity_df = sensitivity_df.rename(index=labels_by_exp_id)
+
+    result_df = get_stats_for_dataframe(sensitivity_df, model_id)
 
     result_df = result_df.rename(columns={"val": "compound_sensitivity"})
     result_df.index.rename("compound", inplace=True)
     return result_df
 
 
-def get_stats_for_dataframe(df: pd.DataFrame, cell_line_col_index: int):
+def get_stats_for_dataframe(df: pd.DataFrame, model_id: str):
     """Get the mean, stddev, and given cell line's value and z_score for each row in a matrix of numeric values.
     Sort the result by z-score."""
     means = df.mean(axis=1).rename("mean")
     standard_devs = df.std(axis=1).rename("stddev")
-    cell_line_vals = df[cell_line_col_index].rename("val")
+    cell_line_vals = df[model_id].rename("val")
     cell_line_z_scores = cell_line_vals.sub(means).div(standard_devs).rename("z_score")
     result_df = pd.concat(
         [cell_line_vals, cell_line_z_scores, means, standard_devs,], axis=1
@@ -359,26 +358,9 @@ def get_stats_for_dataframe(df: pd.DataFrame, cell_line_col_index: int):
     return result_df
 
 
-def get_all_labeled_values(
-    dataset_name: str, labels_by_index: pd.DataFrame
-) -> pd.DataFrame:
-    """Get a dataframe of gene effect data, indexed by gene names from the given dataset. 
-    Rows represent genes and columns represent cell lines."""
-    # read data from matrices, calculate z scores
-    full_gene_effect_matrix: pd.DataFrame = data_access.get_subsetted_df(
-        dataset_id=dataset_name, row_indices=None, col_indices=None
-    )
-    # Merge entity info with the z score dataframe (in order to filter out obsolete rows)
-    merged_df = pd.merge(
-        labels_by_index, full_gene_effect_matrix.reset_index(), on="index"
-    )
-    # Move the label column to the index, remove the other entity info columns
-    merged_df = merged_df.drop(["index"], axis=1)
-    merged_df = merged_df.set_index("label")
-    return merged_df
-
-
-def get_compound_labels_by_index(dataset_name: str):
+def get_compound_labels_by_experiment_id(dataset_name: str) -> dict[str, str]:
+    """Compound labels by row matrix index."""
+    # TODO: move this elsewhere to be replaced
     # Data access details should be in interactive config
     # (Using SQLAlchemy to join the compound object to the matrix)
     matrix_id = data_access.get_matrix_id(dataset_name)
@@ -389,16 +371,10 @@ def get_compound_labels_by_index(dataset_name: str):
         .join(RowMatrixIndex)
         .join(comp_exp_alias)
         .join(compound_alias, compound_alias.entity_id == comp_exp_alias.compound_id)
-        .with_entities(RowMatrixIndex.index, compound_alias.label)
+        .with_entities(comp_exp_alias.label, compound_alias.label)
         .all()
     )
-    return pd.DataFrame(labels_by_indeces, columns=["index", "label"])
-
-
-def get_gene_labels_by_index(dataset_name: str):
-    return pd.DataFrame(
-        data_access.get_all_row_indices_labels_entity_ids(dataset_name)
-    ).drop(["entity_id"], axis=1)
+    return {experiment_id: compound_label for experiment_id, compound_label in labels_by_indeces}
 
 
 @blueprint.route("/datasets/<model_id>")

--- a/portal-backend/depmap/compound/legacy_utils.py
+++ b/portal-backend/depmap/compound/legacy_utils.py
@@ -31,7 +31,7 @@ def get_compound_labels_for_compound_experiment_dataset(dataset_name: str) -> di
     )
     return {experiment_id: compound_label for experiment_id, compound_label in labels_by_indeces}
 
-def get_dataset_data_indexed_by_compound_label(dataset_id: str) -> pd.DataFrame:
+def get_subsetted_df_by_compound_labels(dataset_id: str) -> pd.DataFrame:
     """
     Load the data for a drug screen dataset. This is similar to get_subsetted_df_by_labels,
     except that for compound datasets, the result will be indexed by compound (to match breadbox).

--- a/portal-backend/depmap/compound/legacy_utils.py
+++ b/portal-backend/depmap/compound/legacy_utils.py
@@ -34,7 +34,7 @@ def get_compound_labels_for_compound_experiment_dataset(dataset_name: str) -> di
 
 def get_dataset_data_indexed_by_compound_label(dataset_id: str) -> pd.DataFrame:
     feature_type = interactive_utils.get_entity_type(dataset_id)
-    assert feature_type == "compound", f"Cannot re-index a non-compound dataset '{dataset_id}' by compound label"
+    assert feature_type == "compound_experiment", f"Dataset '{dataset_id}' is indexed by '{feature_type}', cannot be re-indexed by compound label"
     compound_labels_by_experiment = get_compound_labels_for_compound_experiment_dataset(dataset_id)
     compound_experiment_df = interactive_utils.get_subsetted_df_by_labels(dataset_id, None, None)
     compound_df = compound_experiment_df.rename(index=compound_labels_by_experiment)

--- a/portal-backend/depmap/compound/legacy_utils.py
+++ b/portal-backend/depmap/compound/legacy_utils.py
@@ -1,0 +1,27 @@
+import sqlalchemy as sa
+
+from depmap.interactive import interactive_utils
+from depmap.dataset.models import (
+    Compound,
+    CompoundExperiment,
+)
+from depmap.partials.matrix.models import Matrix, RowMatrixIndex
+
+def get_compound_labels_for_compound_experiment_dataset(dataset_name: str) -> dict[str, str]:
+    """
+    In the future, all drug screen datasets will be indexed by compound instead of compound experiment. 
+    This method loads a mapping between the old index (compound experiment label) and 
+    method is used to re-index datasets which are indexed by compound experiment. 
+    """
+    matrix_id = interactive_utils.get_matrix_id(dataset_name)
+    comp_exp_alias = sa.orm.aliased(CompoundExperiment)
+    compound_alias = sa.orm.aliased(Compound)
+    labels_by_indeces = (
+        Matrix.query.filter_by(matrix_id=matrix_id)
+        .join(RowMatrixIndex)
+        .join(comp_exp_alias)
+        .join(compound_alias, compound_alias.entity_id == comp_exp_alias.compound_id)
+        .with_entities(comp_exp_alias.label, compound_alias.label)
+        .all()
+    )
+    return {experiment_id: compound_label for experiment_id, compound_label in labels_by_indeces}

--- a/portal-backend/depmap/compound/legacy_utils.py
+++ b/portal-backend/depmap/compound/legacy_utils.py
@@ -14,8 +14,7 @@ from depmap.partials.matrix.models import Matrix, RowMatrixIndex
 log = logging.getLogger(__name__)
 
 def get_compound_labels_for_compound_experiment_dataset(dataset_name: str) -> dict[str, str]:
-    """
-    In the future, all drug screen datasets will be indexed by compound instead of compound experiment. 
+    """ 
     This method loads a mapping between the old index (compound experiment label) and 
     method is used to re-index datasets which are indexed by compound experiment. 
     """
@@ -33,6 +32,10 @@ def get_compound_labels_for_compound_experiment_dataset(dataset_name: str) -> di
     return {experiment_id: compound_label for experiment_id, compound_label in labels_by_indeces}
 
 def get_dataset_data_indexed_by_compound_label(dataset_id: str) -> pd.DataFrame:
+    """
+    Load the data for a drug screen dataset. This is similar to get_subsetted_df_by_labels,
+    except that for compound datasets, the result will be indexed by compound (to match breadbox).
+    """
     feature_type = interactive_utils.get_entity_type(dataset_id)
     assert feature_type == "compound_experiment", f"Dataset '{dataset_id}' is indexed by '{feature_type}', cannot be re-indexed by compound label"
     compound_labels_by_experiment = get_compound_labels_for_compound_experiment_dataset(dataset_id)

--- a/portal-backend/depmap/data_access/__init__.py
+++ b/portal-backend/depmap/data_access/__init__.py
@@ -30,9 +30,5 @@ from .interface import (
     get_all_row_indices_labels_entity_ids,
     get_context_dataset,
     get_custom_cell_lines_dataset,
-    get_matrix_id,
-    get_sort_key,
     has_config,
-    is_filter,
-    is_standard,
 )

--- a/portal-backend/depmap/data_access/__init__.py
+++ b/portal-backend/depmap/data_access/__init__.py
@@ -19,7 +19,7 @@ from .interface import (
     is_categorical,
     is_continuous,
     # compound-specific methods
-    get_dataset_data_indexed_by_compound_label,
+    get_subsetted_df_by_compound_labels,
     # methods that will be supported with modified contracts
     get_private_datasets,
     get_row_of_values,

--- a/portal-backend/depmap/data_access/__init__.py
+++ b/portal-backend/depmap/data_access/__init__.py
@@ -18,6 +18,8 @@ from .interface import (
     get_slice_data,
     is_categorical,
     is_continuous,
+    # compound-specific methods
+    get_dataset_data_indexed_by_compound_label,
     # methods that will be supported with modified contracts
     get_private_datasets,
     get_row_of_values,

--- a/portal-backend/depmap/data_access/breadbox_dao.py
+++ b/portal-backend/depmap/data_access/breadbox_dao.py
@@ -104,16 +104,6 @@ def get_dataset_sample_ids(dataset_id: str) -> list[str]:
     return [sample["id"] for sample in samples]
 
 
-def get_sort_key(dataset_id: str) -> DatasetSortKey:
-    """
-    Sort breadbox datasets in with private datasets.
-    This method is only used in DE1. DE2 uses the 'priority' field instead.
-    """
-    return DatasetSortKey(
-        DatasetSortFirstKey.custom_or_private.value, 0, get_dataset_label(dataset_id),
-    )
-
-
 def get_dataset_taiga_id(dataset_id: str) -> Optional[str]:
     return get_matrix_dataset(dataset_id).taiga_id
 

--- a/portal-backend/depmap/data_access/interface.py
+++ b/portal-backend/depmap/data_access/interface.py
@@ -222,16 +222,6 @@ def get_dataset_sample_ids(dataset_id: str) -> list[str]:
     return interactive_utils.get_dataset_sample_ids(dataset_id)
 
 
-def get_sort_key(dataset_id: str) -> DatasetSortKey:
-    """
-    Get a DatasetSortKey to order datasets as they should appear in vector catalog.
-    This method is only used in DE1. DE2 uses the 'priority' field instead.
-    """
-    if is_breadbox_id(dataset_id):
-        return breadbox_dao.get_sort_key(dataset_id)
-    return interactive_utils.get_sort_key(dataset_id)
-
-
 def is_categorical(dataset_id: str) -> bool:
     """
     Check whether the given dataset is made up of categorical values
@@ -420,34 +410,11 @@ def get_custom_cell_lines_dataset() -> str:
     return interactive_utils.get_custom_cell_lines_dataset()
 
 
-def get_matrix_id(dataset_id: str) -> int:
-    """
-    Load the matrix id for the given dataset.
-    Matrices are specific to the legacy data access implementation
-    """
-    return interactive_utils.get_matrix_id(dataset_id)
-
-
 def has_config(dataset_id: str) -> bool:
     """
     Check whether the given dataset exists in interactive config
     """
     return interactive_utils.has_config(dataset_id)
-
-
-def is_filter(dataset_id: str) -> bool:
-    """
-    Check whether the given dataset is a context or custom cell lines dataset.
-    """
-    return interactive_utils.is_filter(dataset_id)
-
-
-def is_standard(dataset_id: str) -> bool:
-    """
-    Check whether the given dataset is standard or nonstandard. 
-    Only applicable for the legacy data access implementation.
-    """
-    return interactive_utils.is_standard(dataset_id)
 
 
 def _get_visible_legacy_dataset_ids():

--- a/portal-backend/depmap/data_access/interface.py
+++ b/portal-backend/depmap/data_access/interface.py
@@ -317,16 +317,18 @@ def get_slice_data(slice_query: SliceQuery) -> pd.Series:
 # These methods exist to ensure that both the legacy backend and breadbox are returning the same 
 # data while we are in this transitionary period. 
 
-def get_dataset_data_indexed_by_compound_label(dataset_id) -> pd.DataFrame:
+def get_subsetted_df_by_compound_labels(dataset_id) -> pd.DataFrame:
     """
     Load the data for a drug screen dataset. This is similar to get_subsetted_df_by_labels,
     except that for legacy compound datasets, the result will be indexed by compound 
     (to match breadbox).
     """
-    if is_breadbox_id(dataset_id):
-        return get_subsetted_df_by_labels(dataset_id)
+    dataset = get_matrix_dataset(dataset_id)
+    # Legacy datasets indexed by compound experiment get re-indexed by compound label
+    if not is_breadbox_id(dataset_id) and dataset.feature_type == "compound_experiment":
+        return legacy_compound_utils.get_subsetted_df_by_compound_labels(dataset_id)
     else:
-        return legacy_compound_utils.get_dataset_data_indexed_by_compound_label(dataset_id)
+        return get_subsetted_df_by_labels(dataset_id)
 
 
 ##################################################

--- a/portal-backend/depmap/data_access/interface.py
+++ b/portal-backend/depmap/data_access/interface.py
@@ -304,8 +304,8 @@ def get_slice_data(slice_query: SliceQuery) -> pd.Series:
 # METHODS BELOW ARE SPECIAL WORKAROUNDS FOR COMPOUND DATASETS #
 ###############################################################
 # In the future, all drug screen datasets will be indexed by compound instead of compound experiment.
-# These methods exist to ensure that both the legacy backend and breadbox are returning the same 
-# data while we are in this transitionary period. 
+# These methods exist to ensure that both the legacy backend and breadbox are returning 
+# same shaped data while we are in this transitionary period. 
 
 def get_subsetted_df_by_compound_labels(dataset_id) -> pd.DataFrame:
     """

--- a/portal-backend/depmap/data_access/interface.py
+++ b/portal-backend/depmap/data_access/interface.py
@@ -323,7 +323,7 @@ def get_dataset_data_indexed_by_compound_label(dataset_id) -> pd.DataFrame:
     except that for legacy compound datasets, the result will be indexed by compound 
     (to match breadbox).
     """
-    if is_breadbox_id:
+    if is_breadbox_id(dataset_id):
         return get_subsetted_df_by_labels(dataset_id)
     else:
         return legacy_compound_utils.get_dataset_data_indexed_by_compound_label(dataset_id)

--- a/portal-backend/pyright-ratchet-errors.txt
+++ b/portal-backend/pyright-ratchet-errors.txt
@@ -668,8 +668,6 @@ views.py: error: Argument of type "Literal['value']" cannot be assigned to param
 views.py: error: Argument of type "Literal[DependencyEnum.Avana]" cannot be assigned to parameter "dependency_dataset_name" of type "str" in function "get_dataset_by_name"
 views.py: error: Argument of type "Unknown | FileStorage" cannot be assigned to parameter "filepath_or_buffer" of type "FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str]" in function "read_csv" (reportArgumentType)
 views.py: error: Argument of type "Unknown | Hashable" cannot be assigned to parameter "group_name" of type "str" in function "__init__"
-views.py: error: Argument of type "Unknown | None" cannot be assigned to parameter "cell_line_col_index" of type "int" in function "get_all_cell_line_compound_sensitivity"
-views.py: error: Argument of type "Unknown | None" cannot be assigned to parameter "cell_line_col_index" of type "int" in function "get_all_cell_line_gene_effects"
 views.py: error: Argument of type "Unknown | int | list[Unknown]" cannot be assigned to parameter "color_num" of type "str | int" in function "__init__" (reportArgumentType)
 views.py: error: Argument of type "list[BreadboxVectorCatalogNodeInfo]" cannot be assigned to parameter "__iterable" of type "Iterable[dict[Unknown, Unknown]]" in function "extend"
 views.py: error: Argument of type "list[CellLineSeries]" cannot be assigned to parameter "breadbox_feature_data" of type "list[Series]" in function "get_df_from_feature_list"

--- a/portal-backend/pyright-ratchet-errors.txt
+++ b/portal-backend/pyright-ratchet-errors.txt
@@ -269,7 +269,6 @@ initialize_current_auth.py: error: Argument of type "str | None" cannot be assig
 initialize_current_auth.py: error: Cannot access member "groups" for type "list[str]"
 initialize_current_auth.py: error: Cannot access member "is_admin" for type "list[str]"
 initialize_current_auth.py: error: Cannot assign member "is_everything_visible" for type "list[str]"
-interface.py: error: Expression of type "Unknown | None" cannot be assigned to return type "int"
 iter.py: error: Argument of type "TranslateCRtoNL" cannot be assigned to parameter "__value" of type "int" in function "__setitem__"
 json_dump.py: error: Argument of type "Literal['JSONIFY_MIMETYPE']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 json_dump.py: error: Argument of type "Literal['JSONIFY_PRETTYPRINT_REGULAR']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"

--- a/portal-backend/tests/depmap/cell_line/test_views.py
+++ b/portal-backend/tests/depmap/cell_line/test_views.py
@@ -11,7 +11,6 @@ from depmap.cell_line.views import (
     get_all_cell_line_gene_effects,
     get_all_cell_line_compound_sensitivity,
     get_cell_line_col_index,
-    get_compound_labels_by_experiment_id,
     get_related_models,
     get_rows_with_lowest_z_score,
 )

--- a/portal-backend/tests/depmap/cell_line/test_views.py
+++ b/portal-backend/tests/depmap/cell_line/test_views.py
@@ -301,7 +301,7 @@ def test_get_all_cell_line_compound_sensitivities(empty_db_mock_downloads):
     )
 
     # Check that all non-null rows are included and have the correct gene names
-    assert actual_df.index.values.tolist() == [compounds[0].label, compounds[1].label] # TODO: is this not compound label??
+    assert actual_df.index.values.tolist() == [compounds[0].label, compounds[1].label]
 
     # validate each column's values: compound_sensitivity, z_score, mean, stddev
     expected_sensitivities = [2, 0]

--- a/portal-backend/tests/depmap/cell_line/test_views.py
+++ b/portal-backend/tests/depmap/cell_line/test_views.py
@@ -13,7 +13,7 @@ from depmap.cell_line.views import (
     get_all_cell_line_compound_sensitivity,
     get_cell_line_col_index,
     get_related_models,
-    get_rows_with_lowest_z_score,
+    get_lowest_z_scores_response,
 )
 from depmap.dataset.models import DependencyDataset
 from tests.factories import (
@@ -356,7 +356,7 @@ def test_convert_to_z_score_matrix():
         assert a == pytest.approx(b, 0.001)
 
 
-def test_get_rows_with_lowest_z_score(empty_db_mock_downloads):
+def test_get_lowest_z_scores_response(empty_db_mock_downloads):
     """Test that this outputs the expected format, ordered by z-score.
     Note: z-score calculations are tested above in test_convert_to_z_score_matrix.
     """
@@ -390,10 +390,10 @@ def test_get_rows_with_lowest_z_score(empty_db_mock_downloads):
     # Validate that a result is returned for the correct cell line
     col_index = 1
 
-    actual_result = get_rows_with_lowest_z_score(
+    actual_result = get_lowest_z_scores_response(
         dataset_name=dataset_name.name,
         model_id=cell_lines[col_index].model_id,
-        df=data_access.get_subsetted_df_by_labels(dataset_name.name)
+        dataset_df=data_access.get_subsetted_df_by_labels(dataset_name.name)
     )
     assert actual_result["model_id"] == cell_lines[col_index].model_id
     assert actual_result["cell_line_col_index"] == col_index

--- a/portal-backend/tests/depmap/cell_line/test_views.py
+++ b/portal-backend/tests/depmap/cell_line/test_views.py
@@ -11,8 +11,7 @@ from depmap.cell_line.views import (
     get_all_cell_line_gene_effects,
     get_all_cell_line_compound_sensitivity,
     get_cell_line_col_index,
-    get_compound_labels_by_index,
-    get_gene_labels_by_index,
+    get_compound_labels_by_experiment_id,
     get_related_models,
     get_rows_with_lowest_z_score,
 )
@@ -258,9 +257,8 @@ def test_get_all_cell_line_gene_effects(empty_db_mock_downloads):
     empty_db_mock_downloads.session.flush()
     interactive_test_utils.reload_interactive_config()
 
-    cell_line_col_index = 0
     actual_df = get_all_cell_line_gene_effects(
-        dataset_name=dataset_name.name, cell_line_col_index=cell_line_col_index
+        dataset_name=dataset_name.name, model_id=cell_lines[0].model_id
     )
 
     # Check that all non-null rows are included and have the correct gene names
@@ -298,9 +296,8 @@ def test_get_all_cell_line_compound_sensitivities(empty_db_mock_downloads):
     empty_db_mock_downloads.session.flush()
     interactive_test_utils.reload_interactive_config()
 
-    cell_line_col_index = 0
     actual_df = get_all_cell_line_compound_sensitivity(
-        dataset_name=dataset_name.name, cell_line_col_index=cell_line_col_index
+        dataset_name=dataset_name.name, model_id=cell_lines[0].model_id
     )
 
     # Check that all non-null rows are included and have the correct gene names
@@ -396,7 +393,6 @@ def test_get_rows_with_lowest_z_score(empty_db_mock_downloads):
     actual_result = get_rows_with_lowest_z_score(
         dataset_name=dataset_name.name,
         model_id=cell_lines[col_index].model_id,
-        labels_by_row_index=get_gene_labels_by_index(dataset_name.name),
     )
     assert actual_result["model_id"] == cell_lines[col_index].model_id
     assert actual_result["cell_line_col_index"] == col_index

--- a/portal-backend/tests/depmap/cell_line/test_views.py
+++ b/portal-backend/tests/depmap/cell_line/test_views.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
+from depmap import data_access
 from depmap.cell_line.views import (
     convert_to_z_score_matrix,
     get_all_cell_line_gene_effects,
@@ -300,7 +301,7 @@ def test_get_all_cell_line_compound_sensitivities(empty_db_mock_downloads):
     )
 
     # Check that all non-null rows are included and have the correct gene names
-    assert actual_df.index.values.tolist() == [compounds[0].label, compounds[1].label]
+    assert actual_df.index.values.tolist() == [compounds[0].label, compounds[1].label] # TODO: is this not compound label??
 
     # validate each column's values: compound_sensitivity, z_score, mean, stddev
     expected_sensitivities = [2, 0]
@@ -392,6 +393,7 @@ def test_get_rows_with_lowest_z_score(empty_db_mock_downloads):
     actual_result = get_rows_with_lowest_z_score(
         dataset_name=dataset_name.name,
         model_id=cell_lines[col_index].model_id,
+        df=data_access.get_subsetted_df_by_labels(dataset_name.name)
     )
     assert actual_result["model_id"] == cell_lines[col_index].model_id
     assert actual_result["cell_line_col_index"] == col_index

--- a/portal-backend/tests/depmap/cell_line/test_views.py
+++ b/portal-backend/tests/depmap/cell_line/test_views.py
@@ -410,32 +410,3 @@ def test_get_rows_with_lowest_z_score(empty_db_mock_downloads):
     for gene_data in actual_result["data"]:
         cell_line_gene_effect = gene_data[col_index]
         assert cell_line_gene_effect is not None
-
-
-def test_get_compound_labels_by_index(empty_db_mock_downloads):
-    """Test that the compound labels are loaded correctly"""
-    dataset_name = DependencyDataset.DependencyEnum.Rep_all_single_pt
-    cell_lines = [DepmapModelFactory() for _ in range(3)]
-    compounds = [
-        CompoundFactory(label="drug1"),
-        CompoundFactory(label="drug2"),
-        CompoundFactory(label="drug3"),
-        CompoundFactory(label="drug4"),
-    ]
-    compoundExperiments = [
-        CompoundExperimentFactory(compound=compound) for compound in compounds
-    ]
-    matrix = MatrixFactory(
-        data=[[1, 2, 3], [4, 5, 6], [1, 2, 3], [4, 5, 6],],
-        cell_lines=cell_lines,
-        entities=compoundExperiments,
-        using_depmap_model_table=True,
-    )
-    DependencyDatasetFactory(matrix=matrix, name=dataset_name)
-    empty_db_mock_downloads.session.flush()
-    interactive_test_utils.reload_interactive_config()
-
-    actual_labels = get_compound_labels_by_index(dataset_name.name)
-    assert actual_labels.columns.to_list() == ["index", "label"]
-    assert actual_labels["index"].to_list() == [0, 1, 2, 3]
-    assert actual_labels["label"].to_list() == ["drug1", "drug2", "drug3", "drug4"]


### PR DESCRIPTION
**Goal**: Update the cell line page (specifically the Preferential dependency tiles) so that it will work automatically with either:
* PRISM data stored in breadbox (indexed by compound)
* PRISM data stored in the legacy backend (indexed by compound experiment)

I decided to start the compound-related refactoring with this part of the codebase because: 
1. I'm pretty familiar with it
2. It needed to be refactored at some point anyway since it was tightly coupled with the legacy backend
3. This feature does already display compound-level data to users (so the UI doesn't need to change at all)

**The main changes I made here were:**
1. Defining a new method on the `data_access` interface: `get_subsetted_df_by_compound_labels` 
    * This is very similar to our existing function `get_subsetted_df_by_labels` except that when called on a legacy dataset indexed by compound experiment, it will re-index it by compound. 
2. I did some refactoring of the cell line page endpoints to call this new method
3. I moved the compound-experiment-specific functionality to `depmap/compound/legacy_utils.py` where it can be clearly deprecated and hidden behind this new interface 

After refactoring, I confirmed that the existing tests are still passing and that the UI is appearing identically to before (at least with dev data) 
<img width="495" alt="image" src="https://github.com/user-attachments/assets/7ffd28b0-08c3-4b8c-b3c5-8f5e72868fa6" />

**Any feedback is appreciated!** As I work on other parts of the codebase, I will continue to follow this pattern wherever it makes sense. 
