### PR TITLE
better fix for organizing annotations

### DIFF
--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Variable/DataSourceSelect.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Variable/DataSourceSelect.tsx
@@ -12,7 +12,7 @@ interface Props {
   onChange: (
     nextValue:
       | "legacy_metadata_slice"
-      | "breadbox_metadata_column"
+      | "official_annotation"
       | "matrix_dataset"
   ) => void;
 }
@@ -21,7 +21,7 @@ function DataSourceSelect({ isLoading, slice_type, value, onChange }: Props) {
   let options = [
     {
       label: "Annotation",
-      value: "breadbox_metadata_column",
+      value: "official_annotation",
     },
     {
       label: "Legacy Annotation",

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Variable/HelpText.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Variable/HelpText.tsx
@@ -20,7 +20,7 @@ function HelpText({ dataSourceOption, slice_type }: Props) {
     );
   }
 
-  if (dataSourceOption === "breadbox_metadata_column") {
+  if (dataSourceOption === "official_annotation") {
     return (
       <span>
         This is the set of annotations associated instances of{" "}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Variable/SlicePrefixSelect.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilder/Variable/SlicePrefixSelect.tsx
@@ -8,7 +8,7 @@ import styles from "../../../styles/ContextBuilder.scss";
 interface Props {
   dataSource:
     | "legacy_metadata_slice"
-    | "breadbox_metadata_column"
+    | "official_annotation"
     | "matrix_dataset"
     | null;
   onChangeDataSelect: (option: { label: string; value: string } | null) => void;
@@ -63,9 +63,9 @@ function SlicePrefixSelect({
 
     Object.entries(metadataSlices)
       .filter(([, value]) => {
-        return value.isBreadboxMetadata
-          ? dataSource === "breadbox_metadata_column"
-          : dataSource === "legacy_metadata_slice";
+        return value.isLegacy
+          ? dataSource === "legacy_metadata_slice"
+          : dataSource === "official_annotation";
       })
       .sort((a, b) => compare(a[0], b[0]))
       .forEach(([key, value]) => {

--- a/frontend/packages/@depmap/data-explorer-2/src/contexts/DeprecatedDataExplorerApiContext.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/contexts/DeprecatedDataExplorerApiContext.tsx
@@ -217,7 +217,7 @@ const defaultValue = {
         isHighCardinality?: boolean;
         isPartialSliceId?: boolean;
         sliceTypeLabel?: string;
-        isBreadboxMetadata?: boolean;
+        isLegacy?: boolean;
         isIdColumn?: boolean;
         isLabelColumn?: boolean;
       }

--- a/frontend/packages/portal-frontend/src/data-explorer-2/deprecated-api.ts
+++ b/frontend/packages/portal-frontend/src/data-explorer-2/deprecated-api.ts
@@ -396,7 +396,9 @@ export async function fetchMetadataSlices(
       isHighCardinality?: boolean;
       isPartialSliceId?: boolean;
       sliceTypeLabel?: string;
-      isBreadboxMetadata?: boolean;
+      isLegacy?: boolean;
+      isIdColumn?: boolean;
+      isLabelColumn?: boolean;
     }
   >
 > {

--- a/portal-backend/depmap/data_explorer_2/datatypes.py
+++ b/portal-backend/depmap/data_explorer_2/datatypes.py
@@ -26,36 +26,52 @@ _hardcoded_metadata_slices = {
             "valueType": "categorical",
             "isHighCardinality": True,
             "isLabelColumn": True,
+            "isLegacy": True,
         },
         "slice/age_category/all/label": {
             "name": "Age Category",
             "valueType": "categorical",
+            "isLegacy": True,
         },
-        "slice/lineage/1/label": {"name": "Lineage", "valueType": "categorical"},
+        "slice/lineage/1/label": {
+            "name": "Lineage",
+            "valueType": "categorical",
+            "isLegacy": True,
+        },
         "slice/lineage/2/label": {
             "name": "Lineage Subtype",
             "valueType": "categorical",
+            "isLegacy": True,
         },
         "slice/lineage/3/label": {
             "name": "Lineage Sub-subtype",
             "valueType": "categorical",
+            "isLegacy": True,
         },
         "slice/primary_disease/all/label": {
             "name": "Primary Disease",
             "valueType": "categorical",
+            "isLegacy": True,
         },
         "slice/disease_subtype/all/label": {
             "name": "Disease Subtype",
             "valueType": "categorical",
+            "isLegacy": True,
         },
         "slice/tumor_type/all/label": {
             "name": "Tumor Type",
             "valueType": "categorical",
+            "isLegacy": True,
         },
-        "slice/gender/all/label": {"name": "Gender", "valueType": "categorical"},
+        "slice/gender/all/label": {
+            "name": "Gender",
+            "valueType": "categorical",
+            "isLegacy": True,
+        },
         "slice/growth_pattern/all/label": {
             "name": "Growth Pattern",
             "valueType": "categorical",
+            "isLegacy": True,
         },
         "slice/prism-pools-4441.2%2Fcoded_prism_pools/": {
             "name": "Current PRISM Pools",
@@ -75,7 +91,6 @@ _hardcoded_metadata_slices = {
             "isPartialSliceId": True,
             "isHighCardinality": True,
             "sliceTypeLabel": "gene",
-            "isBreadboxMetadata": True,
         },
         "slice/msi-0584.6%2Fmsi/": {
             "name": "Micro Satellite Instability",
@@ -89,258 +104,211 @@ _hardcoded_metadata_slices = {
         "slice/depmap_model_metadata/depmap_id/label": {
             "name": "ModelID",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
             "isIdColumn": True,
         },
         "slice/depmap_model_metadata/label/label": {
             "name": "CellLineName",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
             "isLabelColumn": True,
         },
         "slice/depmap_model_metadata/Age/label": {
             "name": "Age",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/AgeCategory/label": {
             "name": "AgeCategory",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/CCLEName/label": {
             "name": "CCLEName",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/COSMICID/label": {
             "name": "COSMICID",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/CatalogNumber/label": {
             "name": "CatalogNumber",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/CulturedResistanceDrug/label": {
             "name": "CulturedResistanceDrug",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/DepmapModelType/label": {
             "name": "DepmapModelType",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/EngineeredModel/label": {
             "name": "EngineeredModel",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/EngineeredModelDetails/label": {
             "name": "EngineeredModelDetails",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/FormulationID/label": {
             "name": "FormulationID",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/GrowthPattern/label": {
             "name": "GrowthPattern",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/HCMIID/label": {
             "name": "HCMIID",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/ModelAvailableInDbgap/label": {
             "name": "ModelAvailableInDbgap",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/ModelDerivationMaterial/label": {
             "name": "ModelDerivationMaterial",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/ModelSubtypeFeatures/label": {
             "name": "ModelSubtypeFeatures",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/ModelTreatment/label": {
             "name": "ModelTreatment",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/ModelType/label": {
             "name": "ModelType",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/OnboardedMedia/label": {
             "name": "OnboardedMedia",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/OncotreeCode/label": {
             "name": "OncotreeCode",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/OncotreeLineage/label": {
             "name": "OncotreeLineage",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/OncotreePrimaryDisease/label": {
             "name": "OncotreePrimaryDisease",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/OncotreeSubtype/label": {
             "name": "OncotreeSubtype",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/PatientID/label": {
             "name": "PatientID",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/PatientRace/label": {
             "name": "PatientRace",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/PatientSubtypeFeatures/label": {
             "name": "PatientSubtypeFeatures",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/PatientTreatmentDetails/label": {
             "name": "PatientTreatmentDetails",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/PatientTreatmentResponse/label": {
             "name": "PatientTreatmentResponse",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/PatientTreatmentStatus/label": {
             "name": "PatientTreatmentStatus",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/PatientTreatmentType/label": {
             "name": "PatientTreatmentType",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/PatientTumorGrade/label": {
             "name": "PatientTumorGrade",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/PlateCoating/label": {
             "name": "PlateCoating",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/PrimaryOrMetastasis/label": {
             "name": "PrimaryOrMetastasis",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/PublicComments/label": {
             "name": "PublicComments",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/RRID/label": {
             "name": "RRID",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/SampleCollectionSite/label": {
             "name": "SampleCollectionSite",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/SangerModelID/label": {
             "name": "SangerModelID",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/SerumFreeMedia/label": {
             "name": "SerumFreeMedia",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/Sex/label": {
             "name": "Sex",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/SourceDetail/label": {
             "name": "SourceDetail",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/SourceType/label": {
             "name": "SourceType",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/Stage/label": {
             "name": "Stage",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/StagingSystem/label": {
             "name": "StagingSystem",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/StrippedCellLineName/label": {
             "name": "StrippedCellLineName",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/depmap_model_metadata/TissueOrigin/label": {
             "name": "TissueOrigin",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/depmap_model_metadata/WTSIMasterCellID/label": {
             "name": "WTSIMasterCellID",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         ###################################################
@@ -349,10 +317,12 @@ _hardcoded_metadata_slices = {
         "slice/gene_essentiality/all/label": {
             "name": "Essentiality",
             "valueType": "categorical",
+            "isLegacy": True,
         },
         "slice/gene_selectivity/all/label": {
             "name": "Selectivity",
             "valueType": "categorical",
+            "isLegacy": True,
         },
     },
     "compound_experiment": {
@@ -360,136 +330,116 @@ _hardcoded_metadata_slices = {
             "name": "Compound",
             "valueType": "categorical",
             "isHighCardinality": True,
+            "isLegacy": True,
         },
         "slice/compound_experiment/compound_instance/label": {
             "name": "Experiment",
             "valueType": "categorical",
             "isHighCardinality": True,
+            "isLegacy": True,
         },
     },
     # This type should just be called "screen" but it isn't. The fact that it's
-    # called "Screen metadata" means that the its metadata is called "Screen
+    # called "Screen metadata" means that its metadata is called "Screen
     # metadata metadata" 😵‍💫
     "Screen metadata": {
         "slice/screen_metadata/ScreenID/label": {
             "name": "ScreenID",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
             "isIdColumn": True,
         },
         "slice/screen_metadata/CasActivity/label": {
             "name": "CasActivity",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/screen_metadata/HasCopyNumber/label": {
             "name": "HasCopyNumber",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/screen_metadata/Library/label": {
             "name": "Library",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/screen_metadata/ModelConditionID/label": {
             "name": "ModelConditionID",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/screen_metadata/ModelID/label": {
             "name": "ModelID",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/screen_metadata/nIncludedSequences/label": {
             "name": "nIncludedSequences",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/screen_metadata/nPassingSequences/label": {
             "name": "nPassingSequences",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/screen_metadata/ScreenDoublingTime/label": {
             "name": "ScreenDoublingTime",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/screen_metadata/ScreenFPR/label": {
             "name": "ScreenFPR",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/screen_metadata/ScreenMADEssentials/label": {
             "name": "ScreenMADEssentials",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/screen_metadata/ScreenMADNonessentials/label": {
             "name": "ScreenMADNonessentials",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/screen_metadata/ScreenMedianEssentialDepletion/label": {
             "name": "ScreenMedianEssentialDepletion",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/screen_metadata/ScreenMedianNonessentialDepletion/label": {
             "name": "ScreenMedianNonessentialDepletion",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/screen_metadata/ScreenNNMD/label": {
             "name": "ScreenNNMD",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/screen_metadata/ScreenROCAUC/label": {
             "name": "ScreenROCAUC",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
             "isHighCardinality": True,
         },
         "slice/screen_metadata/ScreenType/label": {
             "name": "ScreenType",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/screen_metadata/CanInclude/label": {
             "name": "CanInclude",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/screen_metadata/PassesQC/label": {
             "name": "PassesQC",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/screen_metadata/QCStatus/label": {
             "name": "QCStatus",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/screen_metadata/ScreenNotBlacklisted/label": {
             "name": "ScreenNotBlacklisted",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
         "slice/screen_metadata/ScreenPermissionToRelease/label": {
             "name": "ScreenPermissionToRelease",
             "valueType": "categorical",
-            "isBreadboxMetadata": True,
         },
     },
 }
@@ -507,7 +457,6 @@ def get_hardcoded_metadata_slices():
         "valueType": "binary",
         "isPartialSliceId": True,
         "sliceTypeLabel": "Molecular subtype",
-        "isBreadboxMetadata": True,
     }
 
     model_slices["slice/Context_Matrix/"] = {
@@ -515,7 +464,6 @@ def get_hardcoded_metadata_slices():
         "valueType": "binary",
         "isPartialSliceId": True,
         "sliceTypeLabel": "Subtype Code",
-        "isBreadboxMetadata": True,
     }
 
     return _hardcoded_metadata_slices

--- a/portal-backend/depmap/data_explorer_2/views.py
+++ b/portal-backend/depmap/data_explorer_2/views.py
@@ -606,11 +606,10 @@ def metadata_slices():
         but this has a specific use on the frontend. The UI interprets
         isHighCardinality=True to mean "you can use this as context variable
         but it would make no sense to try to color by it."
-    "isBreadboxMetadata" (boolean):
-        The legacy Portal backend has a hack to read some metadata from
-        Breadbox tables. This is intended as a stopgap measure. Soon we will
-        remove all of these legacy enpoints and everything will be sourced from
-        Breadbox.
+    "isLegacy" (boolean):
+        Indicates that this should be listed as legacy (deprecated) annotation
+        that does not match the current column name in the corresponding
+        Breadbox metadata table.
     "isIdColumn" (boolean):
         Indicates whether a column is the one associated with a Breadbox
         dimension type's id_column This is used by the frontend to sort this


### PR DESCRIPTION
In my last commit I tried to move "mutation protein changes" out of "legacy annotations" and  make it an official annotation. That didn't work out so well and broke the UI. So here's a proper fix.