### PR TITLE
fix(breadbox): Only allow public datasets for dimension type metadata

### DIFF
--- a/breadbox/breadbox/service/dataset.py
+++ b/breadbox/breadbox/service/dataset.py
@@ -583,6 +583,9 @@ def update_dimension_type(
                 f"Metadata table {given_updated_fields['metadata_dataset_id']} was not indexed by {dimension_type.name}",
             )
 
+        if metadata_dataset.group_id != PUBLIC_GROUP_ID:
+            raise DatasetAccessError("Metadata dataset must be from 'Public' group!")
+
         if dimension_type.dataset != metadata_dataset:
             assert metadata_dataset.index_type_name == dimension_type.name
             old_dataset = dimension_type.dataset

--- a/breadbox/tests/api/test_types.py
+++ b/breadbox/tests/api/test_types.py
@@ -466,6 +466,73 @@ def test_get_dimension_type_dimension_identifiers(
     assert res.json() == []
 
 
+def test_invalid_dimension_type_metadata(client: TestClient, minimal_db, settings):
+    db = minimal_db
+    admin_headers = {"X-Forwarded-Email": settings.admin_users[0]}
+
+    dim_type_fields = {
+        "name": "sample_id_name",
+        "display_name": "Sample Name",
+        "axis": "sample",
+        "id_column": "sample_id",
+    }
+
+    # Create dimension type
+    dim_type_res = client.post(
+        "/types/dimensions", json=dim_type_fields, headers=admin_headers,
+    )
+    assert_status_ok(dim_type_res)
+    expected_dim_type_res = {
+        "name": "sample_id_name",
+        "display_name": "Sample Name",
+        "axis": "sample",
+        "id_column": "sample_id",
+        "properties_to_index": [],
+        "metadata_dataset_id": None,
+    }
+    assert dim_type_res.json() == expected_dim_type_res
+
+    # Confirm dimension type has no dimension identifiers
+    dim_type_ids_res = client.get(
+        f"types/dimensions/{dim_type_fields['name']}/identifiers",
+        headers=admin_headers,
+    )
+    assert_status_ok(dim_type_ids_res)
+    assert dim_type_ids_res.json() == []
+
+    # add a metadata table
+    # Create data type for metadata with non-public group
+    factories.data_type(db, "metadata")
+    group = factories.group(db, settings, "New Group")
+    dim_type_metadata = factories.tabular_dataset(
+        db,
+        settings,
+        group_id=group.id,
+        columns_metadata={
+            "label": ColumnMetadata(units=None, col_type=AnnotationType.text),
+            "sample_id": ColumnMetadata(units=None, col_type=AnnotationType.text),
+        },
+        index_type_name=dim_type_fields["name"],
+        data_type_="metadata",
+        data_df=pd.DataFrame(
+            {"sample_id": ["sample-1", "sample-2"], "label": ["Sample 1", "Sample 2"]}
+        ),
+    )
+
+    dim_type_metadata_res = client.patch(
+        f"/types/dimensions/{dim_type_fields['name']}",
+        json=(
+            {
+                "metadata_dataset_id": dim_type_metadata.id,
+                "properties_to_index": ["label"],
+            }
+        ),
+        headers=admin_headers,
+    )
+    assert_status_not_ok(dim_type_metadata_res)
+    dim_type_metadata_res.status_code = 404
+
+
 #### /types/sample and types/feature endpoints are deprecated!! ###
 
 

--- a/frontend/packages/@depmap/dataset-manager/src/components/DimensionTypeForm.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/DimensionTypeForm.tsx
@@ -34,7 +34,7 @@ export default function DimensionTypeForm(props: DimensionTypeFormProps) {
         (d) => {
           return (
             d.index_type_name === dimensionTypeToEdit.name &&
-            d.group.name === "Public"
+            d.group.id === "00000000-0000-0000-0000-000000000000"
           );
         }
       );

--- a/frontend/packages/@depmap/dataset-manager/src/components/DimensionTypeForm.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/DimensionTypeForm.tsx
@@ -12,7 +12,6 @@ import {
 } from "@depmap/types";
 import { useSubmitButtonIsDisabled } from "../../utils/disableSubmitButton";
 
-
 interface DimensionTypeFormProps {
   onSubmit: (formData: any) => Promise<void>;
   dimensionTypeToEdit: DimensionTypeWithCounts | null;
@@ -31,9 +30,12 @@ export default function DimensionTypeForm(props: DimensionTypeFormProps) {
 
   React.useEffect(() => {
     if (isEditMode && dimensionTypeToEdit) {
-      const datasetsWithDimensionType: TabularDataset[] = datasets.filter(
+      const publicDatasetsWithDimensionType: TabularDataset[] = datasets.filter(
         (d) => {
-          return d.index_type_name === dimensionTypeToEdit.name;
+          return (
+            d.index_type_name === dimensionTypeToEdit.name &&
+            d.group.name === "Public"
+          );
         }
       );
       const dimensionTypeEditSchemaWithOptions = {
@@ -46,13 +48,13 @@ export default function DimensionTypeForm(props: DimensionTypeFormProps) {
             default: null, // must include default null with enum options otherwise UI renders 2 null options
             enum: [
               null,
-              ...datasetsWithDimensionType.map((d) => {
+              ...publicDatasetsWithDimensionType.map((d) => {
                 return d.id;
               }),
             ],
             enumNames: [
               "None",
-              ...datasetsWithDimensionType.map((d) => {
+              ...publicDatasetsWithDimensionType.map((d) => {
                 return d.name;
               }),
             ],


### PR DESCRIPTION
Only allow public tabular datasets to be associated with dimension types