### PR TITLE
Fix custom analysis error from dose level datasets

### DIFF
--- a/portal-backend/depmap/compute/analysis_tasks.py
+++ b/portal-backend/depmap/compute/analysis_tasks.py
@@ -1,6 +1,6 @@
 import os
 import time
-from typing import Any, Dict, List, Tuple, Optional
+from typing import Dict, List, Optional
 
 from depmap.access_control.utils.initialize_current_auth import assume_user
 from depmap_compute import analysis_tasks_interface
@@ -11,7 +11,6 @@ from depmap.compute.celery import app
 import logging
 
 from depmap import data_access
-from depmap.vector_catalog.trees import InteractiveTree
 from depmap.compute.models import CustomCellLineGroup
 from depmap.vector_catalog.models import (
     SliceRowType,
@@ -31,14 +30,14 @@ def make_result_task_directory(result_dir: str, task_id: str):
 def get_features(
     dataset_id: str, feature_labels: list[str]
 ) -> List[analysis_tasks_interface.Feature]:
-    slice_ids = InteractiveTree.get_ids_from_dataset_features(
-        dataset_id, feature_labels, feature_is_entity_id=False
-    )
-
-    features = [
-        analysis_tasks_interface.Feature(feature_label, slice_id)
-        for feature_label, slice_id in zip(feature_labels, slice_ids)
-    ]
+    features = []
+    for feature_label in feature_labels:
+        slice_id = SliceSerializer.encode_slice_id(
+            dataset=dataset_id,
+            feature=feature_label,
+            slice_row_type=SliceRowType.label
+        )
+        features.append(analysis_tasks_interface.Feature(feature_label, slice_id))
 
     return features
 


### PR DESCRIPTION
[Asana](https://app.asana.com/1/9513920295503/project/1165651979405609/task/1210110370161048?focus=true)

**Fixing another Custom Analysis error which appears quite frequently in** [our logs](https://console.cloud.google.com/errors/detail/COHR1tvKzJ2YIQ;filter=%5B%5D;time=P30D;locations=global?inv=1&invt=AbwEew&project=cds-logging) (253 times in the past month) and may be worth including as another last-minute fix in this release. 

**Background on the error:** 
The way we'd been getting slice Ids here was a bit roundabout:
1. For a given dataset, we'd load all of the feature labels
2. We'd pass those labels to a function called `get_ids_from_dataset_features` in order to load a list of slice IDs
3. That function would use the labels to load the entity object (using a function called `get_by_label`). Then, that object could be used to get an entity ID. 
4. Finally, the entity ID would be used to create a slice ID.  

This process seems to be broken for some of our dose-level datasets which use an entity type `CompoundDoseReplicate`. That class doesn't have an implementation for the method `get_by_label` (hence the error) 

**Solution**: Construct the slice IDs using labels instead of entity IDs. This is a slight change in the response, but I don't think it should impact things. I believe these values (in the response under `"vectorId"`) are only used by the frontend to parse out the dataset ID (example [here](https://github.com/broadinstitute/depmap-portal/blob/4c3416a194d4bf2b8295dbaf88fd1286cdb88778/frontend/packages/%40depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/AnalysisResult.tsx#L153)), but maybe @rcreasi would be able to confirm. 

**Follow-up**:  Once things are fully migrated to breadbox, we'll be able to simplify the custom analysis backend, and I'd like to revisit this response format as well. It doesn't really make sense to continue returning a list of slice IDs if the only thing data explorer needs is the dataset ID. 