### PR TITLE
Wide table selection prop

### DIFF
--- a/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
+++ b/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
@@ -166,7 +166,7 @@ const ReactTableV7 = React.forwardRef(
           let newSelections: Set<any>;
           if (singleSelectionMode) {
             // We should always be getting the first selected label here since we expect selectedLabels size to be 1 in single selection mode
-            const label = [selectedLabels][0];
+            const label = [...selectedLabels][0];
             if (!prevSelections.has(label)) {
               newSelections = new Set([label]);
             } else {

--- a/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
+++ b/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
@@ -164,17 +164,23 @@ const ReactTableV7 = React.forwardRef(
       if (selectedLabels && selectedLabels.size > 0) {
         setSelections((prevSelections) => {
           const newSelections = new Set(prevSelections);
-          if (!newSelections.has([...selectedLabels][0])) {
+          if (
+            singleSelectionMode &&
+            !newSelections.has([...selectedLabels][0])
+          ) {
             newSelections.clear();
             newSelections.add([...selectedLabels][0]);
+          } else {
+            selectedLabels.forEach((selectedLabel) =>
+              newSelections.add(selectedLabel)
+            );
           }
-
           return newSelections;
         });
       } else {
         setSelections(() => new Set());
       }
-    }, [selectedLabels, idProp]);
+    }, [selectedLabels, idProp, singleSelectionMode]);
 
     const headersRef = useRef<HTMLDivElement | null>(null);
     const bodyRef = useRef<HTMLDivElement | null>(null);

--- a/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
+++ b/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
@@ -166,7 +166,7 @@ const ReactTableV7 = React.forwardRef(
           let newSelections: Set<any>;
           if (singleSelectionMode) {
             // We should always be getting the first selected label here since we expect selectedLabels size to be 1 in single selection mode
-            const label = [...selectedLabels][0];
+            const label = [selectedLabels][0];
             if (!prevSelections.has(label)) {
               newSelections = new Set([label]);
             } else {

--- a/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
+++ b/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
@@ -166,11 +166,13 @@ const ReactTableV7 = React.forwardRef(
           let newSelections: Set<any>;
           if (singleSelectionMode) {
             // We should always be getting the first selected label here since we expect selectedLabels size to be 1 in single selection mode
-            if (!prevSelections.has([...selectedLabels][0])) {
-              newSelections = new Set([...selectedLabels][0]);
+            const label = [...selectedLabels][0];
+            if (!prevSelections.has(label)) {
+              newSelections = new Set([label]);
+            } else {
+              // in the case of single selection mode we should expect prevSelections size to be 1. Effectively no change to selections here
+              newSelections = new Set(prevSelections);
             }
-            // in the case of single selection mode we should expect prevSelections size to be 1. Effectively no change to selections here
-            newSelections = new Set(prevSelections);
           } else {
             newSelections = new Set(selectedLabels);
           }

--- a/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
+++ b/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
@@ -163,7 +163,7 @@ const ReactTableV7 = React.forwardRef(
     useEffect(() => {
       if (selectedLabels && selectedLabels.size > 0) {
         setSelections((prevSelections) => {
-          const newSelections = new Set(prevSelections);
+          let newSelections = new Set(prevSelections);
           if (
             singleSelectionMode &&
             !newSelections.has([...selectedLabels][0])
@@ -171,9 +171,7 @@ const ReactTableV7 = React.forwardRef(
             newSelections.clear();
             newSelections.add([...selectedLabels][0]);
           } else {
-            selectedLabels.forEach((selectedLabel) =>
-              newSelections.add(selectedLabel)
-            );
+            newSelections = new Set(selectedLabels);
           }
           return newSelections;
         });

--- a/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
+++ b/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
@@ -163,13 +163,14 @@ const ReactTableV7 = React.forwardRef(
     useEffect(() => {
       if (selectedLabels && selectedLabels.size > 0) {
         setSelections((prevSelections) => {
-          let newSelections = new Set(prevSelections);
-          if (
-            singleSelectionMode &&
-            !newSelections.has([...selectedLabels][0])
-          ) {
-            newSelections.clear();
-            newSelections.add([...selectedLabels][0]);
+          let newSelections: Set<any>;
+          if (singleSelectionMode) {
+            // We should always be getting the first selected label here since we expect selectedLabels size to be 1 in single selection mode
+            if (!prevSelections.has([...selectedLabels][0])) {
+              newSelections = new Set([...selectedLabels][0]);
+            }
+            // in the case of single selection mode we should expect prevSelections size to be 1. Effectively no change to selections here
+            newSelections = new Set(prevSelections);
           } else {
             newSelections = new Set(selectedLabels);
           }


### PR DESCRIPTION
Making this change to the WideTable component to support my Correlation Analysis changes. I believe that this change to how the prop `selectedLabels` is used in `ReactTableV7` would ultimately affect all components that use the `WideTable` prop `selectedTableLabels` since its value is passed into `selectedLabels`.   My understanding is that `selectedTableLabels` is used for a more fine-grained control over what gets selected in the table. I'm not too familiar with how this prop works/interacts with other components that use it. So far it appears it is mainly used in conjunction with the `WideTable` prop `singleSelectionMode` EXCEPT for `CellignerPage` which I am unsure how my change would affect its current selection behavior so I would definitely like a second set of eyes to make sure it works as expected.

These are the other components that use the `selectedTableLabels` prop (which I don't think my change should affect its current selection behavior):
- CompoundDashboardTable.tsx
- ContextAnalysisTable.tsx