### PR TITLE
context selection is broken on Compound Sensitivity tab

### DIFF
--- a/frontend/packages/portal-frontend/src/entity/components/EntitySummary.tsx
+++ b/frontend/packages/portal-frontend/src/entity/components/EntitySummary.tsx
@@ -11,8 +11,10 @@ import {
   ControlLabel,
 } from "react-bootstrap";
 import { Checkbox } from "@depmap/common-components";
+import { DeprecatedDataExplorerApiProvider } from "@depmap/data-explorer-2";
 import DropdownButton from "src/common/components/DropdownButton";
 import { CellLineListsDropdown, CustomList } from "@depmap/cell-line-selector";
+import { evaluateLegacyContext } from "src/data-explorer-2/deprecated-api";
 import { getDapi } from "src/common/utilities/context";
 import { DepmapApi, EntitySummaryResponse } from "src/dAPI";
 import { PlotHTMLElement } from "@depmap/plotly-wrapper";
@@ -385,16 +387,20 @@ class EntitySummary extends React.Component<Props, State> {
 
   render() {
     return (
-      <Row>
-        <Col sm={2}>
-          {this.renderControls()}
-          {this.renderLegends()}
-        </Col>
-        <Col sm={10}>
-          {this.renderHeader()}
-          {this.renderPlots()}
-        </Col>
-      </Row>
+      <DeprecatedDataExplorerApiProvider
+        evaluateLegacyContext={evaluateLegacyContext}
+      >
+        <Row>
+          <Col sm={2}>
+            {this.renderControls()}
+            {this.renderLegends()}
+          </Col>
+          <Col sm={10}>
+            {this.renderHeader()}
+            {this.renderPlots()}
+          </Col>
+        </Row>
+      </DeprecatedDataExplorerApiProvider>
     );
   }
 }


### PR DESCRIPTION
All the frontend code that relies on old DE2 APIs now has to explicitly opt-in. That will make it easy us for shutdown those endpoints and know what code needs to be updated. Unfortunately I missed out a lot of those places and now we're discovering them as bugs 🤦