### PR TITLE
fix(breadbox): Improve tabular dataset error handling

### DIFF
--- a/breadbox/breadbox/compute/dataset_uploads_tasks.py
+++ b/breadbox/breadbox/compute/dataset_uploads_tasks.py
@@ -29,7 +29,7 @@ from ..api.uploads import construct_file_from_ids
 from ..io.data_validation import (
     read_and_validate_matrix_df,
     _get_dimension_labels_and_warnings,
-    validate_tabular_df_schema,
+    read_and_validate_tabular_df,
 )
 from .celery import app
 import celery
@@ -159,8 +159,8 @@ def dataset_upload(
 
     else:
         index_type = _get_dimension_type(db, dataset_params.index_type)
-        data_df = validate_tabular_df_schema(
-            file_path, dataset_params.columns_metadata, index_type.id_column
+        data_df = read_and_validate_tabular_df(
+            db, index_type, file_path, dataset_params.columns_metadata
         )
         dimension_labels_and_warnings = _get_dimension_labels_and_warnings(
             db, data_df[index_type.id_column], index_type

--- a/breadbox/breadbox/compute/dataset_uploads_tasks.py
+++ b/breadbox/breadbox/compute/dataset_uploads_tasks.py
@@ -29,7 +29,7 @@ from ..api.uploads import construct_file_from_ids
 from ..io.data_validation import (
     read_and_validate_matrix_df,
     _get_dimension_labels_and_warnings,
-    read_and_validate_tabular_df,
+    validate_tabular_df_schema,
 )
 from .celery import app
 import celery
@@ -159,7 +159,7 @@ def dataset_upload(
 
     else:
         index_type = _get_dimension_type(db, dataset_params.index_type)
-        data_df = read_and_validate_tabular_df(
+        data_df = validate_tabular_df_schema(
             file_path, dataset_params.columns_metadata, index_type.id_column
         )
         dimension_labels_and_warnings = _get_dimension_labels_and_warnings(

--- a/breadbox/breadbox/io/data_validation.py
+++ b/breadbox/breadbox/io/data_validation.py
@@ -523,7 +523,7 @@ def read_and_validate_matrix_df(
     return df
 
 
-def read_and_validate_tabular_df(
+def validate_tabular_df_schema(
     file_path: str,
     columns_metadata: Dict[str, ColumnMetadata],
     dimension_type_identifier: str,

--- a/breadbox/breadbox/schemas/dataset.py
+++ b/breadbox/breadbox/schemas/dataset.py
@@ -189,7 +189,6 @@ class MatrixDatasetParams(SharedDatasetParams):
         # Decision to make allowed values not case-sensitive in case user error in accidental repeats
         allowed_values_list_lower = [str(x).lower() for x in v]
         allowed_values_set = set(allowed_values_list_lower)
-        print(allowed_values_set, allowed_values_list_lower)
         if len(allowed_values_set) != len(v):
             raise UserError(
                 msg="Make sure there are no repeats in allowed_values. Values are not considered case-sensitive",

--- a/breadbox/breadbox/service/dataset.py
+++ b/breadbox/breadbox/service/dataset.py
@@ -22,7 +22,7 @@ from breadbox.crud.group import (
     TRANSIENT_GROUP_ID,
     get_transient_group,
 )
-from ..crud.dimension_types import get_dimension_type
+
 from ..crud.dataset import add_tabular_dimensions, add_matrix_dataset_dimensions
 from ..crud.dimension_types import (
     set_properties_to_index,
@@ -307,8 +307,6 @@ def add_tabular_dataset(
     version: Optional[str],
     description: Optional[str],
 ):
-    _validate_tabular_dimensions(db, dimension_type, columns_metadata, data_df)
-
     group = _get_dataset_group(db, user, dataset_in.group_id, dataset_in.is_transient)
     dataset = TabularDataset(
         id=dataset_in.id,
@@ -336,38 +334,6 @@ def add_tabular_dataset(
     db.flush()
 
     return dataset
-
-
-def _validate_tabular_dimensions(
-    db: SessionWithUser,
-    dimension_type: DimensionType,
-    columns_metadata: Dict[str, ColumnMetadata],
-    data_df: pd.DataFrame,
-):
-    # verify the id_column is present in the data frame before proceeding
-    if dimension_type.id_column not in data_df.columns:
-        raise FileValidationError(
-            f'The dimension type "{dimension_type.name}" uses "{dimension_type.id_column}" for the ID, however that column is not present in the table. The actual columns were: {data_df.columns.to_list()}'
-        )
-
-    missing_metadata = set(data_df.columns).difference(columns_metadata)
-    if len(missing_metadata) > 0:
-        raise FileValidationError(
-            f"The following columns are missing metadata: {', '.join(missing_metadata)}"
-        )
-    extra_metadata = set(columns_metadata).difference(data_df.columns)
-    if len(extra_metadata) > 0:
-        raise FileValidationError(
-            f"The following columns had metadata but are not present in the table: {', '.join(extra_metadata)}"
-        )
-
-    for column_name, column_metadata in columns_metadata.items():
-        if column_metadata.references is not None:
-            dim_type = get_dimension_type(db, column_metadata.references)
-            if dim_type is None:
-                raise FileValidationError(
-                    f"The column '{column_name}' references '{column_metadata.references}' which is not an existing dimension type"
-                )
 
 
 def _get_dataset_group(

--- a/breadbox/breadbox/service/dataset.py
+++ b/breadbox/breadbox/service/dataset.py
@@ -366,7 +366,7 @@ def _validate_tabular_dimensions(
             dim_type = get_dimension_type(db, column_metadata.references)
             if dim_type is None:
                 raise FileValidationError(
-                    f"The column {column_name} references {column_metadata.references} which does not exit"
+                    f"The column '{column_name}' references '{column_metadata.references}' which is not an existing dimension type"
                 )
 
 

--- a/breadbox/breadbox/service/dataset.py
+++ b/breadbox/breadbox/service/dataset.py
@@ -14,7 +14,7 @@ from ..schemas.dataset import (
     ColumnMetadata,
 )
 
-from ..schemas.custom_http_exception import DatasetAccessError
+from ..schemas.custom_http_exception import DatasetAccessError, FileValidationError
 from breadbox.crud.access_control import user_has_access_to_group
 from breadbox.models.dataset import MatrixDataset
 from breadbox.crud.group import (
@@ -346,18 +346,18 @@ def _validate_tabular_dimensions(
 ):
     # verify the id_column is present in the data frame before proceeding
     if dimension_type.id_column not in data_df.columns:
-        raise ValueError(
+        raise FileValidationError(
             f'The dimension type "{dimension_type.name}" uses "{dimension_type.id_column}" for the ID, however that column is not present in the table. The actual columns were: {data_df.columns.to_list()}'
         )
 
     missing_metadata = set(data_df.columns).difference(columns_metadata)
     if len(missing_metadata) > 0:
-        raise ValueError(
+        raise FileValidationError(
             f"The following columns are missing metadata: {', '.join(missing_metadata)}"
         )
     extra_metadata = set(columns_metadata).difference(data_df.columns)
     if len(extra_metadata) > 0:
-        raise ValueError(
+        raise FileValidationError(
             f"The following columns had metadata but are not present in the table: {', '.join(extra_metadata)}"
         )
 
@@ -365,7 +365,7 @@ def _validate_tabular_dimensions(
         if column_metadata.references is not None:
             dim_type = get_dimension_type(db, column_metadata.references)
             if dim_type is None:
-                raise ValueError(
+                raise FileValidationError(
                     f"The column {column_name} references {column_metadata.references} which does not exit"
                 )
 

--- a/breadbox/tests/io/test_data_validation.py
+++ b/breadbox/tests/io/test_data_validation.py
@@ -7,7 +7,7 @@ from breadbox.io.data_validation import (
     AnnotationType,
     FileValidationError,
     read_and_validate_matrix_df,
-    read_and_validate_tabular_df,
+    validate_tabular_df_schema,
     ValueType,
 )
 import pytest
@@ -98,13 +98,13 @@ def test_read_and_validate_matrix_df(tmpdir):
     assert df.columns.to_list() == ["10", "11"]
 
 
-def test_read_and_validate_tabular_df(tmpdir):
+def test_validate_tabular_df_schema(tmpdir):
     def to_csv(*args, **kwargs):
         return _to_csv(tmpdir, *args, **kwargs)
 
     # fewer edge cases with tables. Just exercise columns with numbers to see if
     # anything weird happens
-    df = read_and_validate_tabular_df(
+    df = validate_tabular_df_schema(
         to_csv(pd.DataFrame("0", columns=["13", "10", "11"], index=[1]), index=False),
         {
             "10": ColumnMetadata(col_type=AnnotationType.text),
@@ -121,7 +121,7 @@ def test_read_and_validate_tabular_df(tmpdir):
     import json
 
     # didn't test parsing str lists, so do that here
-    df = read_and_validate_tabular_df(
+    df = validate_tabular_df_schema(
         to_csv(
             pd.DataFrame([["0", json.dumps(["1", "2"])]], columns=["ID", "list"]),
             index=False,

--- a/breadbox/tests/io/test_data_validation.py
+++ b/breadbox/tests/io/test_data_validation.py
@@ -7,7 +7,7 @@ from breadbox.io.data_validation import (
     AnnotationType,
     FileValidationError,
     read_and_validate_matrix_df,
-    validate_tabular_df_schema,
+    _validate_tabular_df_schema,
     ValueType,
 )
 import pytest
@@ -104,7 +104,7 @@ def test_validate_tabular_df_schema(tmpdir):
 
     # fewer edge cases with tables. Just exercise columns with numbers to see if
     # anything weird happens
-    df = validate_tabular_df_schema(
+    df = _validate_tabular_df_schema(
         to_csv(pd.DataFrame("0", columns=["13", "10", "11"], index=[1]), index=False),
         {
             "10": ColumnMetadata(col_type=AnnotationType.text),
@@ -121,7 +121,7 @@ def test_validate_tabular_df_schema(tmpdir):
     import json
 
     # didn't test parsing str lists, so do that here
-    df = validate_tabular_df_schema(
+    df = _validate_tabular_df_schema(
         to_csv(
             pd.DataFrame([["0", json.dumps(["1", "2"])]], columns=["ID", "list"]),
             index=False,


### PR DESCRIPTION
### Issue 1
The issue fixed was that the celery worker ran into a `ValueError` when trying to upload a tabular dataset instead of an `HTTPException` which the celery task result handler couldn't process into a meaningful error message to the client.

![Screenshot 2025-01-24 at 12 09 19 PM](https://github.com/user-attachments/assets/7e1ce543-21bd-4d0b-b939-c243d421c123)

### Issue 2
While fixing the above issue, another issue discovered was that although we had a validation check for the dimension type id column missing in the dataset file upload, it was not being caught since the validation happens AFTER we try to access the missing id column in the file in the code. I did some refactoring since there were multiple places we handle validation for tabular datasets and cleaned up the logic to ensure validation to dataset occurs earlier.

![Screenshot 2025-01-24 at 2 18 40 PM](https://github.com/user-attachments/assets/0cb5cb4e-463d-431d-8ab6-522030879545)
![Screenshot 2025-01-24 at 2 45 37 PM](https://github.com/user-attachments/assets/760cca04-5a46-4edf-bd18-0ca6a2a64e10)