### PR TITLE
Fix problem where DepMapModel and CellLine do not match

### DIFF
--- a/portal-backend/depmap/cell_line/models_new.py
+++ b/portal-backend/depmap/cell_line/models_new.py
@@ -69,7 +69,9 @@ class DepmapModel(Model):
 
     __tablename__ = "depmap_model"
 
-    depmap_id = Column(String, ForeignKey("cell_line.depmap_id"))
+    depmap_id = Column(
+        String, ForeignKey("cell_line.depmap_id"), unique=True, nullable=False
+    )
     cell_line = relationship("CellLine", backref=__tablename__)
 
     model_id = Column(String, primary_key=True)

--- a/portal-backend/loader/depmap_model_loader.py
+++ b/portal-backend/loader/depmap_model_loader.py
@@ -57,7 +57,7 @@ def insert_cell_lines(df):
         if ccle_name in seen_ccle_names:
             ccle_name = None
             log_data_issue(
-                "CellLine",
+                "DepMapModel",
                 "Duplicate ccle_name. Nulling out ccle_name",
                 identifier=ccle_name,
                 id_type="ccle_name",

--- a/portal-backend/loader/depmap_model_loader.py
+++ b/portal-backend/loader/depmap_model_loader.py
@@ -57,8 +57,8 @@ def insert_cell_lines(df):
         if ccle_name in seen_ccle_names:
             ccle_name = None
             log_data_issue(
-                "DepmapModel",
-                "Duplicate ccle_name",
+                "CellLine",
+                "Duplicate ccle_name. Nulling out ccle_name",
                 identifier=ccle_name,
                 id_type="ccle_name",
             )

--- a/portal-backend/tests/utilities/df_test_utils.py
+++ b/portal-backend/tests/utilities/df_test_utils.py
@@ -52,10 +52,12 @@ def load_sample_cell_lines():
     models = pd.read_csv(csv_path)
 
     for rec in models.to_records():
-        cell_line = CellLine(
-            cell_line_display_name=rec["CellLineName"], depmap_id=rec["ModelID"],
-        )
+        if CellLine.get_by_depmap_id(rec["ModelID"], must=False) is None:
+            cell_line = CellLine(
+                cell_line_display_name=rec["CellLineName"], depmap_id=rec["ModelID"],
+            )
 
-        db.session.add(cell_line)
+            db.session.add(cell_line)
+    db.session.flush()
 
     load_depmap_model_metadata(csv_path,)

--- a/portal-backend/tests/utilities/df_test_utils.py
+++ b/portal-backend/tests/utilities/df_test_utils.py
@@ -38,8 +38,24 @@ def test_dfs_equal_ignoring_column_order():
 def load_sample_cell_lines():
     from flask import current_app
     import os
+    from depmap.database import db
+    from depmap.cell_line.models import CellLine
 
     loader_data_dir = current_app.config["LOADER_DATA_DIR"]
-    load_depmap_model_metadata(
-        os.path.join(loader_data_dir, "cell_line/models_metadata.csv"),
-    )
+
+    # DepMapModels have a fk to CellLine and are enforced to be 1:1. This means
+    # that we need to populate some CellLine records in order for load_depmap_model_metadata to
+    # be called. We'll do this manually without filling out all values to keep things simple
+    # this is just for setting up data for testes
+    csv_path = os.path.join(loader_data_dir, "cell_line/models_metadata.csv")
+
+    models = pd.read_csv(csv_path)
+
+    for rec in models.to_records():
+        cell_line = CellLine(
+            cell_line_display_name=rec["CellLineName"], depmap_id=rec["ModelID"],
+        )
+
+        db.session.add(cell_line)
+
+    load_depmap_model_metadata(csv_path,)


### PR DESCRIPTION

We have an assumption that there is 1:1 records between CellLine and DepMapModel. Ideally, we would refactor things to eliminate the CellLine table and only use DepMapModel but that's an extensive change. For the time being, addressed this by adding constraints and an assert which will enforce the 1:1 relationship.