### PR TITLE
fix(breadbox): Fix update dimension type params

### DIFF
--- a/breadbox/breadbox/schemas/types.py
+++ b/breadbox/breadbox/schemas/types.py
@@ -44,18 +44,18 @@ class UpdateDimensionType(BaseModel):
     @model_validator(mode="after")
     def check_metadata_and_properties_to_index(self):
         """
-        If `metadata_dataset_id` is provided, this means a new metadata for dimension type is being provided. Therefore, the properties to index, which are column names, should also change along with the new metadata.
+        Properties to index, which are column names, can only be provided if there is new metadata.
         """
         metadata_dataset_id, properties_to_index = (
             self.metadata_dataset_id,
             self.properties_to_index,
         )
-
-        if (metadata_dataset_id is not None and properties_to_index is None) or (
-            metadata_dataset_id is None and properties_to_index is not None
+        # NOTE: By default `properties_to_index` is set to empty list when new dimension type without metadata is added
+        if metadata_dataset_id is None and (
+            properties_to_index is not None and len(properties_to_index) > 0
         ):
             raise UserError(
-                f"Both `metadata_dataset_id` and `properties_to_index` must be provided if one is to be updated."
+                f"Cannot provide properties to index if there is no dataset metadata!"
             )
 
         return self

--- a/breadbox/breadbox/service/dataset.py
+++ b/breadbox/breadbox/service/dataset.py
@@ -564,10 +564,7 @@ def update_dimension_type(
 ):
     given_updated_fields = dimension_type_update_fields.dict(exclude_unset=True)
 
-    if (
-        "metadata_dataset_id" in given_updated_fields
-        and "properties_to_index" in given_updated_fields
-    ):
+    if "metadata_dataset_id" in given_updated_fields:
         metadata_dataset = get_dataset(
             db, user, given_updated_fields["metadata_dataset_id"]
         )
@@ -602,12 +599,13 @@ def update_dimension_type(
                 delete_dataset(db, user, old_dataset, filestore_location)
 
         db.flush()
-        set_properties_to_index(
-            db,
-            given_updated_fields["properties_to_index"],
-            dimension_type.name,
-            metadata_dataset.group_id,
-        )
+        if "properties_to_index" in given_updated_fields:
+            set_properties_to_index(
+                db,
+                given_updated_fields["properties_to_index"],
+                dimension_type.name,
+                metadata_dataset.group_id,
+            )
 
         populate_search_index_after_update(db, dimension_type)
 

--- a/breadbox/tests/api/test_types.py
+++ b/breadbox/tests/api/test_types.py
@@ -65,13 +65,13 @@ def test_all_dimension_type_methods(client: TestClient, minimal_db, settings):
         data_df=pd.DataFrame({"sample_id": ["Y"], "label": ["X"]}),
     )
 
-    # Make sure if only metadata_dataset_id or properties_to_index is provided, throw and error. Both should be provided when dimension type metadata is changed
+    # Make sure if only properties_to_index is provided, throw and error. It should only be provided when there is dimension type metadata
     response = client.patch(
         "/types/dimensions/sample_id_name",
         json=({"metadata_dataset_id": new_metadata.id}),
         headers=admin_headers,
     )
-    assert_status_not_ok(response)
+    assert_status_ok(response)
     response = client.patch(
         "/types/dimensions/sample_id_name",
         json=({"properties_to_index": ["label"]}),


### PR DESCRIPTION
See: [Asana Task](https://app.asana.com/0/1188486168213297/1208578469618053)

I believe properties to index is not required for dimension types. However, right now in `UpdateDimensionTypeParams` we require both `metadata` and `properties_to_index` to be provided