### PR TITLE
Update cell line description tile

### DIFF
--- a/frontend/packages/portal-frontend/src/cellLine/components/ModelTab.tsx
+++ b/frontend/packages/portal-frontend/src/cellLine/components/ModelTab.tsx
@@ -7,12 +7,10 @@ export interface ModelTabProps {
 }
 
 const ModelTab = ({ modelInfo }: ModelTabProps) => {
-  const showOverview =
-    modelInfo.lineage_tree ||
-    modelInfo.molecular_subtype_tree ||
-    modelInfo.primary_metastasis ||
-    modelInfo.sample_collection_site ||
-    modelInfo.image;
+  const showAnnotations =
+    modelInfo.oncotree_lineage ||
+    modelInfo.oncotree_primary_disease ||
+    modelInfo.oncotree_subtype_and_code;
 
   const showDerivation =
     modelInfo.growth_pattern ||
@@ -28,7 +26,7 @@ const ModelTab = ({ modelInfo }: ModelTabProps) => {
     return (
       <div className={styles.descriptionTileColumns}>
         <div className={styles.descriptionTileColumn}>
-          {showOverview && (
+          {showAnnotations && (
             <h4 className={styles.propertyGroupHeader}>Annotations</h4>
           )}
           {modelInfo.oncotree_subtype_and_code && (

--- a/frontend/packages/portal-frontend/src/cellLine/components/ModelTab.tsx
+++ b/frontend/packages/portal-frontend/src/cellLine/components/ModelTab.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { ModelInfo } from "../models/types";
+import { ModelInfo, SubtypeTreeInfo } from "../models/types";
 import styles from "../styles/CellLinePage.scss";
 
 export interface ModelTabProps {
@@ -8,10 +8,8 @@ export interface ModelTabProps {
 
 const ModelTab = ({ modelInfo }: ModelTabProps) => {
   const showOverview =
-    modelInfo.oncotree_subtype_and_code ||
-    modelInfo.oncotree_primary_disease ||
-    modelInfo.oncotree_lineage ||
-    modelInfo.legacy_molecular_subtype ||
+    modelInfo.lineage_tree ||
+    modelInfo.molecular_subtype_tree ||
     modelInfo.primary_metastasis ||
     modelInfo.sample_collection_site ||
     modelInfo.image;
@@ -31,7 +29,7 @@ const ModelTab = ({ modelInfo }: ModelTabProps) => {
       <div className={styles.descriptionTileColumns}>
         <div className={styles.descriptionTileColumn}>
           {showOverview && (
-            <h4 className={styles.propertyGroupHeader}>Overview</h4>
+            <h4 className={styles.propertyGroupHeader}>Annotations</h4>
           )}
           {modelInfo.oncotree_subtype_and_code && (
             <>
@@ -55,12 +53,55 @@ const ModelTab = ({ modelInfo }: ModelTabProps) => {
               <p>{modelInfo.oncotree_lineage}</p>
             </>
           )}
-          {modelInfo.legacy_molecular_subtype && (
+          {modelInfo.lineage_tree && modelInfo.lineage_tree.length > 0 && (
             <>
-              <h6 className={styles.propertyHeader}>Molecular Subtype</h6>
-              <p>{modelInfo.legacy_molecular_subtype}</p>
+              <h4 className={styles.propertyGroupHeader}>Lineage Contexts</h4>
+              {modelInfo.lineage_tree
+                .sort((a, b) => a.level - b.level)
+                .map((info: SubtypeTreeInfo) => (
+                  <>
+                    <h6 className={styles.propertyHeader}>
+                      Level {info.level}
+                    </h6>
+                    <a
+                      className={styles.descriptionLinks}
+                      href={info.context_explorer_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      {info.node_name} ({info.subtype_code})
+                    </a>
+                  </>
+                ))}
             </>
           )}
+        </div>
+        <div className={styles.descriptionTileColumn}>
+          {modelInfo.molecular_subtype_tree &&
+            modelInfo.molecular_subtype_tree.length > 0 && (
+              <>
+                <h4 className={styles.propertyGroupHeader}>
+                  Molecular Subtypes
+                </h4>
+                {modelInfo.molecular_subtype_tree
+                  .sort((a, b) => a.level - b.level)
+                  .map((info: SubtypeTreeInfo) => (
+                    <>
+                      <h6 className={styles.propertyHeader}>
+                        Level {info.level}
+                      </h6>
+                      <a
+                        className={styles.descriptionLinks}
+                        href={info.context_explorer_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {info.node_name} ({info.subtype_code})
+                      </a>
+                    </>
+                  ))}
+              </>
+            )}
           {modelInfo.metadata.PrimaryOrMetastasis && (
             <>
               <h6 className={styles.propertyHeader}>Primary/Metastasis</h6>
@@ -80,8 +121,6 @@ const ModelTab = ({ modelInfo }: ModelTabProps) => {
               alt="cell line"
             />
           )}
-        </div>
-        <div className={styles.descriptionTileColumn}>
           {showDerivation && (
             <h4 className={styles.propertyGroupHeader}>Derivation</h4>
           )}

--- a/frontend/packages/portal-frontend/src/cellLine/models/types.ts
+++ b/frontend/packages/portal-frontend/src/cellLine/models/types.ts
@@ -5,6 +5,13 @@ export interface DatasetDataTypes {
   datasets: { display_name: string; download_url: string }[];
 }
 
+export interface SubtypeTreeInfo {
+  node_name: string;
+  subtype_code: string;
+  level: number;
+  context_explorer_url: string;
+}
+
 export type OncogenicAlteration = {
   gene: { name: string; url: string };
   alteration: string;
@@ -30,10 +37,11 @@ export interface ModelInfo {
   // cell_line_name: string;
   primary_metastasis: string;
   sample_collection_site: string;
+  lineage_tree: SubtypeTreeInfo[];
+  molecular_subtype_tree: SubtypeTreeInfo[];
   oncotree_lineage: string;
   oncotree_primary_disease: string;
   oncotree_subtype_and_code: string;
-  legacy_molecular_subtype: string;
   engineered_model: string;
   growth_pattern: string;
   tissue_origin: string;

--- a/portal-backend/depmap/cell_line/views.py
+++ b/portal-backend/depmap/cell_line/views.py
@@ -1,5 +1,8 @@
+from dataclasses import dataclass
+import dataclasses
 import json
 from typing import Any, Dict, List
+from depmap.context.models_new import SubtypeContext, TreeType
 from depmap.enums import DataTypeEnum, TabularEnum
 from depmap.oncokb_version.models import OncokbDatasetVersionDate
 from flask import (
@@ -123,6 +126,35 @@ def get_related_models(patient_id: str, model_id: str) -> List[Dict[str, str]]:
     return related_models_info
 
 
+@dataclass
+class SubtypeTreeInfo:
+    node_name: str
+    subtype_code: str
+    level: str
+    context_explorer_url: str
+
+
+def get_subtype_tree_info(tree_type: str, model_id: str) -> List[SubtypeTreeInfo]:
+    level_info = SubtypeContext.get_model_context_tree_levels(tree_type, model_id)
+
+    def create_subtype_level_dict(row):
+        return dataclasses.asdict(
+            SubtypeTreeInfo(
+                node_name=row["node_name"],
+                subtype_code=row["subtype_code"],
+                level=row["node_level"],
+                context_explorer_url=url_for(
+                    "context_explorer.view_context_explorer",
+                    context=row["subtype_code"],
+                ),
+            )
+        )
+
+    tree_info = list(level_info.apply(create_subtype_level_dict, axis=1))
+
+    return tree_info
+
+
 @blueprint.route("/description_tile/<model_id>")
 def get_cell_line_description_tile_data(model_id: str) -> dict:
     model = DepmapModel.get_by_model_id(model_id)
@@ -130,6 +162,13 @@ def get_cell_line_description_tile_data(model_id: str) -> dict:
     if model is None:
         abort(404)
     assert model is not None
+
+    lineage_tree = get_subtype_tree_info(
+        tree_type=TreeType.Lineage.value, model_id=model_id
+    )
+    molecular_subtype_tree = get_subtype_tree_info(
+        tree_type=TreeType.MolecularSubtype.value, model_id=model_id
+    )
 
     image = get_image_url(model.image_filename)
 
@@ -149,6 +188,8 @@ def get_cell_line_description_tile_data(model_id: str) -> dict:
 
     model_info = {
         "image": image,
+        "lineage_tree": lineage_tree,
+        "molecular_subtype_tree": molecular_subtype_tree,
         "oncotree_lineage": oncotree_lineage,
         "oncotree_primary_disease": oncotree_primary_disease,
         "oncotree_subtype_and_code": f"{model.oncotree_subtype} ({model.oncotree_code})"

--- a/portal-backend/depmap/context/models_new.py
+++ b/portal-backend/depmap/context/models_new.py
@@ -11,6 +11,7 @@ from depmap.database import (
 )
 
 import enum
+import pandas as pd
 from typing import Type
 from sqlalchemy import and_, or_
 from depmap.entity.models import Entity
@@ -399,6 +400,31 @@ class SubtypeContext(Model):
             for cell_line in context.depmap_model
         ]
         return list(set(cell_lines))
+
+    @staticmethod
+    def get_model_context_tree_levels(tree_type, model_id: str):
+        model_context_nodes = (
+            db.session.query(SubtypeContext)
+            .join(SubtypeNode, SubtypeNode.subtype_code == SubtypeContext.subtype_code)
+            .filter(SubtypeNode.tree_type == tree_type)
+            .join(DepmapModel, SubtypeContext.depmap_model)
+            .filter(DepmapModel.model_id == model_id)
+            .with_entities(
+                SubtypeNode.subtype_code,
+                SubtypeNode.level_0,
+                SubtypeNode.level_1,
+                SubtypeNode.level_2,
+                SubtypeNode.level_3,
+                SubtypeNode.level_4,
+                SubtypeNode.level_5,
+                SubtypeNode.node_level,
+                SubtypeNode.node_name,
+            )
+        )
+
+        df = pd.DataFrame(model_context_nodes)
+
+        return df
 
 
 class SubtypeContextEntity(Entity):

--- a/portal-backend/depmap/tile/views.py
+++ b/portal-backend/depmap/tile/views.py
@@ -137,42 +137,6 @@ def render_cell_line_tile(tile_name: str, cell_line: DepmapModel):
     return rendered_tile
 
 
-def get_cell_line_description_html(model: DepmapModel):
-    oncotree_primary_disease = (
-        model.oncotree_primary_disease if model.oncotree_primary_disease else None
-    )
-    oncotree_subtype = model.oncotree_subtype if model.oncotree_subtype else None
-    primary_or_metastasis = model.primary_or_metastasis
-    source_type = model.source_type
-    sex = model.sex
-    image = get_image_url(model.image_filename)
-
-    if model.lineage_is_unknown():
-        lineage = []
-    else:
-        lineages = sorted(model.cell_line.lineage.all(), key=lambda x: x.level)
-        lineage = [
-            {
-                "display_name": lineage.display_name,
-                "url": url_for("context.view_context", context_name=lineage.name)
-                if lineage.level < 5
-                else None,  # NOTE: We cannot provide context link for lineage levels 5-6 since context matrix is only built from lineage levels 1-4. Temporary until we are able to include these lineage levels to our context matrix
-            }
-            for lineage in lineages
-        ]
-
-    return render_template(
-        "tiles/cell_line_description.html",
-        oncotree_primary_disease=oncotree_primary_disease,
-        oncotree_subtype=oncotree_subtype,
-        lineage=lineage,
-        primary_or_metastasis=primary_or_metastasis,
-        source_type=source_type,
-        sex=sex,
-        image=image,
-    )
-
-
 def get_cell_line_metmap_html(cell_line: DepmapModel):
     metmap_models = MetMap500.get_all_by_depmap_id(cell_line.model_id)
     metmap_data = [model.serialize for model in metmap_models]


### PR DESCRIPTION
These changes update the cell line page description tile to include every level of the new SubtypeTree. Each level links out to the appropriate page of Context Explorer V2. 

I kept the annotations from the Model file. Barbara and Alison had asked me to keep these in the Context Explorer data availability table, so I figured it's still useful to have here, but @pgm let me know if I should just remove them instead.

I had to rearrange the columns to fit everything cleanly. Now the tile looks like this (see action screenshot in Asana: https://app.asana.com/1/9513920295503/project/1165651979405609/task/1209731092974268):

### COLUMN 1:

**Annotations**

Oncotree Subtype and Code
oncotree_subtype

Oncotree Primary Disease
oncotree_primary_disease

Oncotree Lineage
oncotree_lineage

**Lineage Contexts**

Level 0
level_0

Level 1
level_1

### COLUMN 2:
**Molecular Subtypes**

Level 0
level_0

Level 1
level_1

**Should a header go over these? What should it say?**
Primary/Metastasis
prim_metastasis

Collection Site
collection_site

Source
source

Catalog Number
catalog_number
