### PR TITLE
Fix error detail accessor

### DIFF
--- a/frontend/packages/@depmap/dataset-manager/src/components/DatasetForm.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/DatasetForm.tsx
@@ -16,6 +16,7 @@ import {
   SampleDimensionType,
   FeatureDimensionType,
   Dataset,
+  instanceOfErrorDetail,
 } from "@depmap/types";
 import ChunkedFileUploader from "./ChunkedFileUploader";
 import { CeleryTask } from "@depmap/compute";
@@ -163,7 +164,18 @@ export default function DatasetForm(props: DatasetFormProps) {
   */
   const reject = useCallback((res: any) => {
     const isCeleryTask = (x: any): x is CeleryTask => x.state !== undefined;
-    if (!isCeleryTask(res)) {
+    if (isCeleryTask(res)) {
+      setCompletedTask(res);
+    } else if (instanceOfErrorDetail(res)) {
+      // can occur when error happens before task passed to celery (ex: 'units' missing in 'continuous' col_type)
+      setCompletedTask({
+        id: "",
+        state: "FAILURE",
+        percentComplete: undefined,
+        message: res.detail,
+        result: null,
+      });
+    } else {
       setCompletedTask({
         id: "",
         state: "FAILURE",
@@ -172,8 +184,6 @@ export default function DatasetForm(props: DatasetFormProps) {
           "Unexpected error. If you get this error consistently, please contact us with a screenshot and the actions that lead to this error.",
         result: null,
       });
-    } else {
-      setCompletedTask(res);
     }
     setIsTaskRunning(false);
   }, []);

--- a/frontend/packages/@depmap/dataset-manager/src/components/DimensionTypeForm.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/DimensionTypeForm.tsx
@@ -5,7 +5,7 @@ import Form from "@rjsf/core";
 import { addDimensionTypeSchema } from "../models/addDimensionTypeSchema";
 import { RJSFSchema, UiSchema } from "@rjsf/utils";
 import { updateDimensionTypeSchema } from "../models/updateDimensionTypeSchema";
-import { Dataset } from "@depmap/types";
+import { Dataset, instanceOfErrorDetail } from "@depmap/types";
 
 interface DimensionTypeFormProps {
   onSubmit: (formData: any) => Promise<void>;
@@ -90,7 +90,7 @@ export default function DimensionTypeForm(props: DimensionTypeFormProps) {
     } catch (e: any) {
       console.log(e);
       setHasError(true);
-      if ("detail" in e) {
+      if (instanceOfErrorDetail(e)) {
         setSubmissionMsg(e.detail as string);
       } else {
         setSubmissionMsg("An unknown error occurred!");

--- a/frontend/packages/@depmap/groups-manager/src/components/GroupsPage.tsx
+++ b/frontend/packages/@depmap/groups-manager/src/components/GroupsPage.tsx
@@ -113,7 +113,7 @@ export default function GroupsPage(props: GroupsPageProps) {
     } catch (e) {
       console.error(e);
       if (instanceOfErrorDetail(e)) {
-        setAddGroupError(e.body.detail);
+        setAddGroupError(e.detail);
       }
     }
   };
@@ -127,7 +127,7 @@ export default function GroupsPage(props: GroupsPageProps) {
     } catch (e) {
       console.error(e);
       if (instanceOfErrorDetail(e)) {
-        setAddGroupError(e.body.detail);
+        setAddGroupError(e.detail);
       }
     }
   };
@@ -171,7 +171,7 @@ export default function GroupsPage(props: GroupsPageProps) {
       if (instanceOfErrorDetail(e)) {
         setGroupEntryErrors({
           ...groupEntryErrors,
-          addGroupEntryError: e.body.detail,
+          addGroupEntryError: e.detail,
         });
       }
     }
@@ -240,7 +240,7 @@ export default function GroupsPage(props: GroupsPageProps) {
       if (instanceOfErrorDetail(e)) {
         setGroupEntryErrors({
           ...groupEntryErrors,
-          updateGroupEntryError: e.body.detail,
+          updateGroupEntryError: e.detail,
         });
       }
     }

--- a/frontend/packages/@depmap/types/src/ErrorDetail.ts
+++ b/frontend/packages/@depmap/types/src/ErrorDetail.ts
@@ -1,14 +1,7 @@
-interface BodyDetailError {
-  body: { detail: string };
-}
-
-interface DetailError {
+interface ErrorDetail {
   detail: string;
 }
 
-// TODO: Verify whether this backwards compatibility safeguard is necessary. Error response verified to follow DetailError type definition so far
-type ErrorDetail = BodyDetailError | DetailError;
-
 export function instanceOfErrorDetail(object: any): object is ErrorDetail {
-  return "detail" in object || ("body" in object && "detail" in object.body);
+  return "detail" in object;
 }

--- a/frontend/packages/@depmap/types/src/ErrorDetail.ts
+++ b/frontend/packages/@depmap/types/src/ErrorDetail.ts
@@ -1,7 +1,14 @@
-export default interface ErrorDetail {
+interface BodyDetailError {
   body: { detail: string };
 }
 
+interface DetailError {
+  detail: string;
+}
+
+// TODO: Verify whether this backwards compatibility safeguard is necessary. Error response verified to follow DetailError type definition so far
+type ErrorDetail = BodyDetailError | DetailError;
+
 export function instanceOfErrorDetail(object: any): object is ErrorDetail {
-  return "body" in object && "detail" in object.body;
+  return "detail" in object || ("body" in object && "detail" in object.body);
 }


### PR DESCRIPTION
When debugging an error, I encountered a different error when trying to upload a dataset with bad request params. The error returned provided a vague error message. Looking into this more, it looks like the upload dataset function encountered an error before the task was passed to celery resulting in a non-celery error being uncaught on the frontend. We already had a function that checks if a response object is an error but its property accessors were incorrect presumably due to earlier deprecated changes.

### Fix catches non-celery error and correctly shows error message in UI
![Screenshot 2025-01-23 at 6 11 02 PM](https://github.com/user-attachments/assets/308a1b91-33f3-44f4-82ae-e951d196cd1a)
