### PR TITLE
Filter datasets by access

### DIFF
--- a/frontend/packages/@depmap/api/src/ApiContext.tsx
+++ b/frontend/packages/@depmap/api/src/ApiContext.tsx
@@ -77,7 +77,7 @@ export interface SharedApi {
     datasetId: string,
     datasetToUpdate: DatasetUpdateArgs
   ) => Promise<BreadboxDataset>;
-  getGroups: () => Promise<Group[]>;
+  getGroups: (writeAccess?: boolean) => Promise<Group[]>;
   postGroup: (groupArgs: GroupArgs) => Promise<Group>;
   deleteGroup: (id: string) => Promise<any>;
   postGroupEntry: (

--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -121,7 +121,7 @@ export default function Datasets() {
         let currentDatasets = await dapi.getBreadboxDatasets();
 
         if (!isAdvancedMode) {
-          const writeGroups = await getGroups();
+          const writeGroups = await dapi.getGroups(!isAdvancedMode);
           const group_ids = writeGroups.map((group) => {
             return group.id;
           });

--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -53,7 +53,10 @@ export default function Datasets() {
       dapi.updateDimensionType(dimTypeName, dimTypeArgs),
     [dapi]
   );
-  const getGroups = useCallback(() => dapi.getGroups(), [dapi]);
+  const getGroups = useCallback(() => dapi.getGroups(!isAdvancedMode), [
+    dapi,
+    isAdvancedMode,
+  ]); // write access set to true if not advanced mode
   const getDataTypesAndPriorities = useCallback(
     () => dapi.getDataTypesAndPriorities(),
     [dapi]
@@ -115,7 +118,17 @@ export default function Datasets() {
   useEffect(() => {
     (async () => {
       try {
-        const currentDatasets = await dapi.getBreadboxDatasets();
+        let currentDatasets = await dapi.getBreadboxDatasets();
+
+        if (!isAdvancedMode) {
+          const writeGroups = await getGroups();
+          const group_ids = writeGroups.map((group) => {
+            return group.id;
+          });
+          currentDatasets = currentDatasets.filter((dataset) =>
+            group_ids.includes(dataset.group_id)
+          );
+        }
 
         setDatasets(currentDatasets);
         const dimensionTypeDatasetNum = dimensionTypeDatasetCount(
@@ -139,7 +152,7 @@ export default function Datasets() {
         setInitError(true);
       }
     })();
-  }, [dapi, getDimensionTypes]);
+  }, [dapi, getDimensionTypes, getGroups, isAdvancedMode]);
 
   const datasetForm = useCallback(() => {
     if (datasets) {

--- a/frontend/packages/portal-frontend/src/bbAPI.ts
+++ b/frontend/packages/portal-frontend/src/bbAPI.ts
@@ -368,8 +368,9 @@ export class BreadboxApi {
     return dataTypesPriorities;
   }
 
-  getGroups(): Promise<Group[]> {
-    return this._fetch<Group[]>("/groups/");
+  getGroups(writeAccess: boolean = false): Promise<Group[]> {
+    const queryParams = { write_access: writeAccess };
+    return this._fetch<Group[]>(`/groups/?${encodeParams(queryParams)}`);
   }
 
   postGroup(groupArgs: GroupArgs): Promise<Group> {

--- a/frontend/packages/portal-frontend/src/dAPI.ts
+++ b/frontend/packages/portal-frontend/src/dAPI.ts
@@ -944,7 +944,7 @@ export class DepmapApi {
     return Promise.reject(Error("Wrong api used. Check ApiContext"));
   }
 
-  getGroups = (): Promise<Group[]> => {
+  getGroups = (writeAccess: boolean = false): Promise<Group[]> => {
     return Promise.reject(Error("Wrong api used. Check ApiContext"));
   };
 


### PR DESCRIPTION
In simple mode only, filter out datasets that user does not have write access to. In advanced mode, datasets in groups that user have read or write access are shown and are an option

