### PR TITLE
perf(breadbox): Performance improvements for Elara

### DIFF
--- a/breadbox/breadbox/api/datasets.py
+++ b/breadbox/breadbox/api/datasets.py
@@ -2,7 +2,6 @@ from typing import List, Optional, Set, Union
 from logging import getLogger
 from uuid import UUID
 from ..db.util import transaction
-from time import perf_counter
 
 from fastapi import (
     APIRouter,
@@ -109,18 +108,14 @@ def get_dataset_features(
     """
     Get information about each feature belonging to a given dataset.
     """
-    start = perf_counter()
     dataset = dataset_crud.get_dataset(db=db, user=user, dataset_id=dataset_id)
     if dataset is None:
         raise HTTPException(404, "Dataset not found")
 
-    # start perf counter
-    labels_start = perf_counter()
     feature_labels_by_id = metadata_service.get_matrix_dataset_feature_labels_by_id(  # TODO: this takes almost all of the time
         db=db, user=user, dataset=dataset,
     )
-    result = [{"id": id, "label": label} for id, label in feature_labels_by_id.items()]
-    return result
+    return [{"id": id, "label": label} for id, label in feature_labels_by_id.items()]
 
 
 @router.get(

--- a/breadbox/breadbox/api/datasets.py
+++ b/breadbox/breadbox/api/datasets.py
@@ -112,7 +112,7 @@ def get_dataset_features(
     if dataset is None:
         raise HTTPException(404, "Dataset not found")
 
-    feature_labels_by_id = metadata_service.get_matrix_dataset_feature_labels_by_id(  # TODO: this takes almost all of the time
+    feature_labels_by_id = metadata_service.get_matrix_dataset_feature_labels_by_id(
         db=db, user=user, dataset=dataset,
     )
     return [{"id": id, "label": label} for id, label in feature_labels_by_id.items()]

--- a/breadbox/breadbox/api/datasets.py
+++ b/breadbox/breadbox/api/datasets.py
@@ -119,9 +119,7 @@ def get_dataset_features(
     feature_labels_by_id = metadata_service.get_matrix_dataset_feature_labels_by_id(  # TODO: this takes almost all of the time
         db=db, user=user, dataset=dataset,
     )
-    print(f"Time taken to get feature labels: {perf_counter() - labels_start}")
     result = [{"id": id, "label": label} for id, label in feature_labels_by_id.items()]
-    print(f"Time taken to complete: {perf_counter() - start}")
     return result
 
 

--- a/breadbox/breadbox/api/dimension_types.py
+++ b/breadbox/breadbox/api/dimension_types.py
@@ -625,6 +625,7 @@ def get_dimension_type_identifiers(
     name: str,
     data_type: Annotated[Union[str, None], Query()] = None,
     show_only_dimensions_in_datasets: Annotated[bool, Query()] = False,
+    limit: Annotated[Union[int, None], Query()] = None,
     db: SessionWithUser = Depends(get_db_with_user),
 ):
     dim_type = type_crud.get_dimension_type(db, name)
@@ -632,7 +633,7 @@ def get_dimension_type_identifiers(
         raise HTTPException(404, f"Dimension type {name} not found")
 
     dimension_ids_and_labels = metadata_service.get_dimension_type_identifiers(
-        db, dim_type, data_type, show_only_dimensions_in_datasets
+        db, dim_type, data_type, show_only_dimensions_in_datasets, limit=limit,
     )
 
     return [

--- a/breadbox/breadbox/compute/dataset_tasks.py
+++ b/breadbox/breadbox/compute/dataset_tasks.py
@@ -2,10 +2,11 @@ from dataclasses import dataclass
 import dataclasses
 from io import BytesIO
 import time
-from typing import Any, Callable, Dict, List, Optional, Set, TypedDict, Union, Literal
+from typing import Any, Callable, Dict, List, Optional, Set, Union, Literal
 from logging import getLogger
 from uuid import UUID, uuid4
 from breadbox.io.upload_utils import create_upload_file
+from typing_extensions import TypedDict
 
 import celery
 

--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -462,7 +462,7 @@ def get_matrix_dataset_features(
     return dataset_features
 
 
-def get_matrix_dataset_samples( # TODO: replace this?
+def get_matrix_dataset_samples( 
     db: SessionWithUser, dataset: MatrixDataset
 ) -> list[DatasetSample]:
     assert_user_has_access_to_dataset(dataset, db.user)
@@ -791,8 +791,6 @@ def get_subset_of_tabular_data_as_df(
 
     return pivot_df["value"]
 
-
-from time import perf_counter 
 
 def get_unique_dimension_ids_from_datasets(
     db: SessionWithUser, dataset_ids: List[str], dimension_type: DimensionType

--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -816,5 +816,5 @@ def get_unique_dimension_ids_from_datasets(
     result = matrix_given_ids.union(tabular_given_ids)
     # Combine the unique given ids from the tabular and matrix datasets
     print(f"Time taken to get total dimension ids: {perf_counter() - start}")
-    return given_ids
+    return result
 

--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -462,7 +462,7 @@ def get_matrix_dataset_features(
     return dataset_features
 
 
-def get_matrix_dataset_samples(
+def get_matrix_dataset_samples( # TODO: replace this?
     db: SessionWithUser, dataset: MatrixDataset
 ) -> list[DatasetSample]:
     assert_user_has_access_to_dataset(dataset, db.user)
@@ -475,6 +475,27 @@ def get_matrix_dataset_samples(
     )
 
     return dataset_samples
+
+def get_matrix_dataset_given_ids(
+    db: SessionWithUser, dataset: Dataset, axis: str
+) -> List[str]:
+    assert_user_has_access_to_dataset(dataset, db.user)
+
+    if axis == "feature":
+        dimension_class = DatasetFeature
+    elif axis == "sample":
+        dimension_class = DatasetSample
+    else:
+        raise ValueError(f"Invalid axis: {axis}")
+
+    given_ids = (
+        db.query(dimension_class.given_id)
+        .filter(dimension_class.dataset_id == dataset.id)
+        .order_by(dimension_class.given_id)
+        .all()
+    )
+
+    return [given_id for (given_id,) in given_ids]
 
 
 def get_tabular_dataset_index_given_ids(

--- a/breadbox/breadbox/crud/dimension_types.py
+++ b/breadbox/breadbox/crud/dimension_types.py
@@ -277,14 +277,14 @@ def get_dimension_type_metadata_col(
         return {}
 
     values_by_id_tuples = (
-        db.query(TabularCell)
-        .join(TabularColumn)
+        db.query(TabularColumn)
         .filter(
             and_(
                 TabularColumn.dataset_id == dimension_type.dataset_id,
                 TabularColumn.given_id == col_name,
             )
         )
+        .join(TabularCell)
         .with_entities(TabularCell.dimension_given_id, TabularCell.value)
         .all()
     )

--- a/breadbox/breadbox/crud/dimension_types.py
+++ b/breadbox/breadbox/crud/dimension_types.py
@@ -249,16 +249,16 @@ def delete_dimension_type(db: SessionWithUser, dimension_type: DimensionType):
 
 
 def get_dimension_type_labels_by_id(
-    db: SessionWithUser, dimension_type_name: str
+    db: SessionWithUser, dimension_type_name: str, limit: Optional[int] = None
 ) -> dict[str, str]:
     """
     For a given dimension, get all IDs and labels that exist in the metadata.
     """
-    return get_dimension_type_metadata_col(db, dimension_type_name, col_name="label")
+    return get_dimension_type_metadata_col(db, dimension_type_name, col_name="label", limit=limit)
 
 
 def get_dimension_type_metadata_col(
-    db: SessionWithUser, dimension_type_name: str, col_name: str, index_by_given_id=True
+    db: SessionWithUser, dimension_type_name: str, col_name: str, limit: Optional[int] = None,
 ) -> dict[str, str]:
     assert isinstance(col_name, str)
 
@@ -285,6 +285,7 @@ def get_dimension_type_metadata_col(
             )
         )
         .join(TabularCell)
+        .limit(limit)
         .with_entities(TabularCell.dimension_given_id, TabularCell.value)
         .all()
     )

--- a/breadbox/breadbox/schemas/dataset.py
+++ b/breadbox/breadbox/schemas/dataset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from uuid import UUID
 from typing import Optional, List, Dict, Any, Annotated, Union, Literal
 from pydantic import AfterValidator, BaseModel, Field, model_validator, field_validator
+from typing_extensions import TypedDict
 
 from breadbox.schemas.common import DBBase
 from fastapi import Body
@@ -9,7 +10,6 @@ from breadbox.schemas.custom_http_exception import UserError
 from .group import Group
 import enum
 
-from depmap_compute.slice import SliceQuery
 
 
 # NOTE: Using multivalue Literals seems to be creating errors in pydantic models and fastapi request params.
@@ -550,7 +550,7 @@ UpdateDatasetParams = Annotated[
 ]
 
 
-class NameAndID(BaseModel):
+class NameAndID(TypedDict):
     name: str
     id: str
 

--- a/breadbox/breadbox/schemas/types.py
+++ b/breadbox/breadbox/schemas/types.py
@@ -3,11 +3,11 @@ from breadbox.models.dataset import AnnotationType
 from breadbox.schemas.custom_http_exception import AnnotationValidationError, UserError
 from breadbox.schemas.dataset import TabularDatasetResponse
 from fastapi import File, Form, HTTPException, UploadFile, Body
+from typing_extensions import TypedDict
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_settings import SettingsConfigDict
 from typing import List, Optional, Dict, Annotated
-from typing_extensions import TypedDict
 
 # TypedDict has much better performance for nested structures than pydantic models.
 # See: https://docs.pydantic.dev/latest/concepts/performance/#use-typeddict-over-nested-models

--- a/breadbox/breadbox/schemas/types.py
+++ b/breadbox/breadbox/schemas/types.py
@@ -7,16 +7,13 @@ from fastapi import File, Form, HTTPException, UploadFile, Body
 from pydantic import BaseModel, Field, field_validator, model_validator
 from pydantic_settings import SettingsConfigDict
 from typing import List, Optional, Dict, Annotated
+from typing_extensions import TypedDict
 
-
-class DimensionIdentifiers(BaseModel):
+# TypedDict has much better performance for nested structures than pydantic models.
+# See: https://docs.pydantic.dev/latest/concepts/performance/#use-typeddict-over-nested-models
+class DimensionIdentifiers(TypedDict):
     id: str
     label: str
-
-
-class IdAndName(BaseModel):
-    id: str
-    name: str
 
 
 class DimensionType(BaseModel):
@@ -59,14 +56,6 @@ class UpdateDimensionType(BaseModel):
             )
 
         return self
-
-
-# class DimensionTypeIn(DimensionType):
-#     metadata_file_ids: List[str]
-#
-#
-# class DimensionTypeOut(DimensionType):
-#     dataset: IdAndName
 
 
 class FeatureTypeOut(BaseModel):

--- a/breadbox/breadbox/service/metadata.py
+++ b/breadbox/breadbox/service/metadata.py
@@ -1,5 +1,6 @@
 import logging
 from typing import Any, Optional
+from time import perf_counter
 
 from breadbox.crud import dataset as dataset_crud
 from breadbox.crud import dimension_types as types_crud
@@ -49,16 +50,23 @@ def get_matrix_dataset_feature_metadata(
     For the given matrix dataset, load a column from the associated metadata.
     The result will only include given ids which exist in both the dataset and the metadata.
     """
+    start = perf_counter()
     full_metadata_col = types_crud.get_dimension_type_metadata_col(
         db, dimension_type_name=dataset.feature_type_name, col_name=metadata_col_name
     )
+    print(f"- get_dimension_type_metadata_col: {perf_counter() - start}")
+    start = perf_counter()
     # Filter the metadata to only include the given IDs belonging to this dataset
-    dataset_features = dataset_crud.get_matrix_dataset_features(db, dataset)
+    dataset_feature_given_ids = dataset_crud.get_matrix_dataset_given_ids(db, dataset, axis="feature")
+    # TODO: if this helps, then update the sample method as well
+    print(f"- get features: {perf_counter() - start}")
+    
+    # Below takes basically no time
     filtered_metadata_vals = {}
-    for feature in dataset_features:
-        metadata_val = full_metadata_col.get(feature.given_id)
+    for given_id in dataset_feature_given_ids:
+        metadata_val = full_metadata_col.get(given_id)
         if metadata_val is not None:
-            filtered_metadata_vals[feature.given_id] = metadata_val
+            filtered_metadata_vals[given_id] = metadata_val
     return filtered_metadata_vals
 
 

--- a/breadbox/breadbox/service/metadata.py
+++ b/breadbox/breadbox/service/metadata.py
@@ -9,6 +9,7 @@ from breadbox.schemas.custom_http_exception import ResourceNotFoundError
 from breadbox.models.dataset import (
     DatasetFeature,
     DatasetSample,
+    Dataset, 
     MatrixDataset,
     TabularDataset,
     DimensionType,
@@ -43,53 +44,6 @@ def get_tabular_dataset_metadata_annotations(
     return filtered_metadata_vals
 
 
-def get_matrix_dataset_feature_metadata(
-    db: SessionWithUser, dataset: MatrixDataset, metadata_col_name: str,
-) -> dict[str, Any]:
-    """
-    For the given matrix dataset, load a column from the associated metadata.
-    The result will only include given ids which exist in both the dataset and the metadata.
-    """
-    start = perf_counter()
-    full_metadata_col = types_crud.get_dimension_type_metadata_col(
-        db, dimension_type_name=dataset.feature_type_name, col_name=metadata_col_name
-    )
-    print(f"- get_dimension_type_metadata_col: {perf_counter() - start}")
-    start = perf_counter()
-    # Filter the metadata to only include the given IDs belonging to this dataset
-    dataset_feature_given_ids = dataset_crud.get_matrix_dataset_given_ids(db, dataset, axis="feature")
-    # TODO: if this helps, then update the sample method as well
-    print(f"- get features: {perf_counter() - start}")
-    
-    # Below takes basically no time
-    filtered_metadata_vals = {}
-    for given_id in dataset_feature_given_ids:
-        metadata_val = full_metadata_col.get(given_id)
-        if metadata_val is not None:
-            filtered_metadata_vals[given_id] = metadata_val
-    return filtered_metadata_vals
-
-
-def get_matrix_dataset_sample_metadata(
-    db: SessionWithUser, dataset: MatrixDataset, metadata_col_name: str,
-) -> dict[str, Any]:
-    """
-    For the given matrix dataset, load a column from the associated metadata.
-    The result will only include given ids which exist in both the dataset and the metadata.
-    """
-    full_metadata_col = types_crud.get_dimension_type_metadata_col(
-        db, dimension_type_name=dataset.sample_type_name, col_name=metadata_col_name
-    )
-    # Filter the metadata to only include the given IDs belonging to this dataset
-    sample_given_ids = dataset_crud.get_matrix_dataset_given_ids(db, dataset, axis="sample")
-    filtered_metadata_vals = {}
-    for given_id in sample_given_ids:
-        metadata_val = full_metadata_col.get(given_id)
-        if metadata_val is not None:
-            filtered_metadata_vals[given_id] = metadata_val
-    return filtered_metadata_vals
-
-
 def get_matrix_dataset_feature_labels_by_id(
     db: SessionWithUser, user: str, dataset: MatrixDataset,
 ) -> dict[str, str]:
@@ -98,8 +52,13 @@ def get_matrix_dataset_feature_labels_by_id(
     If there are no labels in the metadata or there is no metadata, then just return the feature names.
     """
     if dataset.feature_type_name is not None:
-        metadata_labels_by_given_id = get_matrix_dataset_feature_metadata(
-            db=db, dataset=dataset, metadata_col_name="label"
+        dimension_type = types_crud.get_dimension_type(db=db, name=dataset.feature_type_name)
+        metadata_labels_by_given_id = dataset_crud.get_metadata_used_in_matrix_dataset(
+            db=db, 
+            dimension_type=dimension_type, 
+            matrix_dataset=dataset, 
+            dimension_subtype_cls=DatasetFeature,
+            metadata_col_name="label",
         )
         if metadata_labels_by_given_id:
             return metadata_labels_by_given_id
@@ -116,13 +75,19 @@ def get_matrix_dataset_sample_labels_by_id(
     Try loading sample labels from metadata.
     If there are no labels in the metadata or there is no metadata, then just return the sample names.
     """
-    metadata_labels = get_matrix_dataset_sample_metadata(
-        db=db, dataset=dataset, metadata_col_name="label"
+    
+    dimension_type = types_crud.get_dimension_type(db=db, name=dataset.sample_type_name)
+    metadata_labels_by_given_id = dataset_crud.get_metadata_used_in_matrix_dataset(
+        db=db, 
+        dimension_type=dimension_type, 
+        matrix_dataset=dataset, 
+        dimension_subtype_cls=DatasetSample,
+        metadata_col_name="label",
     )
-    if metadata_labels:
-        return metadata_labels
+    if metadata_labels_by_given_id:
+        return metadata_labels_by_given_id
     else:
-        sample_given_ids = dataset_crud.get_matrix_dataset_given_ids(db=db, dataset=dataset)
+        sample_given_ids = dataset_crud.get_matrix_dataset_given_ids(db=db, dataset=dataset, axis="sample")
         return {given_id: given_id for given_id in sample_given_ids}
 
 

--- a/breadbox/breadbox/service/metadata.py
+++ b/breadbox/breadbox/service/metadata.py
@@ -265,6 +265,7 @@ def get_dimension_type_identifiers(
     dimension_type: DimensionType,
     data_type: Optional[str] = None,
     show_only_dimensions_in_datasets: Optional[bool] = False,
+    limit: Optional[int] = None,
 ):
     """
     For the given dimension type,
@@ -277,7 +278,7 @@ def get_dimension_type_identifiers(
     """
     # Get all dimension identifiers in a dimension type
     dim_type_ids_and_labels = types_crud.get_dimension_type_labels_by_id(
-        db, dimension_type.name
+        db, dimension_type.name, limit=limit,
     )
 
     if data_type is None and not show_only_dimensions_in_datasets:

--- a/breadbox/breadbox/service/metadata.py
+++ b/breadbox/breadbox/service/metadata.py
@@ -73,12 +73,12 @@ def get_matrix_dataset_sample_metadata(
         db, dimension_type_name=dataset.sample_type_name, col_name=metadata_col_name
     )
     # Filter the metadata to only include the given IDs belonging to this dataset
-    dataset_samples = dataset_crud.get_matrix_dataset_samples(db, dataset)
+    sample_given_ids = dataset_crud.get_matrix_dataset_given_ids(db, dataset, axis="sample")
     filtered_metadata_vals = {}
-    for sample in dataset_samples:
-        metadata_val = full_metadata_col.get(sample.given_id)
+    for given_id in sample_given_ids:
+        metadata_val = full_metadata_col.get(given_id)
         if metadata_val is not None:
-            filtered_metadata_vals[sample.given_id] = metadata_val
+            filtered_metadata_vals[given_id] = metadata_val
     return filtered_metadata_vals
 
 
@@ -97,8 +97,8 @@ def get_matrix_dataset_feature_labels_by_id(
             return metadata_labels_by_given_id
 
     # If there are no labels or there is no feature type, return the given IDs
-    all_dataset_features = dataset_crud.get_matrix_dataset_features(db, dataset)
-    return {feature.given_id: feature.given_id for feature in all_dataset_features}
+    feature_given_ids = dataset_crud.get_matrix_dataset_given_ids(db, dataset, axis="feature")
+    return {given_id: given_id for given_id in feature_given_ids}
 
 
 def get_matrix_dataset_sample_labels_by_id(
@@ -114,8 +114,8 @@ def get_matrix_dataset_sample_labels_by_id(
     if metadata_labels:
         return metadata_labels
     else:
-        samples = dataset_crud.get_matrix_dataset_samples(db=db, dataset=dataset)
-        return {sample.given_id: sample.given_id for sample in samples}
+        sample_given_ids = dataset_crud.get_matrix_dataset_given_ids(db=db, dataset=dataset)
+        return {given_id: given_id for given_id in sample_given_ids}
 
 
 def get_tabular_dataset_labels_by_id(

--- a/breadbox/breadbox/service/metadata.py
+++ b/breadbox/breadbox/service/metadata.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Any, Optional
-from time import perf_counter
 
 from breadbox.crud import dataset as dataset_crud
 from breadbox.crud import dimension_types as types_crud

--- a/breadbox/tests/api/test_types.py
+++ b/breadbox/tests/api/test_types.py
@@ -409,6 +409,17 @@ def test_get_dimension_type_dimension_identifiers(
         {"id": "sample-2", "label": "Sample 2"},
     ]
 
+    # Test that the limit parameter works
+    dim_type_ids_res = client.get(
+        f"types/dimensions/{dim_type_fields['name']}/identifiers?limit=1",
+        headers=admin_headers,
+    )
+    assert_status_ok(dim_type_ids_res)
+    assert dim_type_ids_res.json() == [
+        {"id": "sample-1", "label": "Sample 1"},
+    ]
+
+
     # test dim type doesn't exist
     nonexistent_dim_type_res = client.get(
         f"types/dimensions/nonexistentDimensionType/identifiers", headers=admin_headers,


### PR DESCRIPTION
[Asana](https://app.asana.com/0/1165651979405609/1209671857588613/f)

**Several relatively low-effort performance improvements in breadbox, including:**
* Improving the way we load metadata for a specific dataset - now using a subquery instead of loading two separate results from large SQL queries. Note: I know subqueries are still slow, but they're easy to read, and this change made this particular operation more than 5x faster - it's now taking a negligable amount of time for even with 2-3k results. 
* Adding a method `get_matrix_dataset_given_ids` which can be used instead of `get_matrix_dataset_features` or `get_matrix_dataset_samples`, when we don't need those full objects. This makes a moderate performance improvement to a bunch of different breadbox endpoints. 
* Adding an optional `limit` parameter to the /identifiers endpoint. This was easy to add and seems like something that could be useful when initially populating the dropdown. We may not need all 2-3k results if we're going to send another request anyway once the user starts typing. 
* Using `TypedDict` instead of Pydantic's `BaseModel` for endpoints that return a long list of simple objects 

**Before the changes, loading this page in the test environment consistently took 5.9-6.8 seconds** (URL [here](https://dev.cds.team/depmap-test-perf/breadbox/elara/?p=eJxVjkFrwzAMhf-Lzg20tdumgR523m07jmG0SAmGxDG2aV2C_3vlQjd2EZLe96S3gp-WZNLdM3RA7KJNd7Mj2IB1xPlP8TN6My_Ek2hk54ouLkK3Qq4Fs40vOuDNxMn2LCiOY-ARk8CiDDbEJNt-cYlzqsbfWy_3yK4aHc51ev94-5SJsw-Vvlyg-1rhiqGS9srOWIKyAdXqA3xLI1JNVaQlTBg5VaIDfSJ1PG9Vszvth0YfjtS0rLhpFWpN_Q-hHuTRM_e_KKWUBz-KYTk) (reload with hard refresh)):
<img width="1046" alt="image" src="https://github.com/user-attachments/assets/7bc095b6-6502-4fe3-8f4a-318dd739cffe" />

**After the changes, the page takes about 4.2-4.6 seconds and the id/label loading endpoints are now significantly faster:** 
<img width="1292" alt="image" src="https://github.com/user-attachments/assets/04e8598c-17e7-4919-a5c4-453465ab59e8" />

**Future performance improvement suggestions:**
Seems like the next easiest performance improvement would be in frontend changes:
* Randy had mentioned that (when he has time), he's going to make an update to only call the `/identifiers` endpoint once. This will shave off another ~0.6 seconds.  
* Putting a limit on that initial call to `/identifiers` will also speed this up substantially - since most of the time is spent on serializing this large result. Once the user starts typing, another request is made anyway to the dimension search endpoint.
