### PR TITLE
Reposition Inferred Molecular Subtype in Context Manager

### DIFF
--- a/frontend/packages/@depmap/cell-line-selector/src/components/DataColumnSelect.tsx
+++ b/frontend/packages/@depmap/cell-line-selector/src/components/DataColumnSelect.tsx
@@ -36,7 +36,7 @@ function DataColumnSelect({ onChange }: Props) {
           setValue(null);
         }}
         options={{
-          categorical: "Model Property",
+          categorical: "Model Annotation",
           continuous: "Matrix Data",
         }}
       />

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Comparison.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Comparison.tsx
@@ -26,6 +26,9 @@ import List from "./List";
 import NumberExpr from "./NumberExpr";
 import styles from "../../styles/ContextBuilder.scss";
 
+const LEFT_INDEX = 0;
+const RIGHT_INDEX = 1;
+
 interface Props {
   expr: Record<OperatorType, Expr>;
   path: (string | number)[];
@@ -89,8 +92,8 @@ function Comparison({
 
   const op = getOperator(expr);
   const [left, right] = expr[op] as [Expr, string | string[] | number | null];
-  const leftPath = [...path, op, 0];
-  const rightPath = [...path, op, 1];
+  const leftPath = [...path, op, LEFT_INDEX];
+  const rightPath = [...path, op, RIGHT_INDEX];
   let slice_id = !isVar(left) || isPartialSliceId(left.var) ? null : left.var;
 
   if (datasets && slice_id) {
@@ -228,7 +231,7 @@ function Comparison({
     if (value_type === "binary" && slice_id && right === null) {
       dispatch({
         type: "update-value",
-        payload: { path: [...path, op, 1], value: 1 },
+        payload: { path: [...path, op, RIGHT_INDEX], value: 1 },
       });
     }
   }, [dispatch, slice_id, op, right, path, value_type]);
@@ -238,7 +241,7 @@ function Comparison({
 
   if (summary?.value_type === "binary") {
     rhsExpr = slice_id;
-    rhsPath = [...path, op, 0, "var"];
+    rhsPath = [...path, op, LEFT_INDEX, "var"];
   }
 
   const variableValue =

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Comparison.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Comparison.tsx
@@ -221,7 +221,7 @@ function Comparison({
   // value of 1. The logic behind this is pretty convoluted but I'll try to
   // explain. One-hot encoded slices are typically used to visualize an
   // ingroup/outgroup relationship. Forcing the user to say "SOME_FEATURE == 1"
-  // is awakward. Instead we show the list of features, have the user select
+  // is awkward. Instead we show the list of features, have the user select
   // one, and then automatically set the value to 1 behind the scenes. The
   // features can thus be thought of a set of pseudo-categories.
   useEffect(() => {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Comparison.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Comparison.tsx
@@ -24,6 +24,7 @@ import Variable from "./Variable";
 import Constant from "./Constant";
 import List from "./List";
 import NumberExpr from "./NumberExpr";
+import styles from "../../styles/ContextBuilder.scss";
 
 interface Props {
   expr: Record<OperatorType, Expr>;
@@ -40,13 +41,13 @@ interface SummaryContinuous {
 }
 
 interface SummaryCategorical {
-  value_type: "categorical" | "list_strings";
+  value_type: "categorical" | "list_strings" | "binary";
   unique_values: string[];
 }
 
 type Summary = SummaryContinuous | SummaryCategorical;
 
-interface RHS {
+interface RhsProps {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   expr: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -72,7 +73,8 @@ function Comparison({
   const [summary, setSummary] = useState<Summary | null>(null);
   const [, forceRender] = useState<null>();
   const ref = useRef<HTMLDivElement | null>(null);
-  const { metadataSlices, isLoading } = useContextBuilderContext();
+  const { datasets, metadataSlices, isLoading } = useContextBuilderContext();
+  const [error, setError] = useState<string | null>(null);
 
   useLayoutEffect(() => forceRender(null), []);
 
@@ -89,10 +91,27 @@ function Comparison({
   const [left, right] = expr[op] as [Expr, string | string[] | number | null];
   const leftPath = [...path, op, 0];
   const rightPath = [...path, op, 1];
-  const slice_id = !isVar(left) || isPartialSliceId(left.var) ? null : left.var;
+  let slice_id = !isVar(left) || isPartialSliceId(left.var) ? null : left.var;
 
-  let RhsComponent: React.FC<RHS> = isListOperator(op) ? List : Constant;
-  let options = null;
+  if (datasets && slice_id) {
+    const encodedId = slice_id.split("/")[1];
+    const id = decodeURIComponent(encodedId);
+
+    datasets.forEach((d) => {
+      if (id === d.id && d.given_id !== null) {
+        // Prefer to use `given_id` over datasets regular ID
+        slice_id = slice_id!.replace(encodedId, d.given_id);
+      }
+    });
+  }
+
+  const value_type = getValueType(
+    metadataSlices,
+    isVar(left) ? left.var : null
+  );
+
+  let RhsComponent: React.FC<RhsProps> = isListOperator(op) ? List : Constant;
+  let options: object | object[] | undefined;
 
   if (summary?.value_type === "continuous") {
     RhsComponent = NumberExpr;
@@ -101,6 +120,16 @@ function Comparison({
       min: summary.min,
       max: summary.max,
     };
+  } else if (summary?.value_type === "binary" && isVar(left)) {
+    const dataset_id = (slice_id || left.var).split("/")[1];
+    // For binary datasets, we hide the fact that values are stored as 0 and 1
+    // and instead present the user with a set of features to choose from. When
+    // a feature is selected, the RHS of the expression is automatically set to
+    // 1.
+    options = summary.unique_values.map((label: string) => ({
+      value: `slice/${dataset_id}/${encodeURIComponent(label)}/label`,
+      label,
+    }));
   } else {
     options = summary?.unique_values.map((value: string) => ({
       value,
@@ -128,9 +157,25 @@ function Comparison({
   );
 
   useEffect(() => {
-    let mounted = true;
+    if (value_type === "binary" && isVar(left)) {
+      (async () => {
+        const dataset_id = left.var.split("/")[1];
 
-    if (slice_id) {
+        try {
+          const data = await api.fetchDimensionLabelsOfDataset(
+            null,
+            dataset_id
+          );
+          setSummary({
+            value_type: "binary",
+            unique_values: data.labels,
+          });
+        } catch (e) {
+          setError(`Invalid dataset_id "${dataset_id}".`);
+          window.console.error(e);
+        }
+      })();
+    } else if (slice_id) {
       (async () => {
         setSummary(null);
 
@@ -144,22 +189,17 @@ function Comparison({
             });
           } else {
             const fetchedOptions = await api.fetchUniqueValuesOrRange(slice_id);
-            if (mounted) {
-              setSummary(fetchedOptions);
-            }
+            setSummary(fetchedOptions);
           }
         } catch (e) {
+          setError((e as { error: { message: string } }).error.message);
           window.console.error(e);
         }
       })();
     } else {
       setSummary(null);
     }
-
-    return () => {
-      mounted = false;
-    };
-  }, [api, slice_type, slice_id]);
+  }, [api, slice_type, slice_id, left, value_type]);
 
   useEffect(() => {
     if (summary && summary.value_type === "continuous") {
@@ -177,6 +217,42 @@ function Comparison({
     }
   }, [summary, expr, op, dispatch, path]);
 
+  // If a specific binary slice has been selected, initialize the RHS to a
+  // value of 1. The logic behind this is pretty convoluted but I'll try to
+  // explain. One-hot encoded slices are typically used to visualize an
+  // ingroup/outgroup relationship. Forcing the user to say "SOME_FEATURE == 1"
+  // is awakward. Instead we show the list of features, have the user select
+  // one, and then automatically set the value to 1 behind the scenes. The
+  // features can thus be thought of a set of pseudo-categories.
+  useEffect(() => {
+    if (value_type === "binary" && slice_id && right === null) {
+      dispatch({
+        type: "update-value",
+        payload: { path: [...path, op, 1], value: 1 },
+      });
+    }
+  }, [dispatch, slice_id, op, right, path, value_type]);
+
+  let rhsExpr = right;
+  let rhsPath = rightPath;
+
+  if (summary?.value_type === "binary") {
+    rhsExpr = slice_id;
+    rhsPath = [...path, op, 0, "var"];
+  }
+
+  const variableValue =
+    isVar(left) && isPartialSliceId(left.var) ? left.var : slice_id;
+
+  if (error) {
+    return (
+      <div className={styles.ComparisonError}>
+        <div>❗ Error</div>
+        <div>{error}</div>
+      </div>
+    );
+  }
+
   return (
     <div ref={ref} style={{ scrollMargin: 22 }}>
       <Variable
@@ -186,7 +262,7 @@ function Comparison({
         // from. Because we first prompt the user to choose a data source, so
         // we need a placeholder to keep track of that selection.
         placeholderDataSource={(left as any)?.placeholderDataSource}
-        value={isVar(left) ? left.var : null}
+        value={variableValue}
         path={leftPath}
         dispatch={dispatch}
         onChangeDataSelect={handleChangeDataSelect}
@@ -198,13 +274,12 @@ function Comparison({
         path={path}
         op={op}
         dispatch={dispatch}
-        value_type={getValueType(metadataSlices, slice_id)}
+        value_type={summary?.value_type || null}
         isLoading={isLoading || (Boolean(slice_id) && !summary)}
       />
       <RhsComponent
-        key={slice_id}
-        expr={right}
-        path={rightPath}
+        expr={rhsExpr}
+        path={rhsPath}
         dispatch={dispatch}
         options={options}
         shouldShowValidation={shouldShowValidation}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Constant.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Constant.tsx
@@ -21,8 +21,8 @@ function Constant({
     <PlotConfigSelect
       show
       enable={Boolean(options)}
-      hasError={shouldShowValidation && !expr}
-      value={expr || null}
+      hasError={shouldShowValidation && expr === null}
+      value={expr ?? null}
       onChange={(value) => {
         dispatch({
           type: "update-value",

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/ContextBuilderContext.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/ContextBuilderContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useState } from "react";
+import { DataExplorerDatasetDescriptor } from "@depmap/types";
 import {
   DeprecatedDataExplorerApiResponse,
   useDeprecatedDataExplorerApi,
@@ -8,6 +9,7 @@ type MetadataSlices = DeprecatedDataExplorerApiResponse["fetchMetadataSlices"];
 
 const ContextBuilderContext = createContext({
   metadataSlices: {} as MetadataSlices,
+  datasets: null as DataExplorerDatasetDescriptor[] | null,
   isLoading: false,
 });
 
@@ -25,6 +27,9 @@ export const ContextBuilderContextProvider = ({
   const api = useDeprecatedDataExplorerApi();
   const [isLoading, setIsLoading] = useState(true);
   const [metadataSlices, setMetadataSlices] = useState<MetadataSlices>({});
+  const [datasets, setDatasets] = useState<
+    DataExplorerDatasetDescriptor[] | null
+  >(null);
 
   useEffect(() => {
     (async () => {
@@ -33,6 +38,10 @@ export const ContextBuilderContextProvider = ({
 
         const slices = await api.fetchMetadataSlices(dimension_type);
         setMetadataSlices(slices);
+
+        const datasetsByIndexType = await api.fetchDatasetsByIndexType();
+        const fetchedDatasets = datasetsByIndexType?.[dimension_type] || [];
+        setDatasets(fetchedDatasets);
 
         setIsLoading(false);
       }
@@ -43,6 +52,7 @@ export const ContextBuilderContextProvider = ({
     <ContextBuilderContext.Provider
       value={{
         isLoading,
+        datasets,
         metadataSlices,
       }}
     >

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/NumberExpr.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/NumberExpr.tsx
@@ -21,7 +21,9 @@ function NumberExpr({
   dispatch,
   shouldShowValidation,
 }: Props) {
-  const [value, setValue] = useState<number | null>(expr || floor(options.min));
+  const [value, setValue] = useState<number | null>(
+    expr === null ? floor(options.min) : expr
+  );
 
   const { min, max } = options;
   const step = ceil(max - min) / 100;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Operator.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Operator.tsx
@@ -5,7 +5,12 @@ import { ContextBuilderReducerAction } from "./contextBuilderReducer";
 import styles from "../../styles/ContextBuilder.scss";
 
 type OperatorType = keyof typeof opLabels;
-type ValueType = "continuous" | "categorical" | "list_strings" | null;
+type ValueType =
+  | "continuous"
+  | "categorical"
+  | "list_strings"
+  | "binary"
+  | null;
 
 const toOperatorLabel = (value_type: ValueType, op: OperatorType) => {
   if (value_type === "continuous" && op === "==") {
@@ -73,6 +78,10 @@ function Operator({ expr, op, path, dispatch, value_type, isLoading }: Props) {
 
   if (value_type === "list_strings") {
     options = ["has_any", "!has_any"];
+  }
+
+  if (value_type === "binary") {
+    options = ["==", "!="];
   }
 
   const label = toOperatorLabel(value_type, op);

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Variable/DataSourceSelect.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Variable/DataSourceSelect.tsx
@@ -6,6 +6,7 @@ import HelpText from "./HelpText";
 import styles from "../../../styles/ContextBuilder.scss";
 
 interface Props {
+  isLoading: boolean;
   slice_type: string;
   value: string | null;
   onChange: (
@@ -16,7 +17,7 @@ interface Props {
   ) => void;
 }
 
-function DataSourceSelect({ slice_type, value, onChange }: Props) {
+function DataSourceSelect({ isLoading, slice_type, value, onChange }: Props) {
   let options = [
     {
       label: "Annotation",
@@ -55,9 +56,9 @@ function DataSourceSelect({ slice_type, value, onChange }: Props) {
     <PlotConfigSelect
       show
       enable
-      value={value}
+      value={isLoading ? "" : value}
       options={options}
-      isLoading={false}
+      isLoading={isLoading}
       onChange={onChange as (nextValue: string | null) => void}
       className={styles.varSelect}
       placeholder="Select data source…"

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Variable/SlicePrefixSelect.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Variable/SlicePrefixSelect.tsx
@@ -91,13 +91,17 @@ function SlicePrefixSelect({
         }
       );
 
-      return Object.entries(groups).map(([dataType, sliceIds]) => {
-        const optionsByDataType = sliceIds.map((sliceId) => {
-          return { value: sliceId, label: variables[sliceId] };
-        });
+      return Object.keys(groups)
+        .sort()
+        .map((dataType) => {
+          const sliceIds = groups[dataType];
 
-        return { label: dataType, options: optionsByDataType };
-      });
+          const optionsByDataType = sliceIds.map((sliceId) => {
+            return { value: sliceId, label: variables[sliceId] };
+          });
+
+          return { label: dataType, options: optionsByDataType };
+        });
     }
 
     return Object.entries(variables).map(([value, label]) => ({

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/contextBuilderUtils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/contextBuilderUtils.ts
@@ -1,6 +1,6 @@
 import { get_operator, get_values } from "json-logic-js";
 import { DataExplorerContext } from "@depmap/types";
-import { urlLibEncode } from "../../utils/misc";
+import { isSampleType, urlLibEncode } from "../../utils/misc";
 
 export const opLabels = {
   "==": "is",
@@ -59,8 +59,7 @@ export const makeSliceId = (
   dataset_id: string,
   feature: string
 ) => {
-  const featureType =
-    slice_type === "depmap_model" ? "transpose_label" : "label";
+  const featureType = isSampleType(slice_type) ? "transpose_label" : "label";
 
   return [
     "slice",
@@ -124,8 +123,8 @@ export const normalizeExpr = (expr: Expr) => {
 };
 
 export const getValueType = (
-  categoricalSlices:
-    | Record<string, { valueType: "categorical" | "list_strings" }>
+  metadataSlices:
+    | Record<string, { valueType: "categorical" | "list_strings" | "binary" }>
     | undefined,
   slice_id: string | null
 ) => {
@@ -137,15 +136,15 @@ export const getValueType = (
     return "categorical";
   }
 
-  if (categoricalSlices) {
-    if (slice_id in categoricalSlices) {
-      return categoricalSlices[slice_id].valueType;
+  if (metadataSlices) {
+    if (slice_id in metadataSlices) {
+      return metadataSlices[slice_id].valueType;
     }
 
     const sliceIdPrefix = slice_id.replace(/(slice\/[^/]+\/).*/, "$1");
 
-    if (sliceIdPrefix in categoricalSlices) {
-      return categoricalSlices[sliceIdPrefix].valueType;
+    if (sliceIdPrefix in metadataSlices) {
+      return metadataSlices[sliceIdPrefix].valueType;
     }
   }
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/RightHandSide/NumberInput.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/RightHandSide/NumberInput.tsx
@@ -43,7 +43,13 @@ function NumberInput({ expr, path, domain, isLoading }: Props) {
       <label htmlFor={`number-input-${path}`}>Value</label>
       <FormControl
         className={cx({
-          [styles.invalidNumber]: shouldShowValidation && value === null,
+          [styles.invalidNumber]:
+            // FIXME: This will show that the number is out of range but the
+            // user can still save the context that way. We should add some
+            // more validation logic on the save handler.
+            (value !== null && value < floor(min)) ||
+            (value !== null && value > ceil(max)) ||
+            (value === null && shouldShowValidation),
         })}
         disabled={isLoading || !domain}
         componentClass="input"

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/selectors.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/selectors.tsx
@@ -191,18 +191,18 @@ export function ColorByTypeSelector({
     options.aggregated_slice = `${sliceTypeLabel} Context`;
     helpContent.push(
       <p key={1}>
-        Choose <b>{sliceTypeLabel} context</b> to color by membership in a
+        Choose <b>{sliceTypeLabel} Context</b> to color by membership in a
         user-defined context.
       </p>
     );
   }
 
   if (hasLegacyColorProperty || value === "property") {
-    options.property = `${sliceTypeLabel} Property`;
+    options.property = `${sliceTypeLabel} Annotation`;
     helpContent.push(
       <p key={2}>
-        Choose <b>{sliceTypeLabel} property</b> to color by major properties of
-        the {sliceTypeLabel}, such as selectivity for genes or lineage for
+        Choose <b>{sliceTypeLabel} Annotation</b> to color by major properties
+        of the {sliceTypeLabel}, such as selectivity for genes or lineage for
         models.
       </p>
     );
@@ -217,11 +217,11 @@ export function ColorByTypeSelector({
   }
 
   if (slice_type !== "other") {
-    options.custom = isElara ? "Matrix Data" : "Custom";
+    options.custom = "Matrix Data";
     helpContent.push(
       <p key={3}>
-        Choose <b>Custom</b> to treat color as a third axis, letting you choose
-        any data type that could have been an axis.
+        Choose <b>Matrix data</b> to treat color as a third axis, letting you
+        choose any data type that could have been an axis.
       </p>
     );
   }

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerDensity1DPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerDensity1DPlot.tsx
@@ -217,9 +217,15 @@ function DataExplorerDensity1DPlot({
     return out;
   }, [colorMap, data, continuousBins, plotConfig.color_by]);
 
-  const legendTitle = data?.dimensions?.color
-    ? `${data.dimensions.color.axis_label}<br>${data.dimensions.color.dataset_label}`
-    : null;
+  let legendTitle = "";
+
+  if (data?.dimensions?.color) {
+    legendTitle = `${data.dimensions.color.axis_label}<br>${data.dimensions.color.dataset_label}`;
+  }
+
+  if (data?.metadata?.color_property) {
+    legendTitle = data.metadata.color_property.label;
+  }
 
   const pointVisibility = useMemo(
     () =>

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerScatterPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerScatterPlot.tsx
@@ -227,9 +227,15 @@ function DataExplorerScatterPlot({
 
   // The plot only needs legend info if the user is downloading an image of it.
   const legendForDownload = useMemo(() => {
-    const title = data?.dimensions?.color
-      ? `${data.dimensions.color.axis_label}<br>${data.dimensions.color.dataset_label}`
-      : "";
+    let title = "";
+
+    if (data?.dimensions?.color) {
+      title = `${data.dimensions.color.axis_label}<br>${data.dimensions.color.dataset_label}`;
+    }
+
+    if (data?.metadata?.color_property) {
+      title = data.metadata.color_property.label;
+    }
 
     const items: { name: string; hexColor: string }[] = [];
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerWaterfallPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerWaterfallPlot.tsx
@@ -233,9 +233,15 @@ function DataExplorerWaterfallPlot({
 
   // The plot only needs legend info if the user is downloading an image of it.
   const legendForDownload = useMemo(() => {
-    const title = data?.dimensions?.color
-      ? `${data.dimensions.color.axis_label}<br>${data.dimensions.color.dataset_label}`
-      : "";
+    let title = "";
+
+    if (data?.dimensions?.color) {
+      title = `${data.dimensions.color.axis_label}<br>${data.dimensions.color.dataset_label}`;
+    }
+
+    if (data?.metadata?.color_property) {
+      title = data.metadata.color_property.label;
+    }
 
     const items: { name: string; hexColor: string }[] = [];
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/PlotLegend.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/PlotLegend.tsx
@@ -77,6 +77,27 @@ function LegendLabels({
   );
 }
 
+function SliceDescription({ data }: { data: DataExplorerPlotResponse | null }) {
+  if (data?.dimensions?.color) {
+    return (
+      <div className={styles.colorDimensionLabels}>
+        <div>{data.dimensions.color.axis_label}</div>
+        <div>{data.dimensions.color.dataset_label}</div>
+      </div>
+    );
+  }
+
+  if (data?.metadata?.color_property) {
+    return (
+      <div className={styles.colorDimensionLabels}>
+        <div>{data.metadata.color_property.label}</div>
+      </div>
+    );
+  }
+
+  return null;
+}
+
 interface Props {
   data: DataExplorerPlotResponse | null;
   // TODO: Convert `colorMap` to a proper Map so that `sortedLegendKeys` is not
@@ -114,12 +135,7 @@ function PlotLegend({
         Click to toggle on/off
         <HelpTip id="legend-doubleclick-help" />
       </div>
-      {data?.dimensions?.color && (
-        <div className={styles.colorDimensionLabels}>
-          <div>{data.dimensions.color.axis_label}</div>
-          <div>{data.dimensions.color.dataset_label}</div>
-        </div>
-      )}
+      <SliceDescription data={data} />
       <LegendLabels
         data={data}
         colorMap={colorMap}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/plotUtils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/plotUtils.ts
@@ -201,25 +201,39 @@ export function formatDataForScatterPlot(
     [data.dimensions.x, data.dimensions.y!]
   );
 
+  let xLabel = [data.dimensions.x.axis_label, data.dimensions.x.dataset_label]
+    .filter(Boolean)
+    .join("<br>");
+
+  let yLabel: string | null = null;
+
+  if (data.dimensions.y) {
+    yLabel = [data.dimensions.y.axis_label, data.dimensions.y.dataset_label]
+      .filter(Boolean)
+      .join("<br>");
+  }
+
+  if (data.filters.visible) {
+    if (xLabel) {
+      xLabel += `<br>filtered by ${data.filters.visible.name}`;
+    } else {
+      yLabel += `<br>filtered by ${data.filters.visible.name}`;
+    }
+  }
+
   return {
+    xLabel,
+    yLabel,
+
     x: nullifyUnplottableValues(
       data.dimensions.x.values,
       data.filters?.visible?.values
     ),
-    xLabel: [
-      data.dimensions.x.axis_label,
-      data.dimensions.x.dataset_label,
-    ].join("<br>"),
 
     y: nullifyUnplottableValues(
       data.dimensions?.y?.values,
       data.filters?.visible?.values
     ),
-    yLabel: data.dimensions.y
-      ? [data.dimensions.y.axis_label, data.dimensions.y.dataset_label].join(
-          "<br>"
-        )
-      : null,
 
     color1: c1Values || null,
     color2: c2Values || null,
@@ -264,9 +278,11 @@ export function formatDataForScatterPlot(
           : [`<b>${formattedLabel}</b>`, ...colorInfo];
 
       Object.keys(data.metadata || {}).forEach((key) => {
-        const { label: hoverLabel, values } = data.metadata[key]!;
+        const { label: hoverLabel, values, value_type } = data.metadata[key]!;
 
-        let val = values[i] != null ? values[i].toString() : "<b>N/A</b>";
+        const nullValueLabel =
+          value_type === "categorical" ? "<b>N/A</b>" : "Other";
+        let val = values[i] != null ? values[i].toString() : nullValueLabel;
         val = val.length > 40 ? `${val.substr(0, 40)}…` : val;
 
         formattedLines.push(`${hoverLabel}: ${val}`);

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/styles/DataExplorer2.scss
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/styles/DataExplorer2.scss
@@ -294,6 +294,7 @@
 .colorDimensionLabels {
   max-width: 221px;
   word-wrap: break-word;
+  font-weight: bold;
 }
 
 .plotEmptyState {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DatasetMetadataSelector/BinaryColorsHelpTip.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DatasetMetadataSelector/BinaryColorsHelpTip.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import cx from "classnames";
+import { Tooltip } from "@depmap/common-components";
+import { pluralize } from "../../utils/misc";
+import styles from "../../styles/DatasetMetadataSelector.scss";
+
+interface Props {
+  valueType: string | null;
+  sliceTypeLabel: string;
+}
+
+function BinaryColorsHelpTip({ valueType, sliceTypeLabel }: Props) {
+  if (valueType !== "binary") {
+    return null;
+  }
+
+  const indefiniteArticle = ["a", "e", "i", "o", "u"].includes(
+    sliceTypeLabel.toLowerCase()
+  )
+    ? "an"
+    : "a";
+
+  return (
+    <Tooltip
+      id="BinaryColorsHelpTip"
+      content={
+        <div>
+          Because these {pluralize(sliceTypeLabel)} overlap, a unique color
+          cannot be assigned to each one.
+          <br />
+          <br />
+          Please select {indefiniteArticle} {sliceTypeLabel} of interest and it
+          will be colored as the in-group.
+        </div>
+      }
+      placement="right"
+    >
+      <div className={styles.BinaryColorsHelpTip}>
+        <span
+          className={cx("glyphicon", "glyphicon-info-sign")}
+          style={{ marginInlineStart: 8, top: 2, color: "#7B317C" }}
+        />
+      </div>
+    </Tooltip>
+  );
+}
+
+export default BinaryColorsHelpTip;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DatasetMetadataSelector/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DatasetMetadataSelector/index.tsx
@@ -5,10 +5,12 @@ import {
 } from "../../contexts/DeprecatedDataExplorerApiContext";
 import PlotConfigSelect from "../PlotConfigSelect";
 import SliceLabelSelector from "../SliceLabelSelector";
+import BinaryColorsHelpTip from "./BinaryColorsHelpTip";
 import {
   containsPartialSlice,
   getDatasetIdFromSlice,
   getMetadataSliceTypeLabelFromSlice,
+  getValueTypeFromSlice,
   getOptions,
   sliceLabel,
   slicePrefix,
@@ -59,6 +61,11 @@ function DatasetMetadataSelector({
     options[value1] = isLoading ? "Loading…" : "(unknown property)";
   }
 
+  const sliceTypeLabel = getMetadataSliceTypeLabelFromSlice(
+    metadataSlices,
+    value
+  );
+
   return (
     <div>
       <PlotConfigSelect
@@ -73,17 +80,20 @@ function DatasetMetadataSelector({
         isLoading={isLoading}
       />
       {hasDynamicLabel && (
-        <SliceLabelSelector
-          value={value2}
-          onChange={onChange}
-          isClearable={false}
-          menuPortalTarget={null}
-          dataset_id={getDatasetIdFromSlice(metadataSlices, value as string)}
-          sliceTypeLabel={getMetadataSliceTypeLabelFromSlice(
-            metadataSlices,
-            value as string
-          )}
-        />
+        <div style={{ display: "flex" }}>
+          <SliceLabelSelector
+            value={value2}
+            onChange={onChange}
+            isClearable={false}
+            menuPortalTarget={null}
+            dataset_id={getDatasetIdFromSlice(metadataSlices, value as string)}
+            sliceTypeLabel={sliceTypeLabel}
+          />
+          <BinaryColorsHelpTip
+            valueType={getValueTypeFromSlice(metadataSlices, value)}
+            sliceTypeLabel={sliceTypeLabel}
+          />
+        </div>
       )}
     </div>
   );

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DatasetMetadataSelector/utils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DatasetMetadataSelector/utils.ts
@@ -32,13 +32,36 @@ export const getDatasetIdFromSlice = (
 
 export const getMetadataSliceTypeLabelFromSlice = (
   slices: MetadataSlices,
-  value: string
+  value: string | null
 ) => {
+  if (!value) {
+    return "";
+  }
+
   let out = "";
 
   Object.entries(slices).forEach(([sliceId, descriptor]) => {
     if (sliceId === slicePrefix(slices, value)) {
       out = descriptor.sliceTypeLabel as string;
+    }
+  });
+
+  return out;
+};
+
+export const getValueTypeFromSlice = (
+  slices: MetadataSlices,
+  value: string | null
+) => {
+  if (!value) {
+    return null;
+  }
+
+  let out = null;
+
+  Object.entries(slices).forEach(([sliceId, descriptor]) => {
+    if (sliceId === slicePrefix(slices, value)) {
+      out = descriptor.valueType as string;
     }
   });
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/PlotConfigSelect.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/PlotConfigSelect.tsx
@@ -48,7 +48,7 @@ const reactSelectOptionsToMap = (options: Option[]) => {
   for (let i = 0; i < options.length; i += 1) {
     const opt = options[i];
 
-    if (opt.value) {
+    if (opt.value != null && opt.value !== "") {
       out[opt.value] = opt.label;
     }
 
@@ -82,7 +82,9 @@ function PlotConfigSelect({
     : options;
 
   const toOption = (val: string | null) => {
-    return val ? { value: val, label: flattenedOptions[val] } : null;
+    return val != null && val !== ""
+      ? { value: val, label: flattenedOptions[val] }
+      : null;
   };
 
   const formattedOptions = Array.isArray(options)

--- a/frontend/packages/@depmap/data-explorer-2/src/contexts/DeprecatedDataExplorerApiContext.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/contexts/DeprecatedDataExplorerApiContext.tsx
@@ -200,6 +200,7 @@ const defaultValue = {
     slice_id: string;
     label: string;
     indexed_values: Record<string, string>;
+    value_type: "categorical" | "binary";
   }> => {
     window.console.log("fetchMetadataColumn:", { slice_id });
     throw new Error("Not implemented");
@@ -212,7 +213,7 @@ const defaultValue = {
       string,
       {
         name: string;
-        valueType: "categorical" | "list_strings";
+        valueType: "categorical" | "list_strings" | "binary";
         isHighCardinality?: boolean;
         isPartialSliceId?: boolean;
         sliceTypeLabel?: string;
@@ -270,7 +271,7 @@ const defaultValue = {
     slice_id: string
   ): Promise<
     | {
-        value_type: "categorical";
+        value_type: "categorical" | "binary";
         unique_values: string[];
       }
     | {

--- a/frontend/packages/@depmap/data-explorer-2/src/styles/ContextBuilder.scss
+++ b/frontend/packages/@depmap/data-explorer-2/src/styles/ContextBuilder.scss
@@ -218,3 +218,22 @@
 .unblockable {
   display: block !important;
 }
+
+.ComparisonError {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #e50001;
+  border-radius: 4px;
+  padding: 10px;
+  margin-right: 30px;
+  background-color: #ffe7eb;
+
+  & > div {
+    display: flex;
+    width: 100%;
+  }
+
+  & > div:first-child {
+    color: #e50001;
+  }
+}

--- a/frontend/packages/@depmap/data-explorer-2/src/styles/DatasetMetadataSelector.scss
+++ b/frontend/packages/@depmap/data-explorer-2/src/styles/DatasetMetadataSelector.scss
@@ -1,0 +1,4 @@
+.BinaryColorsHelpTip {
+  margin-top: 2px;
+  align-self: center;
+}

--- a/frontend/packages/@depmap/types/src/data-explorer-2.ts
+++ b/frontend/packages/@depmap/types/src/data-explorer-2.ts
@@ -147,6 +147,7 @@ export interface DataExplorerPlotResponse {
         label: string;
         slice_id: string;
         values: (string | number)[];
+        value_type: "categorical" | "binary";
       }
     >
   >;

--- a/frontend/packages/portal-frontend/src/data-explorer-2/deprecated-api.ts
+++ b/frontend/packages/portal-frontend/src/data-explorer-2/deprecated-api.ts
@@ -380,6 +380,7 @@ export async function fetchMetadataColumn(
   slice_id: string;
   label: string;
   indexed_values: Record<string, string>;
+  value_type: "categorical" | "binary";
 }> {
   return postJson("/get_metadata", { metadata: { slice_id } });
 }
@@ -571,7 +572,7 @@ export function fetchUniqueValuesOrRange(
   slice_id: string
 ): Promise<
   | {
-      value_type: "categorical";
+      value_type: "categorical" | "binary";
       unique_values: string[];
     }
   | {

--- a/portal-backend/depmap/data_explorer_2/datatypes.py
+++ b/portal-backend/depmap/data_explorer_2/datatypes.py
@@ -19,7 +19,7 @@ entity_aliases = {
     ],
 }
 
-hardcoded_metadata_slices = {
+_hardcoded_metadata_slices = {
     "depmap_model": {
         "slice/cell_line_display_name/all/label": {
             "name": "Cell Line Name",
@@ -492,3 +492,30 @@ hardcoded_metadata_slices = {
         },
     },
 }
+
+
+def get_hardcoded_metadata_slices():
+    # FIXME: Instead of hardcoding this, find datasets with data_type
+    # "metadata" and value_type "binary". Those two conditions represent
+    # an annotation that's stored as a one-hot encoded matrix.
+    molecular_subtypes_slice_id = "slice/OmicsInferredMolecularSubtypes/"
+    model_slices = _hardcoded_metadata_slices["depmap_model"]
+
+    model_slices[molecular_subtypes_slice_id] = {
+        "name": "Inferred Molecular Subtype",
+        "valueType": "binary",
+        "isPartialSliceId": True,
+        "sliceTypeLabel": "Molecular subtype",
+        "isBreadboxMetadata": True,
+    }
+
+    return _hardcoded_metadata_slices
+
+
+def is_hardcoded_binarylike_slice(slice_id: str) -> bool:
+    for slices in get_hardcoded_metadata_slices().values():
+        for m_slice_id, info in slices.items():
+            if m_slice_id in slice_id:
+                if info.get("valueType") == "binary":
+                    return True
+    return False

--- a/portal-backend/depmap/data_explorer_2/utils.py
+++ b/portal-backend/depmap/data_explorer_2/utils.py
@@ -6,13 +6,13 @@ import pandas as pd
 from typing import Any, Optional
 from collections import defaultdict
 from logging import getLogger
-from flask import abort, json, make_response
+from flask import json, make_response
 
 from depmap_compute.context import (
     ContextEvaluator,
     LegacyContextEvaluator,
 )
-from depmap_compute.slice import decode_slice_id, SliceQuery
+from depmap_compute.slice import decode_slice_id
 from depmap import data_access
 from depmap.data_access.models import MatrixDataset
 from depmap.settings.download_settings import get_download_list
@@ -351,6 +351,8 @@ def get_all_supported_continuous_datasets() -> list[MatrixDataset]:
         if dataset.feature_type in blocked_dimension_types:
             continue
         if dataset.sample_type in blocked_dimension_types:
+            continue
+        if dataset.data_type == "metadata":
             continue
 
         if dataset.data_type is None:


### PR DESCRIPTION
Asana: https://app.asana.com/0/1165651979405609/1209804368349686/f

This modifies the UI to treat one-hot encoded matrices more gracefully. Instead of exposing the details of the encoding to the user, the columns are displayed as pseudo-categories they can choose from.

For now, only the Molecular Subtypes dataset behaves this way. I've done some experiments that suggest this could be a good approach for handling all of our one-hot encoded matrices.