### PR TITLE
fix(breadbox): Improve custom analysis error handling

### DIFF
--- a/breadbox/breadbox/compute/analysis_tasks.py
+++ b/breadbox/breadbox/compute/analysis_tasks.py
@@ -133,11 +133,11 @@ def _get_filtered_dataset_and_query_feature(
         value_query_vector = [0 if x == "out" else 1 for x in query_values]
 
         # Validate that BOTH the in-group and out-group have cell lines present in the dataset
-        in_group_cell_lines = {depmap_model_ids[i] for i in range(len(query_values)) if query_values[i] == "in"}
-        out_group_cell_lines = {depmap_model_ids[i] for i in range(len(query_values)) if query_values[i] == "out"}
-        if len(in_group_cell_lines.intersection(set(dataset_sample_ids))) == 0:
+        in_group_sample_ids = {depmap_model_ids[i] for i in range(len(query_values)) if query_values[i] == "in"}
+        out_group_sample_ids = {depmap_model_ids[i] for i in range(len(query_values)) if query_values[i] == "out"}
+        if len(in_group_sample_ids.intersection(set(dataset_sample_ids))) == 0:
             raise UserError("No cell lines in common between in-group and dataset selected")
-        if len(out_group_cell_lines.intersection(set(dataset_sample_ids))) == 0:
+        if len(out_group_sample_ids.intersection(set(dataset_sample_ids))) == 0:
             raise UserError("No cell lines in common between out-group and dataset selected")
 
     elif (

--- a/breadbox/pyright-ratchet-errors.txt
+++ b/breadbox/pyright-ratchet-errors.txt
@@ -1,6 +1,4 @@
 __init__.py: error: Expression of type "tuple[str, stat_result | None]" is incompatible with return type "Tuple[str, stat_result]"
-analysis_tasks.py: error: Argument of type "DataFrame | None" cannot be assigned to parameter "query_series" of type "DataFrame" in function "_get_filtered_dataset_and_query_feature"
-analysis_tasks.py: error: Object of type "None" cannot be used as iterable value (reportOptionalIterable)
 common.py: error: Cannot access attribute "__fields__" for class "type[ResponseMixin]*"
 conftest.py: error: Argument of type "Literal['read']" cannot be assigned to parameter "access_type" of type "AccessType" in function "__init__"
 data_validation.py: error: Argument of type "BinaryIO" cannot be assigned to parameter "filepath_or_buffer" of type "FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str]" in function "read_csv"


### PR DESCRIPTION
[Asana](https://app.asana.com/1/9513920295503/project/1165651979405609/task/1210110364922974?focus=true)

**Adding better error handling for a Custom Analysis issue that users run into surprisingly frequently**. Our error logs show this occurring ~350 times in the past month across environments. 

**From what I can tell this _only_ occurs when:**
1. The user is running a Two Class Comparison
2. One of the two groups (in-group, out-group) does _not_ overlap with the cell lines in the selected dataset.

For example:
<img width="1492" alt="image" src="https://github.com/user-attachments/assets/6ea69d5d-fe9f-40a1-9d2d-e8a1d8258502" />

**Logs** 
* When run with a non-breadbox dataset, the error seems to appear in our logs as: _"Exception: Error: Running this analysis returned no results"_  ([logs](https://console.cloud.google.com/errors/detail/CPrK58qYhYatjQE;filter=%5B%5D;time=P30D;locations=global?inv=1&invt=AbwEtA&project=cds-logging))
* When run with a breadbox dataset, the error appears as: "_ValueError: `ps` must include only numbers between 0 and 1"_ ([logs](https://console.cloud.google.com/errors/detail/COSR-JLxo9vFvQE;filter=%5B%22must%20include%20only%20numbers%20between%200%20and%201%22%5D;time=P30D;locations=global?project=cds-logging&inv=1&invt=AbwJig))

**Fix:** 
<img width="502" alt="image" src="https://github.com/user-attachments/assets/6a7ba6f5-c53e-439f-9a9c-b25642e87135" />

