### PR TITLE
Fix for "Compound page fails to load for 2'-MECCPA"

### DIFF
--- a/portal-backend/depmap/templates/compounds/index.html
+++ b/portal-backend/depmap/templates/compounds/index.html
@@ -168,7 +168,7 @@
             {% include "entities/partials/async_cards.js" %}
             {% for group in order %}
               {% for tile_name, _ in group %}
-                loadAsyncTile("{{ config.APPLICATION_ROOT }}", "compound", "{{tile_name}}", "{{name}}", "{{tile_name}}_placeholder")
+                loadAsyncTile("{{ config.APPLICATION_ROOT }}", "compound", {{tile_name | tojson}}, {{name | tojson }}, "{{tile_name}}_placeholder")
               {% endfor %}
             {% endfor %}
         });
@@ -181,11 +181,11 @@
             $(function () { // document ready for middle-of-html js
                 DepMap.initPredictiveTab(
                     'predictive-tab-root',
-                    "{{ name }}",
-                    "{{ name }}",
+                    {{ name | tojson }},
+                    {{ name | tojson }},
                     "compound",
-                    "{{ predictability_custom_downloads_link }}",
-                    "{{ predictability_methodology_link | safe}}"
+                    {{ predictability_custom_downloads_link | tojson }} ,
+                    {{ predictability_methodology_link | tojson }}
                 );
             });
         </script>


### PR DESCRIPTION
used `to_json` to avoid mangling of compound name by jinja's autoquoting.

Compound name is used to build URLs and so it was generating bad URLs causing tiles to fail to load. 