### PR TITLE
Fix parsing unknown ids and styling bugs

### DIFF
--- a/frontend/packages/@depmap/dataset-manager/src/components/DatasetForm.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/DatasetForm.tsx
@@ -21,6 +21,7 @@ import {
 import ChunkedFileUploader from "./ChunkedFileUploader";
 import { CeleryTask } from "@depmap/compute";
 import progressTrackerStyles from "@depmap/common-components/src/styles/ProgressTracker.scss";
+import styles from "../styles/styles.scss";
 
 interface DatasetFormProps {
   getDimensionTypes: () => Promise<DimensionType[]>;
@@ -225,19 +226,51 @@ export default function DatasetForm(props: DatasetFormProps) {
     if (completedTask?.state === "SUCCESS" && !isTaskRunning) {
       return (
         <div>
-          <div style={{ color: "green" }}>SUCCESS!</div>
-          {completedTask.result.unknownIDs.length > 0 ? (
-            <div style={{ color: "goldenrod" }}>
-              WARNING: Unknown IDS:{" "}
-              {JSON.parse(completedTask.result.unknownIDs)}
-            </div>
-          ) : null}
+          <div style={{ color: "green" }}>
+            <b>
+              <i>SUCCESS!</i>
+            </b>
+          </div>
+          <div style={{ color: "goldenrod" }}>
+            {completedTask.result.unknownIDs.map(
+              (unknownIDGroup: {
+                axis: string;
+                dimensionType: string;
+                IDs: string[];
+              }) => {
+                // shorten list if list of IDs is long and add ellipsis at the end
+                const sublistIDs = unknownIDGroup.IDs.slice(0, 10);
+                return (
+                  <>
+                    <div>
+                      <p style={{ margin: "10px 0 0 0" }}>
+                        <i>
+                          {unknownIDGroup.IDs.length} unknown{" "}
+                          {unknownIDGroup.axis} IDs for{" "}
+                          {unknownIDGroup.dimensionType}:
+                        </i>
+                      </p>
+                      <div className={styles.unknownIDsText}>
+                        <p>
+                          <i>{sublistIDs.toString() + "..."}</i>
+                        </p>
+                      </div>
+                    </div>
+                  </>
+                );
+              }
+            )}
+          </div>
         </div>
       );
     }
     if (completedTask?.state === "FAILURE" && !isTaskRunning) {
       return (
-        <div style={{ color: "red" }}>FAILED: {completedTask.message}!</div>
+        <div style={{ color: "red" }}>
+          <b>
+            <i>FAILED: {completedTask.message}!</i>
+          </b>
+        </div>
       );
     }
     if (isTaskRunning) {

--- a/frontend/packages/@depmap/dataset-manager/src/styles/styles.scss
+++ b/frontend/packages/@depmap/dataset-manager/src/styles/styles.scss
@@ -24,3 +24,13 @@
   overflow-y: auto;
   height: 500px;
 }
+
+.unknownIDsText {
+  width: 100%;
+  p {
+    overflow: hidden;
+    text-wrap: nowrap;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+}


### PR DESCRIPTION
### Fixes

- Uploading datasets with unknown IDs caused page to crash. This is because the data structure for unknown IDs has changed and was no longer able to be parsed
- List of unknown IDs could be very long and therefore displaying it all on the modal means the modal can get extremely long. Additional logic to truncate list and styling for long strings added
<img width="594" alt="Screenshot 2025-02-12 at 10 31 29 AM" src="https://github.com/user-attachments/assets/00637920-9e49-451b-826f-0be020ec5359" />
