### PR TITLE
Fix delete dataset button state

### DIFF
--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -182,7 +182,7 @@ export default function Datasets() {
     // Only show dim type delete error message for 3 seconds
     if (dimTypeDeleteError) {
       setTimeout(() => {
-        setDatasetDeleteError(null);
+        setDimTypeDeleteError(null);
       }, 3000);
     }
   }, [dimTypeDeleteError]);

--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -91,11 +91,9 @@ export default function Datasets() {
   const [isEditDimensionTypeMode, setIsEditDimensionTypeMode] = useState(false);
   const [showDimensionTypeModal, setShowDimensionTypeModal] = useState(false);
 
-  const [showDatasetDeleteError, setShowDatasetDeleteError] = useState(false);
   const [datasetDeleteError, setDatasetDeleteError] = useState<string | null>(
     null
   );
-  const [showDimTypeDeleteError, setShowDimTypeDeleteError] = useState(false);
   const [dimTypeDeleteError, setDimTypeDeleteError] = useState<string | null>(
     null
   );
@@ -430,7 +428,6 @@ export default function Datasets() {
         setSelectedDatasetIds(new Set());
       })
       .catch((e) => {
-        setShowDatasetDeleteError(true);
         console.error(e);
         if (instanceOfErrorDetail(e)) {
           setDatasetDeleteError(e.detail);
@@ -447,7 +444,6 @@ export default function Datasets() {
         await dapi
           .deleteDimensionType(dimensionType.name)
           .then(() => {
-            setShowDimTypeDeleteError(false);
             setDimTypeDeleteError(null);
             setDimensionTypes(
               dimensionTypes.filter(
@@ -457,7 +453,6 @@ export default function Datasets() {
             setSelectedDimensionType(null);
           })
           .catch((e) => {
-            setShowDimTypeDeleteError(true);
             console.error(e);
             if (instanceOfErrorDetail(e)) {
               setDimTypeDeleteError(e.detail);
@@ -510,12 +505,12 @@ export default function Datasets() {
           </div>
 
           <h2>Datasets</h2>
-          {showDatasetDeleteError && (selectedDatasetIds.size !== 0) !== null && (
-            <Alert bsStyle="danger">
-              <strong>Dataset Delete Failed!</strong>{" "}
-              {datasetDeleteError !== null ? datasetDeleteError : null}
-            </Alert>
-          )}
+          {datasetDeleteError !== null &&
+            (selectedDatasetIds.size !== 0) !== null && (
+              <Alert bsStyle="danger">
+                <strong>Dataset Delete Failed!</strong> {datasetDeleteError}
+              </Alert>
+            )}
           <div className={styles.primaryButtons}>
             <Button
               bsStyle="primary"
@@ -560,7 +555,6 @@ export default function Datasets() {
                   );
                   setDatasetToEdit(selectedDataset || null);
                 }
-                setShowDatasetDeleteError(false);
                 setDatasetDeleteError(null);
               }}
               data={formatDatasetTableData(datasets)}
@@ -625,12 +619,12 @@ export default function Datasets() {
           <div>
             <h2>Dimension Types</h2>
 
-            {showDimTypeDeleteError && selectedDimensionType !== null && (
+            {dimTypeDeleteError !== null && selectedDimensionType !== null && (
               <Alert bsStyle="danger">
                 <strong>
                   Delete &quot;{selectedDimensionType.name}&quot; Failed!
                 </strong>{" "}
-                {dimTypeDeleteError !== null ? dimTypeDeleteError : null}
+                {dimTypeDeleteError}
               </Alert>
             )}
 
@@ -669,7 +663,6 @@ export default function Datasets() {
                   } else {
                     setSelectedDimensionType(null);
                   }
-                  setShowDimTypeDeleteError(false);
                   setDimTypeDeleteError(null);
                 }}
                 rowHeight={40}

--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -169,6 +169,26 @@ export default function Datasets() {
     })();
   }, [dapi, getDimensionTypes, isAdvancedMode]);
 
+  useEffect(() => {
+    // Only show dataset delete error message for 3 seconds
+    if (datasetDeleteError) {
+      setTimeout(() => {
+        setDatasetDeleteError(null);
+        setShowDatasetDeleteError(false);
+      }, 3000);
+    }
+  }, [datasetDeleteError]);
+
+  useEffect(() => {
+    // Only show dim type delete error message for 3 seconds
+    if (dimTypeDeleteError) {
+      setTimeout(() => {
+        setDatasetDeleteError(null);
+        setShowDatasetDeleteError(false);
+      }, 3000);
+    }
+  }, [dimTypeDeleteError]);
+
   const datasetForm = useCallback(() => {
     if (datasets) {
       let datasetFormComponent;

--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -410,16 +410,16 @@ export default function Datasets() {
   };
 
   const deleteDatasetButtonAction = async () => {
-    const datasetIdsSet = new Set(selectedDatasetIds);
+    setDatasetDeleteError(null);
 
     await Promise.all(
-      Array.from(datasetIdsSet).map((dataset_id) => {
+      Array.from(selectedDatasetIds).map((dataset_id) => {
         return dapi.deleteDatasets(dataset_id);
       })
     )
       .then(() => {
         const datasetsRemaining = datasets.filter(
-          (dataset) => !datasetIdsSet.has(dataset.id)
+          (dataset) => !selectedDatasetIds.has(dataset.id)
         );
         setDatasets(datasetsRemaining);
         const dimTypeDatasetsNum = dimensionTypeDatasetCount(datasetsRemaining);
@@ -427,6 +427,7 @@ export default function Datasets() {
           return { ...dt, datasetsCount: dimTypeDatasetsNum[dt.name] };
         });
         setDimensionTypes(updatedDimensionTypeCounts);
+        setSelectedDatasetIds(new Set());
       })
       .catch((e) => {
         setShowDatasetDeleteError(true);

--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -91,9 +91,11 @@ export default function Datasets() {
   const [isEditDimensionTypeMode, setIsEditDimensionTypeMode] = useState(false);
   const [showDimensionTypeModal, setShowDimensionTypeModal] = useState(false);
 
+  const [isDeletingDataset, setIsDeletingDataset] = useState(false);
   const [datasetDeleteError, setDatasetDeleteError] = useState<string | null>(
     null
   );
+  const [isDeletingDimType, setIsDeletingDimType] = useState(false);
   const [dimTypeDeleteError, setDimTypeDeleteError] = useState<string | null>(
     null
   );
@@ -426,6 +428,7 @@ export default function Datasets() {
   };
 
   const deleteDatasetButtonAction = async () => {
+    setIsDeletingDataset(true);
     setDatasetDeleteError(null);
 
     await Promise.all(
@@ -451,10 +454,13 @@ export default function Datasets() {
           setDatasetDeleteError(e.detail);
         }
       });
+
+    setIsDeletingDataset(false);
   };
 
   const deleteDimensionType = async () => {
     if (selectedDimensionType != null) {
+      setIsDeletingDimType(true);
       const dimensionType = dimensionTypes.find(
         (dt) => dt.name === selectedDimensionType.name
       );
@@ -477,6 +483,7 @@ export default function Datasets() {
             }
           });
       }
+      setIsDeletingDimType(false);
     }
   };
 
@@ -554,7 +561,8 @@ export default function Datasets() {
               disabled={
                 selectedDatasetIds.size === 0 ||
                 datasets.length === 0 ||
-                userGroups.writeGroups.length === 0
+                userGroups.writeGroups.length === 0 ||
+                isDeletingDataset
               }
             >
               Delete Selected Dataset
@@ -663,7 +671,7 @@ export default function Datasets() {
               <Button
                 bsStyle="danger"
                 onClick={() => deleteDimensionType()}
-                disabled={!selectedDimensionType}
+                disabled={!selectedDimensionType || isDeletingDimType}
               >
                 Delete Selected Dimension Type
               </Button>

--- a/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
+++ b/frontend/packages/@depmap/dataset-manager/src/components/index.tsx
@@ -174,7 +174,6 @@ export default function Datasets() {
     if (datasetDeleteError) {
       setTimeout(() => {
         setDatasetDeleteError(null);
-        setShowDatasetDeleteError(false);
       }, 3000);
     }
   }, [datasetDeleteError]);
@@ -184,7 +183,6 @@ export default function Datasets() {
     if (dimTypeDeleteError) {
       setTimeout(() => {
         setDatasetDeleteError(null);
-        setShowDatasetDeleteError(false);
       }, 3000);
     }
   }, [dimTypeDeleteError]);


### PR DESCRIPTION
- Fix error where deleting dataset does not clear state such that delete button is disabled ([see error log here](https://app.asana.com/1/9513920295503/project/1188486168213297/task/1210082114924877))
- Show delete error message for 3 seconds (it's a bit confusing the error message stays around when user does some other action)
- remove unnecessary state