### PR TITLE
Fix dataset manager delete errors

### DIFF
--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -4,6 +4,7 @@ import {
   DatasetParams,
   DatasetTableData,
   DatasetUpdateArgs,
+  DimensionType,
   // instanceOfErrorDetail,
   DimensionTypeAddArgs,
   DimensionTypeUpdateArgs,
@@ -193,9 +194,22 @@ export default function Datasets() {
             uploadDataset={postDatasetUpload}
             isAdvancedMode={isAdvancedMode}
             getTaskStatus={getTaskStatus}
-            onSuccess={(dataset: Dataset) =>
-              setDatasets([...datasets, dataset])
-            }
+            onSuccess={(dataset: Dataset) => {
+              const addedDatasets = [...datasets, dataset];
+              setDatasets(addedDatasets);
+              const dimTypeDatasetsNum = dimensionTypeDatasetCount(
+                addedDatasets
+              );
+              setDimensionTypes((oldDimensionTypes) => {
+                if (oldDimensionTypes == null) {
+                  // condition to make eslint happy. TBD: consider changing typing
+                  return null;
+                }
+                return oldDimensionTypes.map((dt) => {
+                  return { ...dt, datasetsCount: dimTypeDatasetsNum[dt.name] };
+                });
+              });
+            }}
           />
         );
       }

--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -7,6 +7,7 @@ import {
   // instanceOfErrorDetail,
   DimensionTypeAddArgs,
   DimensionTypeUpdateArgs,
+  instanceOfErrorDetail,
 } from "@depmap/types";
 
 import { FormModal, Spinner, ToggleSwitch } from "@depmap/common-components";
@@ -27,9 +28,7 @@ export default function Datasets() {
   const [datasets, setDatasets] = useState<Dataset[] | null>(null);
 
   const [initError, setInitError] = useState(false);
-  // const [datasetSubmissionError, setDatasetSubmissionError] = useState<
-  //   string | null
-  // >(null);
+
   const [isAdvancedMode, setIsAdvancedMode] = useState(false);
   const [selectedDatasetIds, setSelectedDatasetIds] = useState<Set<string>>(
     new Set()
@@ -84,6 +83,11 @@ export default function Datasets() {
   const [isEditDimensionTypeMode, setIsEditDimensionTypeMode] = useState(false);
   const [showDimensionTypeModal, setShowDimensionTypeModal] = useState(false);
   const [showDeleteError, setShowDeleteError] = useState(false);
+
+  const [showDimTypeDeleteError, setShowDimTypeDeleteError] = useState(false);
+  const [dimTypeDeleteError, setDimTypeDeleteError] = useState<str | null>(
+    null
+  );
 
   const dimensionTypeDatasetCount = (datasetsList: Dataset[]) =>
     datasetsList.reduce(
@@ -407,11 +411,15 @@ export default function Datasets() {
         }
 
         isDeleted = true;
-        setShowDeleteError(false);
+        setShowDimTypeDeleteError(false);
+        setDimTypeDeleteError(null);
       }
     } catch (e) {
-      setShowDeleteError(true);
+      setShowDimTypeDeleteError(true);
       console.error(e);
+      if (instanceOfErrorDetail(e)) {
+        setDimTypeDeleteError(e.detail);
+      }
     }
     if (isDeleted) {
       setDimensionTypes(
@@ -531,13 +539,12 @@ export default function Datasets() {
           <div>
             <h1>Dimension Types</h1>
 
-            {showDeleteError && (
+            {showDimTypeDeleteError && selectedDimensionType !== null && (
               <Alert bsStyle="danger">
                 <strong>
                   Delete &quot;{selectedDimensionType.name}&quot; Failed!
                 </strong>{" "}
-                Make sure &quot;{selectedDimensionType.name}&quot; has no
-                datasets with its dimension type.
+                {dimTypeDeleteError !== null ? dimTypeDeleteError : null}
               </Alert>
             )}
 
@@ -576,7 +583,8 @@ export default function Datasets() {
                   } else {
                     setSelectedDimensionType(null);
                   }
-                  setShowDeleteError(false);
+                  setShowDimTypeDeleteError(false);
+                  setDimTypeDeleteError(null);
                 }}
                 rowHeight={40}
                 columns={[

--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -82,14 +82,13 @@ export default function Datasets() {
   >(null);
   const [isEditDimensionTypeMode, setIsEditDimensionTypeMode] = useState(false);
   const [showDimensionTypeModal, setShowDimensionTypeModal] = useState(false);
-  const [showDeleteError, setShowDeleteError] = useState(false);
 
   const [showDatasetDeleteError, setShowDatasetDeleteError] = useState(false);
-  const [datasetDeleteError, setDatasetDeleteError] = useState<str | null>(
+  const [datasetDeleteError, setDatasetDeleteError] = useState<string | null>(
     null
   );
   const [showDimTypeDeleteError, setShowDimTypeDeleteError] = useState(false);
-  const [dimTypeDeleteError, setDimTypeDeleteError] = useState<str | null>(
+  const [dimTypeDeleteError, setDimTypeDeleteError] = useState<string | null>(
     null
   );
 
@@ -381,6 +380,7 @@ export default function Datasets() {
         return dapi.deleteDatasets(dataset_id);
       })
     )
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       .then((vals) => {
         isDeleted = true;
       })

--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -4,7 +4,6 @@ import {
   DatasetParams,
   DatasetTableData,
   DatasetUpdateArgs,
-  DimensionType,
   // instanceOfErrorDetail,
   DimensionTypeAddArgs,
   DimensionTypeUpdateArgs,

--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -401,9 +401,9 @@ export default function Datasets() {
           (dt) => dt.name === selectedDimensionType.name
         );
         if (dimensionType.axis === "feature") {
-          await dapi.deleteFeatureType(dimensionType.name);
+          await dapi.deleteDimensionType(dimensionType.name);
         } else {
-          await dapi.deleteSampleType(dimensionType.name);
+          await dapi.deleteDimensionType(dimensionType.name);
         }
 
         isDeleted = true;


### PR DESCRIPTION
### Fixes:
- Update dataset manager to remove deprecated DELETE method for dimension type and use new method
- Fix UI bug where failing to delete a dataset while having a dimension type selected shows the error for dimension type instead of dataset error
**Actions that caused UI Bug:**
1. Go to Advanced Mode
2. Select a dimension type
3. Select a dataset (that user doesn't have write access for such as a public dataset)
4. Click 'Delete Datasets' button 

**Fixed UI**
![Screenshot 2025-02-10 at 4 45 57 PM](https://github.com/user-attachments/assets/6bebd429-1c60-4e66-b4c8-6efe6a158154)

