### PR TITLE
chore(breadbox): Refactor admin user check

### DIFF
--- a/breadbox/breadbox/api/dimension_types.py
+++ b/breadbox/breadbox/api/dimension_types.py
@@ -41,7 +41,6 @@ from breadbox.schemas.types import (
     DimensionIdentifiers,
 )
 from breadbox.service import metadata as metadata_service
-from .settings import assert_is_admin_user
 from breadbox.db.util import transaction
 
 
@@ -57,6 +56,13 @@ log = getLogger(__name__)
 from breadbox.schemas.custom_http_exception import FileValidationError
 from typing import Dict
 from pydantic import Json
+
+
+def assert_is_admin_user(user: str, settings: Settings):
+    if user not in settings.admin_users:
+        raise HTTPException(
+            403, "You do not have permission to modify dimension types."
+        )
 
 
 @router.post(

--- a/breadbox/breadbox/api/settings.py
+++ b/breadbox/breadbox/api/settings.py
@@ -1,9 +1,0 @@
-from breadbox.config import Settings
-from fastapi import HTTPException
-
-
-def assert_is_admin_user(user: str, settings: Settings):
-    if user not in settings.admin_users:
-        raise HTTPException(
-            403, "You do not have permission to delete the dimension type."
-        )


### PR DESCRIPTION
It seems a bit strange that this function is under `breadbox/api/settings` when it is only used in dimension type api endpoints and seems more like a utility function. Furthermore, the exception message is incorrect for some of its use cases (See below image). I've modified the message to better represent its intention.

<img width="596" alt="Screenshot 2025-03-06 at 12 13 46 PM" src="https://github.com/user-attachments/assets/21514cd9-35b4-4911-bf1d-46bb10ce825b" />
