### PR TITLE
perf(breadbox): Sparse matrix chunked storage

### DIFF
--- a/breadbox/breadbox/compute/dataset_uploads_tasks.py
+++ b/breadbox/breadbox/compute/dataset_uploads_tasks.py
@@ -34,7 +34,6 @@ from ..io.data_validation import (
 from .celery import app
 import celery
 from ..config import get_settings
-import time
 
 
 @app.task(bind=True)
@@ -93,16 +92,12 @@ def dataset_upload(
         )
         sample_type = _get_dimension_type(db, dataset_params.sample_type, "sample")
 
-        start_time = time.perf_counter()
         data_df = read_and_validate_matrix_df(
             file_path,
             dataset_params.value_type,
             dataset_params.allowed_values,
             dataset_params.data_file_format,
         )
-        end_time = time.perf_counter()
-        execution_time = end_time - start_time
-        print(f"Validation Execution time: {execution_time:.4f} seconds")
 
         feature_labels_and_warnings = _get_dimension_labels_and_warnings(
             db, data_df.columns.to_list(), feature_type
@@ -160,15 +155,9 @@ def dataset_upload(
             dataset_params.version,
             dataset_params.description,
         )
-        print(f"Starting write...")
-        start_time = time.perf_counter()
         save_dataset_file(
             dataset_id, data_df, dataset_params.value_type, settings.filestore_location
         )
-        # Code to be timed
-        end_time = time.perf_counter()
-        execution_time = end_time - start_time
-        print(f"WRITE Execution time: {execution_time:.4f} seconds")
 
     else:
         index_type = _get_dimension_type(db, dataset_params.index_type)

--- a/breadbox/breadbox/compute/dataset_uploads_tasks.py
+++ b/breadbox/breadbox/compute/dataset_uploads_tasks.py
@@ -34,6 +34,7 @@ from ..io.data_validation import (
 from .celery import app
 import celery
 from ..config import get_settings
+import time
 
 
 @app.task(bind=True)
@@ -92,12 +93,16 @@ def dataset_upload(
         )
         sample_type = _get_dimension_type(db, dataset_params.sample_type, "sample")
 
+        start_time = time.perf_counter()
         data_df = read_and_validate_matrix_df(
             file_path,
             dataset_params.value_type,
             dataset_params.allowed_values,
             dataset_params.data_file_format,
         )
+        end_time = time.perf_counter()
+        execution_time = end_time - start_time
+        print(f"Validation Execution time: {execution_time:.4f} seconds")
 
         feature_labels_and_warnings = _get_dimension_labels_and_warnings(
             db, data_df.columns.to_list(), feature_type
@@ -155,9 +160,15 @@ def dataset_upload(
             dataset_params.version,
             dataset_params.description,
         )
+        print(f"Starting write...")
+        start_time = time.perf_counter()
         save_dataset_file(
             dataset_id, data_df, dataset_params.value_type, settings.filestore_location
         )
+        # Code to be timed
+        end_time = time.perf_counter()
+        execution_time = end_time - start_time
+        print(f"WRITE Execution time: {execution_time:.4f} seconds")
 
     else:
         index_type = _get_dimension_type(db, dataset_params.index_type)

--- a/breadbox/breadbox/io/data_validation.py
+++ b/breadbox/breadbox/io/data_validation.py
@@ -198,10 +198,10 @@ def _validate_data_value_type(
                 return val
             else:
                 # hdf5 will stringify 'None' or '<NA>'. Use empty string to represent NAs instead
-                return ""
+                return pd.NA
 
         df = df.applymap(validate_list_strings)
-        return df.astype(str)
+        return df.astype(pd.StringDtype())
     else:
         if not all([is_numeric_dtype(df[col].dtypes) for col in df.columns]):
             raise FileValidationError(

--- a/breadbox/breadbox/io/data_validation.py
+++ b/breadbox/breadbox/io/data_validation.py
@@ -197,10 +197,10 @@ def _validate_data_value_type(
                 _parse_list_strings(val)
                 return val
             else:
-                # hdf5 will stringify 'None' or '<NA>'. Use empty string to represent NAs instead
                 return pd.NA
 
         df = df.applymap(validate_list_strings)
+        # astype(str) will stringify 'None' or '<NA>'. Using pd.StringDtype() will preserve <NA>
         return df.astype(pd.StringDtype())
     else:
         if not all([is_numeric_dtype(df[col].dtypes) for col in df.columns]):

--- a/breadbox/breadbox/io/hdf5_utils.py
+++ b/breadbox/breadbox/io/hdf5_utils.py
@@ -24,32 +24,35 @@ def create_index_dataset(f: h5py.File, key: str, idx: pd.Index):
 def write_hdf5_file(path: str, df: pd.DataFrame, dtype: Literal["float", "str"]):
     f = h5py.File(path, mode="w")
     try:
-        dataset = f.create_dataset(
-            "data",
-            shape=df.shape,
-            dtype=h5py.string_dtype() if dtype == "str" else np.float64,
-            # data=df.values,
-            chunks=(1, 1),
-        )
-        rows, cols = np.where(df.notnull())
-        for row, col in zip(rows, cols):
-            dataset[row, col] = df.iloc[row, col]
+        # Get the row,col positions where df values are not null
+        rows_idx, cols_idx = np.where(df.notnull())
+        total_nulls = df.size - len(rows_idx)
+        # Determine whether matrix is considered sparse (~2/3 elements are null). Use chunked storage for sparse matrices for more optimal storage
+        if total_nulls / df.size > 0.6:
+            dataset = f.create_dataset(
+                "data",
+                shape=df.shape,
+                dtype=h5py.string_dtype() if dtype == "str" else np.float64,
+                chunks=(
+                    1,
+                    1,
+                ),  # Arbitrarily set size since it at least appears to yield smaller storage size than autochunking
+            )
+            # only insert nonnull values into hdf5 at given positions
+            for row_idx, col_idx in zip(rows_idx, cols_idx):
+                dataset[row_idx, col_idx] = df.iloc[row_idx, col_idx]
+        else:
+            if dtype == "str":
+                # NOTE: hdf5 will fail to stringify None or <NA>. Use empty string to represent NAs instead
+                df = df.fillna("")
 
-        # also took far too long
-        # for col in range(df.shape[1]):
-        #     if (~(pd.isna(df.iloc[:,col]))).sum() == 0:
-        #         continue
-        #     for row in range(df.shape[0]):
-        #         value = df.iloc[row, col]
-        #         if not pd.isna(value):
-        #             dataset[row, col] = value
-
-        # this literally took forever
-        # for row in range(df.shape[0]):
-        #     for col in range(df.shape[1]):
-        #         value = df.iloc[row, col]
-        #         if not pd.isna(value):
-        #             dataset[row, col] = value
+            # NOTE: For a large and dense string matrix, the size of the hdf5 will be very large. Right now, list of string matrices are a very rare use case and it is unlikely we'll encounter one that is not sparse. However, if that changes, we should consider other hdf5 size optimization methods such as compression
+            f.create_dataset(
+                "data",
+                shape=df.shape,
+                dtype=h5py.string_dtype() if dtype == "str" else np.float64,
+                data=df.values,
+            )
 
         create_index_dataset(f, "features", df.columns)
         create_index_dataset(f, "samples", df.index)

--- a/breadbox/breadbox/io/hdf5_utils.py
+++ b/breadbox/breadbox/io/hdf5_utils.py
@@ -24,12 +24,32 @@ def create_index_dataset(f: h5py.File, key: str, idx: pd.Index):
 def write_hdf5_file(path: str, df: pd.DataFrame, dtype: Literal["float", "str"]):
     f = h5py.File(path, mode="w")
     try:
-        f.create_dataset(
+        dataset = f.create_dataset(
             "data",
             shape=df.shape,
             dtype=h5py.string_dtype() if dtype == "str" else np.float64,
-            data=df.values,
+            # data=df.values,
+            chunks=(1, 1),
         )
+        rows, cols = np.where(df.notnull())
+        for row, col in zip(rows, cols):
+            dataset[row, col] = df.iloc[row, col]
+
+        # also took far too long
+        # for col in range(df.shape[1]):
+        #     if (~(pd.isna(df.iloc[:,col]))).sum() == 0:
+        #         continue
+        #     for row in range(df.shape[0]):
+        #         value = df.iloc[row, col]
+        #         if not pd.isna(value):
+        #             dataset[row, col] = value
+
+        # this literally took forever
+        # for row in range(df.shape[0]):
+        #     for col in range(df.shape[1]):
+        #         value = df.iloc[row, col]
+        #         if not pd.isna(value):
+        #             dataset[row, col] = value
 
         create_index_dataset(f, "features", df.columns)
         create_index_dataset(f, "samples", df.index)


### PR DESCRIPTION
Large string matrices take up a lot of space when stored as an hdf5 file (2k rows x 18 columns resulted in over 1GB!). Our only use case so far where we store a list of strings matrix as strings is a pretty sparse matrix. So instead of writing the entire matrix into hdf5, we only store nonnull values and add chunked storage for more optimal storage size of the hdf5 file. This heuristic is defined for a sparse matrix of any dtype, not just string hdf5 datasets.