### PR TITLE
Fix celligner nan bug

### DIFF
--- a/frontend/packages/portal-frontend/src/celligner/components/CellignerPage.tsx
+++ b/frontend/packages/portal-frontend/src/celligner/components/CellignerPage.tsx
@@ -595,7 +595,7 @@ export default class CellignerPage extends React.Component<Props, State> {
                   )
                 )
               }
-              allowDownloadFromTableDataWithMenu
+              allowDownloadFromTableData
               hideSelectAllCheckbox
             />
           </div>

--- a/frontend/packages/portal-frontend/src/celligner/components/CellignerPage.tsx
+++ b/frontend/packages/portal-frontend/src/celligner/components/CellignerPage.tsx
@@ -595,6 +595,7 @@ export default class CellignerPage extends React.Component<Props, State> {
                   )
                 )
               }
+              allowDownloadFromTableDataWithMenu
               hideSelectAllCheckbox
             />
           </div>

--- a/frontend/packages/portal-frontend/src/celligner/components/CellignerTumorsForCellLineControlPanel.tsx
+++ b/frontend/packages/portal-frontend/src/celligner/components/CellignerTumorsForCellLineControlPanel.tsx
@@ -46,6 +46,7 @@ export default class CellignerTumorsForCellLineControlPanel extends React.Compon
     const { cellLine } = this.state;
 
     const kNeighbors = parseInt(formEvent.currentTarget.value, 10);
+
     this.setState({ kNeighbors });
     if (cellLine) {
       onCellLineSelected(cellLine, kNeighbors);
@@ -77,7 +78,8 @@ export default class CellignerTumorsForCellLineControlPanel extends React.Compon
         <FormGroup controlId="selectK">
           <ControlLabel>2. Select K nearest neighbors</ControlLabel>
           <FormControl
-            type="text"
+            type="number"
+            min="0"
             value={kNeighbors}
             onChange={this.handleKNeighborsChange}
           />


### PR DESCRIPTION
These changes fix a bug that caused the k neighbors text input to get stuck on NaN if the user deleted everything in the input box.

The bug was caused by parse int of an empty string. This is fixed by using type="number" and min="0".

These changes also allow export of the nearest neighbors table data.