### PR TITLE
feat(breadbox): Aggregate matrix dataset

### DIFF
--- a/breadbox/breadbox/schemas/dataset.py
+++ b/breadbox/breadbox/schemas/dataset.py
@@ -43,6 +43,13 @@ class SliceQueryIdentifierType(enum.Enum):
     column = "column"
 
 
+class AggregationMethod(enum.Enum):
+    mean = "mean"
+    median = "median"
+    per25 = "25%tile"
+    per75 = "75%tile"
+
+
 # NOTE: `param: Annotated[Optional[str], Field(None)]` gives pydantic error 'ValueError: `Field` default cannot be set in `Annotated` for 'param''.
 # `param: Annotated[Optional[str], Field()] = None` solves the default issue
 # According to https://github.com/pydantic/pydantic/issues/8118 this issue is only in Pydantic V1.10 not V2.0.
@@ -425,6 +432,10 @@ class MatrixDimensionsInfo(BaseModel):
             description="Denotes whether the list of samples are given as ids or sample labels"
         ),
     ] = None
+    aggregate: Annotated[
+        Optional[MatrixAggregation],
+        Field(description="Aggregates features or samples into a single series"),
+    ] = None
 
     @model_validator(mode="after")
     def check_valid_values(self):
@@ -444,6 +455,13 @@ class MatrixDimensionsInfo(BaseModel):
             )
         else:
             return self
+
+
+class MatrixAggregation(BaseModel):
+    aggregate_by: Literal[
+        "features", "samples"
+    ]  # collapse features or samples into a single series
+    aggregation: AggregationMethod  # Literal["mean", "median", "25%tile", "75%tile"]
 
 
 class FeatureResponse(BaseModel):

--- a/breadbox/breadbox/service/dataset.py
+++ b/breadbox/breadbox/service/dataset.py
@@ -173,12 +173,11 @@ def _aggregate_matrix_df(
     }
 
     # Replace None with numpy nan so np.nanpercentile works
-    df = df.replace({pd.NA: np.nan})
+    nan_df: pd.DataFrame = df.replace({pd.NA: np.nan})
 
-    df = df.agg(
+    return nan_df.agg(
         enum_to_agg_method[aggregation], axis=0 if aggregate_by == "samples" else 1
     )
-    return df
 
 
 def get_subsetted_tabular_dataset_df(

--- a/breadbox/breadbox/service/dataset.py
+++ b/breadbox/breadbox/service/dataset.py
@@ -6,6 +6,8 @@ from breadbox.schemas.dataset import (
     FeatureSampleIdentifier,
     MatrixDimensionsInfo,
     TabularDimensionsInfo,
+    AggregationMethod,
+    ValueType,
 )
 from breadbox.service import metadata as metadata_service
 import logging
@@ -36,6 +38,7 @@ from typing import Any, Dict, List, Literal, Optional, Type, Union
 from uuid import uuid4
 
 import pandas as pd
+import numpy as np
 
 from breadbox.schemas.types import UpdateDimensionType
 from breadbox.db.session import SessionWithUser
@@ -143,6 +146,30 @@ def get_subsetted_matrix_dataset_df(
         )
         df = df.rename(index=label_by_id)
 
+    if dimensions_info.aggregate:
+        aggregate_by, aggregation = (
+            dimensions_info.aggregate.aggregate_by,
+            dimensions_info.aggregate.aggregation,
+        )
+
+        if dataset.value_type != ValueType.continuous:
+            raise UserError(
+                f"The 'value_type' of {dataset.name} is {dataset.value_type}. Dataset must have continuous values! "
+            )
+
+        enum_to_agg_method = {
+            AggregationMethod.mean: np.mean,
+            AggregationMethod.median: np.median,
+            AggregationMethod.per25: lambda x: np.nanpercentile(x, q=0.25),
+            AggregationMethod.per75: lambda x: np.nanpercentile(x, q=0.75),
+        }
+
+        # Replace None with numpy nan so np.nanpercentile works
+        df = df.replace({pd.NA: np.nan})
+
+        df = df.agg(
+            enum_to_agg_method[aggregation], axis=0 if aggregate_by == "samples" else 1
+        )
     return df
 
 

--- a/breadbox/breadbox/service/dataset.py
+++ b/breadbox/breadbox/service/dataset.py
@@ -149,7 +149,7 @@ def get_subsetted_matrix_dataset_df(
     if dimensions_info.aggregate:
         if dataset.value_type != ValueType.continuous:
             raise UserError(
-                f"The 'value_type' of {dataset.name} is {dataset.value_type}. Dataset must have continuous values! "
+                f"The `value_type` of '{dataset.name}' is '{dataset.value_type.value}'. Dataset must have continuous values! "
             )
 
         df = _aggregate_matrix_df(

--- a/breadbox/breadbox/service/dataset.py
+++ b/breadbox/breadbox/service/dataset.py
@@ -177,7 +177,7 @@ def _aggregate_matrix_df(
 
     return nan_df.agg(
         enum_to_agg_method[aggregation], axis=0 if aggregate_by == "samples" else 1
-    )
+    ).to_frame(name=aggregation.value)
 
 
 def get_subsetted_tabular_dataset_df(

--- a/breadbox/tests/api/test_datasets.py
+++ b/breadbox/tests/api/test_datasets.py
@@ -2577,6 +2577,50 @@ class TestPost:
         """
         assert response.json() == {"Id1": 2, "Id3": 3}
 
+    def test_bad_matrix_dataset_categorical_aggregation(
+        self,
+        client: TestClient,
+        minimal_db: SessionWithUser,
+        settings,
+        mock_celery,
+        public_group,
+        tmpdir,
+    ):
+        data_path = str(tmpdir.join("dataset.csv"))
+        pd.DataFrame(
+            {"A": ["Yes", "No", "Yes"], "B": ["No", pd.NA, "Yes"]},
+            index=["Id1", "Id2", "Id3"],
+        ).to_csv(data_path)
+
+        file_ids, expected_md5 = upload_and_get_file_ids(client, filename=data_path)
+
+        admin_headers = {"X-Forwarded-Email": settings.admin_users[0]}
+        matrix_dataset = client.post(
+            "/dataset-v2/",
+            json={
+                "format": "matrix",
+                "name": "Test Aggregation Categorical Dataset",
+                "units": "a unit",
+                "feature_type": "generic",
+                "sample_type": "depmap_model",
+                "data_type": "User upload",
+                "file_ids": file_ids,
+                "dataset_md5": expected_md5,
+                "is_transient": False,
+                "group_id": public_group.id,
+                "value_type": "categorical",
+                "allowed_values": ["Yes", "No"],
+            },
+            headers=admin_headers,
+        )
+        assert_status_ok(matrix_dataset)
+
+        response = client.post(
+            f"/datasets/matrix/{matrix_dataset.json()['result']['datasetId']}",
+            json={"aggregate": {"aggregate_by": "samples", "aggregation": "mean"}},
+        )
+        assert_status_not_ok(response)
+
     def test_get_tabular_dataset_data(
         self,
         client: TestClient,

--- a/breadbox/tests/api/test_datasets.py
+++ b/breadbox/tests/api/test_datasets.py
@@ -2539,12 +2539,13 @@ class TestPost:
         )
         """
         Expected:
+            mean
         ------------------- 
         A     2
         B     3.5
         C     3
         """
-        assert response.json() == {"A": 2, "B": 3.5, "C": 3}
+        assert response.json() == {"mean": {"A": 2, "B": 3.5, "C": 3}}
 
         response = client.post(
             f"/datasets/matrix/{matrix_dataset.json()['result']['datasetId']}",
@@ -2552,12 +2553,13 @@ class TestPost:
         )
         """
         Expected:
+            25%tile
         ------------------- 
         A    1.0050
         B    3.0025
         C    2.0050
         """
-        assert response.json() == {"A": 1.0050, "B": 3.0025, "C": 2.0050}
+        assert response.json() == {"25%tile": {"A": 1.0050, "B": 3.0025, "C": 2.0050}}
 
         response = client.post(
             f"/datasets/matrix/{matrix_dataset.json()['result']['datasetId']}",
@@ -2571,11 +2573,12 @@ class TestPost:
         )
         """
         Expected:
+                mean
         ------------------- 
         Id1     2
         Id3     3
         """
-        assert response.json() == {"Id1": 2, "Id3": 3}
+        assert response.json() == {"mean": {"Id1": 2, "Id3": 3}}
 
     def test_bad_matrix_dataset_categorical_aggregation(
         self,


### PR DESCRIPTION
Add aggregation to api endpoint: `/datasets/matrix/{dataset_id}` which can return a subsetted matrix df as well as aggregate the df on either axis.