### PR TITLE
Add submission message details in edit dataset form

### DIFF
--- a/frontend/packages/@depmap/dataset-manager/src/components/DatasetEditForm.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/DatasetEditForm.tsx
@@ -6,6 +6,7 @@ import {
   Dataset,
   DatasetUpdateArgs,
   Group,
+  instanceOfErrorDetail,
   InvalidPrioritiesByDataType,
 } from "@depmap/types";
 import { RegistryFieldsType, RJSFSchema, UiSchema } from "@rjsf/utils";
@@ -33,6 +34,8 @@ export default function DatasetForm(props: DatasetEditFormProps) {
 
   const [schema, setSchema] = useState<RJSFSchema | null>(null);
   const [formDataVals, setFormDataVals] = useState<any>(null);
+  const [submissionMsg, setSubmissionMsg] = useState<string | null>(null);
+  const [hasError, setHasError] = useState<boolean>(false);
   console.log(formDataVals);
 
   console.log(datasetToEdit);
@@ -125,16 +128,38 @@ export default function DatasetForm(props: DatasetEditFormProps) {
   }, [submitButtonIsDisabled]);
 
   return schema && formDataVals ? (
-    <Form
-      formData={formDataVals}
-      schema={schema}
-      uiSchema={uiSchema}
-      validator={validator}
-      fields={fields}
-      onSubmit={async ({ formData }) => {
-        console.log(formData);
-        await onSubmit(datasetToEdit.id, formData);
-      }}
-    />
+    <>
+      <Form
+        formData={formDataVals}
+        schema={schema}
+        uiSchema={uiSchema}
+        validator={validator}
+        fields={fields}
+        onSubmit={async ({ formData }) => {
+          console.log(formData);
+          setSubmissionMsg("Loading...");
+          setHasError(false);
+          try {
+            await onSubmit(datasetToEdit.id, formData);
+            setSubmissionMsg("SUCCESS!");
+          } catch (e) {
+            console.error(e);
+            if (instanceOfErrorDetail(e)) {
+              setSubmissionMsg(e.detail);
+              setHasError(true);
+            }
+          }
+        }}
+      />
+      <p
+        style={{
+          color: hasError ? "red" : "gray",
+          paddingTop: "5px",
+          fontStyle: "italic",
+        }}
+      >
+        {submissionMsg}
+      </p>
+    </>
   ) : null;
 }


### PR DESCRIPTION
Before, no info was relayed to user on whether an edit to a dataset was successful or not. This change adds a status message on submitting the form.

The below image is a POC to show that an error message is shown when a dataset edit fails 
<img width="592" alt="Screenshot 2025-03-06 at 4 02 27 PM" src="https://github.com/user-attachments/assets/5553c3a9-e81c-4d92-942c-e6b528b86e01" />
