### PR TITLE
Change context matrix to subtype matrix

### DIFF
--- a/data-prep-pipeline/data_prep_pipeline/publish.conseq
+++ b/data-prep-pipeline/data_prep_pipeline/publish.conseq
@@ -83,4 +83,4 @@ rule publish_context_matrix:
         update_taiga_script=fileref('upload_to_taiga.py')
     outputs:{"type": "release_context_matrix_published"}
 
-    run "python3 {{inputs.update_taiga_script.filename}} {{inputs.release_taiga_id.dataset_id}} 'Created ContextMatrix for release'  'ContextMatrix' {{inputs.context_matrix.filename}} 'csv_matrix'"
+    run "python3 {{inputs.update_taiga_script.filename}} {{inputs.release_taiga_id.dataset_id}} 'Created ContextMatrix for release'  'SubtypeMatrix' {{inputs.context_matrix.filename}} 'csv_matrix'"

--- a/data-prep-pipeline/scripts/subtype_tree/create_subtype_tree.py
+++ b/data-prep-pipeline/scripts/subtype_tree/create_subtype_tree.py
@@ -322,6 +322,10 @@ def add_depmap_nodes(models, oncotable):
             ## DECISION: Add cancerous nodes at level 1, right underneath lineage
             parent_code = lin_node.DepmapModelType
 
+            ## Hard-coded PedDep request for 25Q2: Add BALL and TALL under Lymphoid Neoplasm 
+            if new_type.DepmapModelType in ['BALL', 'TALL']:
+                parent_code = 'LNM'
+
         elif new_type.OncotreePrimaryDisease == "Non-Cancerous":
             if lin_node.NodeSource == "Oncotree":
                 ## DECISION: Add underneath the Non-Cancerous Level 1 node


### PR DESCRIPTION
Changing the name of ContextMatrix to be SubtypeMatrix in the release files so that it's more clear what is in this file, and so that it matches the name of SubtypeTree.

Also added special request for PedDep subtypes.