### PR TITLE
Disable advanced mode dataset buttons

### DIFF
--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -498,14 +498,22 @@ export default function Datasets() {
             <Button
               bsStyle="default"
               onClick={() => handleEditDatasetButtonClick()}
-              disabled={selectedDatasetIds.size !== 1 || datasets.length === 1}
+              disabled={
+                selectedDatasetIds.size !== 1 ||
+                datasets.length === 1 ||
+                userGroups.writeGroups.length === 0
+              }
             >
               Edit Selected Dataset
             </Button>
             <Button
               bsStyle="danger"
               onClick={() => deleteDatasetButtonAction()}
-              disabled={selectedDatasetIds.size === 0 || datasets.length === 0}
+              disabled={
+                selectedDatasetIds.size === 0 ||
+                datasets.length === 0 ||
+                userGroups.writeGroups.length === 0
+              }
             >
               Delete Selected Dataset
             </Button>


### PR DESCRIPTION
UI Bug: In advanced mode, buttons for edit and delete dataset are not disabled. 
Currently: If a user without write access tries to delete a dataset, an error message is shown. If they try to edit a dataset they do not have permission to edit, an error occurs however this is not noticeable in the UI as the edit dataset form doesn't show an error occurred (Will be addressed in another PR)

This should have been part of [this PR](https://github.com/broadinstitute/depmap-portal/pull/204) but was not added by accident.