### PR TITLE
fix(breadbox): Refactor tabular dataset schema error

### DIFF
--- a/breadbox/breadbox/io/data_validation.py
+++ b/breadbox/breadbox/io/data_validation.py
@@ -628,7 +628,7 @@ def _validate_tabular_df_schema(
     )
 
     # NOTE: missing values are denoted as pd.NA
-    df = pd.read_csv(file_path)
+    df = pd.read_csv(file_path, dtype=str)
     try:
         validated_df = schema.validate(df)
     except SchemaError as schema_error:

--- a/breadbox/breadbox/io/data_validation.py
+++ b/breadbox/breadbox/io/data_validation.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 from pandas.api.types import is_numeric_dtype, is_string_dtype, is_bool_dtype
 import pandera as pa
-from pandera.errors import SchemaError
+from pandera.errors import SchemaError, SchemaErrorReason
 from fastapi import UploadFile
 from sqlalchemy import and_, or_
 
@@ -613,43 +613,26 @@ def _validate_tabular_df_schema(
     schema = pa.DataFrameSchema(
         {
             k: pa.Column(
-                annotation_type_to_pandas_column_type(
-                    v.col_type
-                ),  # annotation_type_to_pandera_column_type(v.col_type),
-                nullable=False if dimension_type_identifier == k else True,
+                annotation_type_to_pandas_column_type(v.col_type),
+                coerce=True,  # SchemaErrorReason: DATATYPE_COERCION
+                nullable=False
+                if dimension_type_identifier == k
+                else True,  # SchemaErrorReason: SERIES_CONTAINS_NULLS
                 checks=get_checks_for_col(v.col_type),
-                unique=dimension_type_identifier == k,
+                unique=dimension_type_identifier == k,  # SchemaErrorReason: DUPLICATES
             )
             for k, v in columns_metadata.items()
         },
         index=None,
-        strict=True,  # Df only contains columns in schema
+        strict=True,  # Df only contains columns in schema. SchemaErrorReason: COLUMN_NOT_IN_SCHEMA or COLUMN_NOT_IN_DATAFRAME
     )
 
     # NOTE: missing values are denoted as pd.NA
-    df = pd.read_csv(
-        file_path,
-        dtype={
-            k: annotation_type_to_pandas_column_type(v.col_type)
-            for k, v in columns_metadata.items()
-        },
-    )
+    df = pd.read_csv(file_path)
     try:
         validated_df = schema.validate(df)
     except SchemaError as schema_error:
         error_msg = str(schema_error)
-        if schema_error.check is not None:
-            if (
-                hasattr(schema_error.check, "name")
-                and schema_error.check.name == "can_parse_list_strings"
-            ):
-                if schema_error.failure_cases is not None and hasattr(
-                    schema_error.failure_cases, "failure_case"
-                ):
-                    error_msg = str(schema_error.failure_cases.failure_case[0])
-            if isinstance(schema_error.check, str):
-                error_msg = schema_error.check
-            # error message returned for failed json deserialization is long so truncate it
         if schema_error.reason_code == SchemaErrorReason.COLUMN_NOT_IN_SCHEMA:
             # Original error msg: "column '{column_name}' not in DataFrameSchema <schema>"
             # Modify error message vocabulary to be more intuitive to users

--- a/breadbox/breadbox/io/data_validation.py
+++ b/breadbox/breadbox/io/data_validation.py
@@ -650,6 +650,10 @@ def _validate_tabular_df_schema(
             if isinstance(schema_error.check, str):
                 error_msg = schema_error.check
             # error message returned for failed json deserialization is long so truncate it
+        if schema_error.reason_code == SchemaErrorReason.COLUMN_NOT_IN_SCHEMA:
+            # Original error msg: "column '{column_name}' not in DataFrameSchema <schema>"
+            # Modify error message vocabulary to be more intuitive to users
+            error_msg = error_msg.split("DataFrameSchema")[0] + "Columns Metadata"
 
         raise FileValidationError(error_msg) from schema_error
     return validated_df

--- a/breadbox/breadbox/io/data_validation.py
+++ b/breadbox/breadbox/io/data_validation.py
@@ -628,7 +628,16 @@ def _validate_tabular_df_schema(
     )
 
     # NOTE: missing values are denoted as pd.NA
-    df = pd.read_csv(file_path, dtype=str)
+    try:
+        df = pd.read_csv(
+            file_path,
+            dtype={
+                k: annotation_type_to_pandas_column_type(v.col_type)
+                for k, v in columns_metadata.items()
+            },
+        )
+    except ValueError as val_e:
+        raise FileValidationError(str(val_e)) from val_e
     try:
         validated_df = schema.validate(df)
     except SchemaError as schema_error:

--- a/breadbox/tests/io/test_data_validation.py
+++ b/breadbox/tests/io/test_data_validation.py
@@ -137,3 +137,43 @@ def test_validate_tabular_df_schema(tmpdir):
     # I think it's make sense for read_and_validate_tabular_df to parse the list column, but it doesn't today
     # so leaving it this way and just reflecting that in the test case
     assert df["list"].to_list() == ['["1", "2"]']
+
+    df = _validate_tabular_df_schema(
+        to_csv(
+            pd.DataFrame(
+                {
+                    "ID": ["id1", "id2", "id3"],
+                    "col1": [1, 2.1, 3],
+                    "col2": ["1", "2.1", "3"],
+                    "col3": [1, 1.1, 1],
+                    "col4": [1, 0, 1],
+                    "col5": ["1", "1.1", "1"],
+                },
+                columns=["ID", "col1", "col2", "col3", "col4", "col5"],
+            ),
+            index=False,
+        ),
+        {
+            "ID": ColumnMetadata(col_type=AnnotationType.text),
+            "col1": ColumnMetadata(col_type=AnnotationType.continuous, units="units"),
+            "col2": ColumnMetadata(col_type=AnnotationType.text),
+            "col3": ColumnMetadata(col_type=AnnotationType.categorical),
+            "col4": ColumnMetadata(col_type=AnnotationType.categorical),
+            "col5": ColumnMetadata(col_type=AnnotationType.categorical),
+        },
+        "ID",
+    )
+    assert df["col1"].to_list() == [1.0, 2.1, 3.0]
+    assert df["col1"].dtype == pd.Float64Dtype()
+    assert df["col2"].to_list() == ["1", "2.1", "3"]
+    assert df["col2"].dtype == pd.StringDtype()
+    assert df["col3"].to_list() == ["1.0", "1.1", "1.0"]
+    assert df["col3"].dtype == pd.CategoricalDtype(
+        categories=["1.0", "1.1"], ordered=False
+    )
+    assert df["col4"].to_list() == ["1", "0", "1"]
+    assert df["col4"].dtype == pd.CategoricalDtype(categories=["0", "1"], ordered=False)
+    assert df["col5"].to_list() == ["1", "1.1", "1"]
+    assert df["col5"].dtype == pd.CategoricalDtype(
+        categories=["1", "1.1"], ordered=False
+    )


### PR DESCRIPTION
Error message returned to client is an obscure pandera error. Change error message to be more intuitive to users

This PR addresses the original task's use case. While completing this task, I noticed many pandera error codes are obscure and that stringifying the SchemaError often gives a better error message. However, in some cases doing so messes up the formatting of the message in the frontend so that is a TODO that I will address later. In addition, it is difficult to catch every single schema error case but I have noted down the types of errors I have accounted for and expect the schema validation to catch so far..

![Screenshot 2025-01-29 at 4 13 07 PM](https://github.com/user-attachments/assets/71118e30-cb7a-4d5d-b891-08635d7f4ffa)
