### PR TITLE
fix(breadbox): Improve breadbox client usability

### DIFF
--- a/breadbox-client/README.md
+++ b/breadbox-client/README.md
@@ -4,7 +4,7 @@ A python client library for interacting with the Breadbox API.
 
 This includes both an auto-generated `breadbox_client` module and a human-curated `breadbox_facade` which defines a more user-friendly interface for the client. 
 
-## Quick Start for Client Users
+## Quick Start for client users
 
 Reading data from the public DepMap portal does not require authentication, and is a good place to get started. 
 
@@ -34,6 +34,8 @@ df = client.get_tabular_dataset_data(dataset_id={some_other_dataset_id})
 ```
 
 _Note: Not all breadbox endpoints are available through the easy-to-use "breadbox_facade" portion of the client. This is under active development and will continue to improve._
+
+You can view the full list of available `breadbox_facade` methods [here](./breadbox_facade/client.py).
 
 # Guide for Breadbox Developers:
 
@@ -115,7 +117,7 @@ installed by brew and when using `poetry self ...` it's not updating the
 environment in the right directory. `poetry self update` flat out aborts
 saying it cannot do that when installed via brew.)
 
-## Advanced Usage
+# Advanced Client Usage
 
 If the endpoints you're going to hit require authentication, use `AuthenticatedClient` instead:
 

--- a/breadbox-client/README.md
+++ b/breadbox-client/README.md
@@ -1,9 +1,41 @@
 # The Breadbox Client
 
-A client library for accessing Breadbox
+A python client library for interacting with the Breadbox API. 
 
-Includes both an auto-generated `breadbox_client` module and a human-curated `breadbox_facade` which defines a more user-friendly interface for the client. 
+This includes both an auto-generated `breadbox_client` module and a human-curated `breadbox_facade` which defines a more user-friendly interface for the client. 
 
+## Quick Start for Client Users
+
+Reading data from the public DepMap portal does not require authentication, and is a good place to get started. 
+
+### Install the breadbox-client package:
+
+```
+poetry source add --priority=supplemental public-python https://us-central1-python.pkg.dev/cds-artifacts/public-python/simple/
+poetry add --source public-python breadbox-client
+```
+
+### Read data from the public portal
+
+```python
+from breadbox_facade import BBClient
+
+# First, instantiate the client:
+client = BBClient(base_url="https://depmap.org/portal/breadbox/", user="someusername")
+
+# View the full list datasets we have available: 
+datasets = client.get_datasets()
+
+# Load the full contents of a matrix dataset into a pandas dataframe
+df = client.get_matrix_dataset_data(dataset_id={some_dataset_id})
+
+# Or, get the contents of a tabular dataset (our metadata is stored in tabular datasets)
+df = client.get_tabular_dataset_data(dataset_id={some_other_dataset_id})
+```
+
+_Note: Not all breadbox endpoints are available through the easy-to-use "breadbox_facade" portion of the client. This is under active development and will continue to improve._
+
+# Guide for Breadbox Developers:
 
 ## Auto-Generating the breadbox_client
 When changes are merged to master, the `breadbox-client/breadbox_client` directory will be auto-generated before the breadbox-client module is published.
@@ -83,37 +115,7 @@ installed by brew and when using `poetry self ...` it's not updating the
 environment in the right directory. `poetry self update` flat out aborts
 saying it cannot do that when installed via brew.)
 
-## Usage
-
-### To install this module outside this repo:
-
-```
-poetry source add --priority=supplemental public-python https://us-central1-python.pkg.dev/cds-artifacts/public-python/simple/
-poetry add --source public-python breadbox-client
-```
-
-First, create a client:
-
-```python
-from breadbox_facade import BBClient
-
-client = BBClient(base_url="https://depmap.org/portal/breadbox/", user="someusername")
-
-
-# If you're connnecting to the public portal or a local instance, you can now go ahead and use the client.
-# For example:
-datasets = client.get_datasets()
-dimension_types = client.get_dimension_types()
-
-# If you wanted to get the metadata for a particular gene, you could do something like:
-df = client.get_tabular_dataset_data(
-    dataset_id=dataset_id, # The ID of the gene metadata dataset
-    columns=None,
-    identifier="label",
-    indices=[gene_name], # This will filter the result to just the gene you're interested in
-    strict=True,
-)
-```
+## Advanced Usage
 
 If the endpoints you're going to hit require authentication, use `AuthenticatedClient` instead:
 

--- a/breadbox-client/breadbox_facade/client.py
+++ b/breadbox-client/breadbox_facade/client.py
@@ -189,9 +189,9 @@ class BBClient:
     def get_tabular_dataset_data(
         self, 
         dataset_id: str,
-        columns: Optional[list[str]],
-        identifier: Optional[Literal["id", "label"]],
-        indices: Optional[list[str]],
+        columns: Optional[list[str]] = None,
+        identifier: Optional[Literal["id", "label"]] = None,
+        indices: Optional[list[str]] = None,
         strict: bool = False,
     ):
         request_params = TabularDimensionsInfo(
@@ -214,10 +214,10 @@ class BBClient:
     def get_matrix_dataset_data(
         self, 
         dataset_id: str,
-        features: Optional[list[str]],
-        feature_identifier: Optional[Literal["id", "label"]],
-        samples: Optional[list[str]],
-        sample_identifier: Optional[Literal["id", "label"]],
+        features: Optional[list[str]] = None,
+        feature_identifier: Optional[Literal["id", "label"]] = None,
+        samples: Optional[list[str]] = None,
+        sample_identifier: Optional[Literal["id", "label"]] = None,
         strict = False,
     ):
         request_params = MatrixDimensionsInfo(

--- a/breadbox/breadbox/api/datasets.py
+++ b/breadbox/breadbox/api/datasets.py
@@ -396,6 +396,10 @@ def get_dataset_data(
     ] = None,
 ):
     """Get dataset dataframe subset given the features and samples. Filtering should be possible using either labels (cell line name, gene name, etc.) or ids (depmap_id, entrez_id, etc.). If features or samples are not specified, return all features or samples"""
+    if dataset.format != "matrix_dataset":
+        raise HTTPException(
+            400, "This endpoint only supports matrix_datasets. Use the `/tabular` endpoint instead."
+        )
     try:
         dim_info = MatrixDimensionsInfo(
             features=features,

--- a/breadbox/breadbox/api/datasets.py
+++ b/breadbox/breadbox/api/datasets.py
@@ -324,6 +324,8 @@ def get_matrix_dataset_data(
         ),
     ] = False,
 ):
+    if dataset.format != "matrix_dataset":
+        raise UserError("This endpoint only supports matrix_datasets. Use the `/tabular` endpoint instead.")
     try:
         df = dataset_service.get_subsetted_matrix_dataset_df(
             db,
@@ -355,6 +357,8 @@ def get_tabular_dataset_data(
         ),
     ] = False,
 ):
+    if dataset.format != "tabular_dataset":
+        raise UserError("This endpoint only supports tabular datasets. Use the `/matrix` endpoint instead.")
     try:
         df = dataset_service.get_subsetted_tabular_dataset_df(
             db, user, dataset, tabular_dimensions_info, strict
@@ -397,9 +401,7 @@ def get_dataset_data(
 ):
     """Get dataset dataframe subset given the features and samples. Filtering should be possible using either labels (cell line name, gene name, etc.) or ids (depmap_id, entrez_id, etc.). If features or samples are not specified, return all features or samples"""
     if dataset.format != "matrix_dataset":
-        raise HTTPException(
-            400, "This endpoint only supports matrix_datasets. Use the `/tabular` endpoint instead."
-        )
+        raise UserError("This endpoint only supports matrix_datasets. Use the `/tabular` endpoint instead.")
     try:
         dim_info = MatrixDimensionsInfo(
             features=features,

--- a/breadbox/breadbox/service/dataset.py
+++ b/breadbox/breadbox/service/dataset.py
@@ -193,7 +193,7 @@ def get_subsetted_tabular_dataset_df(
     If either indices or columns are not specified, return all indices or columns
     By default, if indices and identifier not specified, then dimension ids are used as identifier
     """
-    if not user_has_access_to_group(dataset.group, user, write_access=True):
+    if not user_has_access_to_group(dataset.group, user, write_access=False):
         raise DatasetAccessError(f"User {user} does not have access to dataset")
 
     # If labels were given as the filter, get the corresponding set of given ids

--- a/breadbox/breadbox/service/dataset.py
+++ b/breadbox/breadbox/service/dataset.py
@@ -193,8 +193,7 @@ def get_subsetted_tabular_dataset_df(
     If either indices or columns are not specified, return all indices or columns
     By default, if indices and identifier not specified, then dimension ids are used as identifier
     """
-    if not user_has_access_to_group(dataset.group, user, write_access=False):
-        raise DatasetAccessError(f"User {user} does not have access to dataset")
+    dataset_crud.assert_user_has_access_to_dataset(dataset, user)
 
     # If labels were given as the filter, get the corresponding set of given ids
     dataset_labels_by_id = metadata_service.get_tabular_dataset_labels_by_id(


### PR DESCRIPTION
A few small improvements that make the breadbox-client more usable for people reading data from the public portal. These are all addressing things that came up as I was showing Yajit how to query the breadbox API:
1. Users should not need write access in order to use the `get_tabular_dataset_data` endpoint. I'm not sure why that was the case before. I updated the endpoint to match the behavior we have in `get_matrix_dataset_data`.
2. I added a "quick start for users" section to the breadbox client documentation
3. I added error handling in the deprecated `get_dataset_data` endpoint (I was trying it out this morning, and accidentally caused a 500 error by passing in a tabular dataset ID)
4.  I added the `get_matrix_dataset_data` method to the breadbox facade so it's easier to call. 