### PR TITLE
move `toStaticUrl()` helper to @depmap/globals package

### DIFF
--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/StartScreen/StartScreenExamples.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/StartScreen/StartScreenExamples.tsx
@@ -1,21 +1,9 @@
 import React from "react";
-import { DepMap, isElara } from "@depmap/globals";
+import { DepMap, toStaticUrl } from "@depmap/globals";
 import { DataExplorerPlotConfig } from "@depmap/types";
 import StartScreenExample from "./StartScreenExample";
 import examples from "./examples.json";
 import styles from "../../styles/DataExplorer2.scss";
-
-function toStaticUrl(relativeUrl: string) {
-  const assetUrl = relativeUrl.trim().replace(/^\//, "");
-
-  if (isElara) {
-    return `static/${assetUrl}`;
-  }
-
-  const element = document.getElementById("webpack-config");
-  const urlPrefix = JSON.parse(element!.textContent as string).rootUrl;
-  return `${urlPrefix}/static/${assetUrl}`.replace(/^\/\//, "");
-}
 
 const handleClickAdherentGrowthPattern = () => {
   DepMap.saveNewContext({

--- a/frontend/packages/@depmap/globals/src/globals.ts
+++ b/frontend/packages/@depmap/globals/src/globals.ts
@@ -37,6 +37,21 @@ export const enabledFeatures: Record<string, boolean> =
 // Just a convenience function for looking up this flag.
 export const isElara: boolean = Boolean(enabledFeatures.elara);
 
+// Takes a relative path and generates a URL to the static/ folder.
+// Use this for images (i.e. files in the img/ subfolder) and for other
+// static resources.
+export function toStaticUrl(relativeUrl: string) {
+  const assetUrl = relativeUrl.trim().replace(/^\//, "");
+
+  if (isElara) {
+    return `static/${assetUrl}`;
+  }
+
+  const element = document.getElementById("webpack-config");
+  const urlPrefix = JSON.parse(element!.textContent as string).rootUrl;
+  return `${urlPrefix}/static/${assetUrl}`.replace(/^\/\//, "");
+}
+
 // Currently, the `errorHandler` doesn't really do anything special outside of
 // logging to the console. In the Portal, it's defined here:
 // https://github.com/broadinstitute/depmap-portal/blob/a2e2cc9/portal-backend/depmap/templates/nav_footer/layout.html#L103

--- a/frontend/packages/@depmap/globals/src/globals.ts
+++ b/frontend/packages/@depmap/globals/src/globals.ts
@@ -48,8 +48,23 @@ export function toStaticUrl(relativeUrl: string) {
   }
 
   const element = document.getElementById("webpack-config");
-  const urlPrefix = JSON.parse(element!.textContent as string).rootUrl;
-  return `${urlPrefix}/static/${assetUrl}`.replace(/^\/\//, "");
+  let urlPrefix = "";
+
+  try {
+    const config = JSON.parse(element?.textContent || "{}");
+
+    if (config && typeof config.rootUrl === "string") {
+      urlPrefix = config.rootUrl.trim();
+    } else {
+      window.console.error(
+        "Invalid webpack-config: Missing or malformed rootUrl."
+      );
+    }
+  } catch (e) {
+    window.console.error("Failed to parse webpack-config:", e);
+  }
+
+  return `${encodeURI(urlPrefix)}/static/${assetUrl}`.replace(/^\/\//, "");
 }
 
 // Currently, the `errorHandler` doesn't really do anything special outside of

--- a/frontend/packages/portal-frontend/src/cellLine/components/CompoundSensitivityTile.tsx
+++ b/frontend/packages/portal-frontend/src/cellLine/components/CompoundSensitivityTile.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Tooltip, OverlayTrigger } from "react-bootstrap";
-
+import { toStaticUrl } from "@depmap/globals";
 import RectanglePlot from "src/cellLine/components/RectanglePlot";
 import { DepmapApi } from "src/dAPI";
 import { CellLineDataMatrix } from "../models/types";
@@ -33,7 +33,7 @@ const CompoundSensitivityTile = ({
             <span className="stacked-boxplot-tooltip">
               <OverlayTrigger placement="bottom" overlay={prefDepTooltip}>
                 <img
-                  src={dapi._getFileUrl("/static/img/predictability/info.svg")}
+                  src={toStaticUrl("img/predictability/info.svg")}
                   alt="info icon"
                 />
               </OverlayTrigger>

--- a/frontend/packages/portal-frontend/src/cellLine/components/OncogenicAlterationsTile.tsx
+++ b/frontend/packages/portal-frontend/src/cellLine/components/OncogenicAlterationsTile.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { OncogenicAlteration } from "src/cellLine/models/types";
-import { toStaticUrl } from "src/common/utilities/context";
+import { toStaticUrl } from "@depmap/globals";
 
 interface OncogenicAlterationsTileProps {
   oncogenicAlterations: Array<OncogenicAlteration>;

--- a/frontend/packages/portal-frontend/src/cellLine/components/PrefDepTile.tsx
+++ b/frontend/packages/portal-frontend/src/cellLine/components/PrefDepTile.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Tooltip, OverlayTrigger } from "react-bootstrap";
-
+import { toStaticUrl } from "@depmap/globals";
 import RectanglePlot from "src/cellLine/components/RectanglePlot";
 import { DepmapApi } from "src/dAPI";
 import { CellLineDataMatrix } from "../models/types";
@@ -35,7 +35,7 @@ const PrefDepTile = ({
             <span className="stacked-boxplot-tooltip">
               <OverlayTrigger placement="bottom" overlay={prefDepTooltip}>
                 <img
-                  src={dapi._getFileUrl("/static/img/predictability/info.svg")}
+                  src={toStaticUrl("img/predictability/info.svg")}
                   alt="info icon"
                 />
               </OverlayTrigger>

--- a/frontend/packages/portal-frontend/src/celligner/components/CellignerPage.tsx
+++ b/frontend/packages/portal-frontend/src/celligner/components/CellignerPage.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Grid, Row, Col, Tabs, Tab, SelectCallback } from "react-bootstrap";
 
-import { enabledFeatures } from "@depmap/globals";
+import { enabledFeatures, toStaticUrl } from "@depmap/globals";
 import { DepmapApi } from "src/dAPI";
 import { getDapi } from "src/common/utilities/context";
 import WideTable, { WideTableColumns } from "@depmap/wide-table";
@@ -88,11 +88,8 @@ type State = {
   sidePanelSelectedPts: Set<number>;
   lassoOrBoxSelectedPts: Set<number>;
 };
-const ExplanationText = (props: {
-  dapi: DepmapApi;
-  methodologyUrl: string;
-}) => {
-  const { dapi, methodologyUrl } = props;
+const ExplanationText = (props: { methodologyUrl: string }) => {
+  const { methodologyUrl } = props;
   return (
     <>
       {methodologyUrl && (
@@ -104,7 +101,7 @@ const ExplanationText = (props: {
             className="icon-button-link"
           >
             <img
-              src={dapi._getFileUrl("/static/img/predictability/pdf.svg")}
+              src={toStaticUrl("img/predictability/pdf.svg")}
               alt=""
               className="icon"
             />
@@ -638,7 +635,7 @@ export default class CellignerPage extends React.Component<Props, State> {
         <Row>
           <Col sm={2}>
             {this.renderControlPanel()}
-            <ExplanationText dapi={this.dapi} methodologyUrl={methodologyUrl} />
+            <ExplanationText methodologyUrl={methodologyUrl} />
           </Col>
           <Col sm={10}>
             {this.renderGraph()}

--- a/frontend/packages/portal-frontend/src/common/components/Glossary/index.tsx
+++ b/frontend/packages/portal-frontend/src/common/components/Glossary/index.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from "react";
 import cx from "classnames";
 import { Typeahead } from "react-bootstrap-typeahead";
 import { CSSTransition } from "react-transition-group";
-import { toStaticUrl } from "src/common/utilities/context";
+import { toStaticUrl } from "@depmap/globals";
 import styles from "src/common/styles/Glossary.scss";
 import replaceReferencesWithLinks, {
   replaceSuperscriptTags,

--- a/frontend/packages/portal-frontend/src/common/components/InfoIcon.tsx
+++ b/frontend/packages/portal-frontend/src/common/components/InfoIcon.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { OverlayTrigger, Popover } from "react-bootstrap";
-import { getDapi } from "../utilities/context";
+import { toStaticUrl } from "@depmap/globals";
 
 type TriggerType = "click" | "hover" | "focus";
 
@@ -21,7 +21,7 @@ const infoImg = (
       paddingLeft: "4px",
       cursor: "pointer",
     }}
-    src={getDapi()._getFileUrl("/static/img/gene_overview/info_purple.svg")}
+    src={toStaticUrl("img/gene_overview/info_purple.svg")}
     alt="description of term"
     className="icon"
   />

--- a/frontend/packages/portal-frontend/src/common/utilities/context.ts
+++ b/frontend/packages/portal-frontend/src/common/utilities/context.ts
@@ -31,11 +31,6 @@ export function getBreadboxApi(): BreadboxApi {
   return bbapi;
 }
 
-export function toStaticUrl(relativeUrl: string) {
-  const assetUrl = relativeUrl.trim().replace(/^\//, "");
-  return `${fetchUrlPrefix()}/static/${assetUrl}`.replace(/^\/\//, "");
-}
-
 export const apiFunctions = {
   breadbox: {
     getApi: getBreadboxApi,

--- a/frontend/packages/portal-frontend/src/contextExplorer/components/ContextExplorer.tsx
+++ b/frontend/packages/portal-frontend/src/contextExplorer/components/ContextExplorer.tsx
@@ -5,6 +5,7 @@ import {
 import update from "immutability-helper";
 import qs from "qs";
 import React, { useCallback, useEffect, useState } from "react";
+import { toStaticUrl } from "@depmap/globals";
 import { getDapi } from "src/common/utilities/context";
 import ExtendedPlotType from "src/plot/models/ExtendedPlotType";
 import {
@@ -245,7 +246,7 @@ export const ContextExplorer = () => {
         margin: "1px 3px 4px 3px",
         cursor: "pointer",
       }}
-      src={getDapi()._getFileUrl("/static/img/gene_overview/info_purple.svg")}
+      src={toStaticUrl("img/gene_overview/info_purple.svg")}
       alt="description of term"
       className="icon"
     />

--- a/frontend/packages/portal-frontend/src/dataPage/components/DataStructureSection.tsx
+++ b/frontend/packages/portal-frontend/src/dataPage/components/DataStructureSection.tsx
@@ -1,6 +1,6 @@
 import { Accordion } from "@depmap/common-components";
 import React from "react";
-import { getDapi } from "src/common/utilities/context";
+import { toStaticUrl } from "@depmap/globals";
 
 import styles from "src/dataPage/styles/DataPage.scss";
 import { currentReleaseTabHref, de2PageHref } from "./utils";
@@ -17,9 +17,7 @@ const DataStructureSection = ({
   const dataStructureImage = (
     <img
       style={{ maxWidth: "675px", width: "100%" }}
-      src={getDapi()._getFileUrl(
-        "/static/img/data_page/data_structure_final.png"
-      )}
+      src={toStaticUrl("img/data_page/data_structure_final.png")}
       alt="Diagram of DepMap data structure"
     />
   );

--- a/frontend/packages/portal-frontend/src/dataPage/components/MapSection.tsx
+++ b/frontend/packages/portal-frontend/src/dataPage/components/MapSection.tsx
@@ -1,6 +1,6 @@
 import { Accordion } from "@depmap/common-components";
 import React from "react";
-import { getDapi } from "src/common/utilities/context";
+import { toStaticUrl } from "@depmap/globals";
 
 import styles from "src/dataPage/styles/DataPage.scss";
 
@@ -8,7 +8,7 @@ const MapSection = () => {
   const mapImage = (
     <img
       style={{ maxWidth: "700px", width: "100%" }}
-      src={getDapi()._getFileUrl("/static/img/data_page/Mapping2.png")}
+      src={toStaticUrl("img/data_page/Mapping2.png")}
       alt="Diagram of how to map data"
     />
   );

--- a/frontend/packages/portal-frontend/src/dataSlicer/components/DataSlicer.tsx
+++ b/frontend/packages/portal-frontend/src/dataSlicer/components/DataSlicer.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { Button, Checkbox, Radio, Modal } from "react-bootstrap";
 import update from "immutability-helper";
 
-import { enabledFeatures } from "@depmap/globals";
+import { enabledFeatures, toStaticUrl } from "@depmap/globals";
 import { CellLineListsDropdown, CustomList } from "@depmap/cell-line-selector";
 import {
   DatasetOptionsWithLabels,
@@ -808,7 +808,7 @@ export default class DataSlicer extends React.Component<
           margin: "2px 7px 7px",
           cursor: "pointer",
         }}
-        src={dapi._getFileUrl("/static/img/gene_overview/info_purple.svg")}
+        src={toStaticUrl("img/gene_overview/info_purple.svg")}
         alt="description of term"
         className="icon"
       />

--- a/frontend/packages/portal-frontend/src/genePage/components/GenePageTabs.tsx
+++ b/frontend/packages/portal-frontend/src/genePage/components/GenePageTabs.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { CustomList } from "@depmap/cell-line-selector";
+import { toStaticUrl } from "@depmap/globals";
 import {
   TabsWithHistory,
   TabList,
@@ -279,11 +280,9 @@ const GenePageTabs = ({
                     dependencyProfileOptions={dependencyProfileOptions}
                     onCelfieInitialized={() => dapi.endTrace()}
                     howToImg={howToImg}
-                    methodIcon={dapi._getFileUrl(
-                      "/static/img/predictability/pdf.svg"
-                    )}
-                    methodPdf={dapi._getFileUrl(
-                      "/static/pdf/Genomic_Associations_Methodology.pdf"
+                    methodIcon={toStaticUrl("img/predictability/pdf.svg")}
+                    methodPdf={toStaticUrl(
+                      "pdf/Genomic_Associations_Methodology.pdf"
                     )}
                   />
                 </React.Suspense>

--- a/frontend/packages/portal-frontend/src/index.tsx
+++ b/frontend/packages/portal-frontend/src/index.tsx
@@ -6,6 +6,7 @@ import {
   CustomList,
   renderCellLineSelectorModal,
 } from "@depmap/cell-line-selector";
+import { toStaticUrl } from "@depmap/globals";
 
 import { getQueryParams } from "@depmap/utils";
 import { getDapi } from "src/common/utilities/context";
@@ -397,10 +398,8 @@ export function initCelfiePage(
         dependencyProfileOptions={dependencyProfileOptions}
         onCelfieInitialized={() => dapi.endTrace()}
         howToImg={howToImg}
-        methodIcon={dapi._getFileUrl("/static/img/predictability/pdf.svg")}
-        methodPdf={dapi._getFileUrl(
-          "/static/pdf/Genomic_Associations_Methodology.pdf"
-        )}
+        methodIcon={toStaticUrl("img/predictability/pdf.svg")}
+        methodPdf={toStaticUrl("pdf/Genomic_Associations_Methodology.pdf")}
       />
     </React.Suspense>,
     document.getElementById(elementId) as HTMLElement

--- a/frontend/packages/portal-frontend/src/predictability/components/PredictabilityTab.tsx
+++ b/frontend/packages/portal-frontend/src/predictability/components/PredictabilityTab.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { Row, Col, Button } from "react-bootstrap";
 import * as Papa from "papaparse";
 
+import { toStaticUrl } from "@depmap/globals";
 import { getDapi } from "src/common/utilities/context";
 import { Spinner } from "@depmap/common-components";
 import { EntityType } from "src/entity/models/entities";
@@ -112,7 +113,7 @@ const InformationalContent = ({
         target="_blank"
       >
         <img
-          src={dapi._getFileUrl("/static/img/predictability/pdf.svg")}
+          src={toStaticUrl("img/predictability/pdf.svg")}
           alt=""
           className="icon"
         />
@@ -127,7 +128,7 @@ const InformationalContent = ({
         onClick={downloadData}
       >
         <img
-          src={dapi._getFileUrl("/static/img/predictability/download.svg")}
+          src={toStaticUrl("img/predictability/download.svg")}
           alt=""
           style={{ height: 14, marginInlineEnd: 2 }}
         />
@@ -142,7 +143,7 @@ const InformationalContent = ({
         download
       >
         <img
-          src={dapi._getFileUrl("/static/img/predictability/download.svg")}
+          src={toStaticUrl("img/predictability/download.svg")}
           alt=""
           style={{ height: 14, marginInlineEnd: 2 }}
         />

--- a/frontend/packages/portal-frontend/src/predictability/components/PredictiveModelTable.tsx
+++ b/frontend/packages/portal-frontend/src/predictability/components/PredictiveModelTable.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { DepmapApi } from "src/dAPI";
 
+import { toStaticUrl } from "@depmap/globals";
 import InfoIcon from "src/common/components/InfoIcon";
 import StyledMeter from "src/common/components/StyledMeter";
 import { EntityType } from "src/entity/models/entities";
@@ -100,7 +101,7 @@ const getRelationshipDescription = (
     <>
       <div style={{ display: "flex", alignItems: "center" }}>
         <img
-          src={dapi._getFileUrl("/static/img/predictability/self.svg")}
+          src={toStaticUrl("img/predictability/self.svg")}
           alt=""
           style={{ height: 12, marginInlineEnd: 4 }}
         />
@@ -113,7 +114,7 @@ const getRelationshipDescription = (
 
       <div style={{ display: "flex", alignItems: "center" }}>
         <img
-          src={dapi._getFileUrl("/static/img/predictability/related.svg")}
+          src={toStaticUrl("img/predictability/related.svg")}
           alt=""
           style={{ height: 12, marginInlineEnd: 4 }}
         />
@@ -130,7 +131,7 @@ const getRelationshipDescription = (
     <>
       <div style={{ display: "flex", alignItems: "center" }}>
         <img
-          src={dapi._getFileUrl("/static/img/predictability/target.svg")}
+          src={toStaticUrl("img/predictability/target.svg")}
           alt=""
           style={{ height: 12, marginInlineEnd: 4 }}
         />
@@ -267,8 +268,8 @@ const PredictiveModelTable = ({
                     {relatedType && (
                       <span className="related-icon-container">
                         <img
-                          src={dapi._getFileUrl(
-                            `/static/img/predictability/${relatedType}.svg`
+                          src={toStaticUrl(
+                            `img/predictability/${relatedType}.svg`
                           )}
                           alt={relatedType}
                         />


### PR DESCRIPTION
We already had a helper for this; it was just being used inconsistently.

Example usage:
https://github.com/broadinstitute/depmap-portal/blob/f08f1890d4fa9a6f2bc9ec7f9b8ab4a15f161573/frontend/packages/portal-frontend/src/cellLine/components/OncogenicAlterationsTile.tsx#L50-L54