### PR TITLE
Fix celligner lasso bug

### DIFF
--- a/frontend/packages/portal-frontend/src/celligner/components/CellignerGraph.tsx
+++ b/frontend/packages/portal-frontend/src/celligner/components/CellignerGraph.tsx
@@ -90,8 +90,6 @@ export default class CellignerGraph extends React.Component<Props, State> {
       annotatedPoints,
       selectedPoints,
       colorByCategory,
-      lassoOrBoxSelectedPoints,
-      sidePanelSelectedPoints,
       handleResetContextPtSelection,
       handleSelectingContextPts,
       handleUnselectTableRows,
@@ -111,9 +109,7 @@ export default class CellignerGraph extends React.Component<Props, State> {
       pointSize.tumor,
       handleUnselectTableRows,
       handleSelectingContextPts,
-      handleResetContextPtSelection,
-      lassoOrBoxSelectedPoints,
-      sidePanelSelectedPoints
+      handleResetContextPtSelection
     );
 
     this.plotElement!.on("plotly_relayout", this.onPlotRelayout);

--- a/frontend/packages/portal-frontend/src/celligner/components/CellignerGraph.tsx
+++ b/frontend/packages/portal-frontend/src/celligner/components/CellignerGraph.tsx
@@ -36,7 +36,6 @@ interface Props {
   lassoOrBoxSelectedPoints: Set<number>;
   sidePanelSelectedPoints: Set<number>;
   handleUnselectTableRows: () => void;
-  handleResetContextPtSelection: () => void;
   handleSelectingContextPts: (pointIndexes: number[]) => void;
   handleDeselectContextPts: () => void;
 }
@@ -90,7 +89,6 @@ export default class CellignerGraph extends React.Component<Props, State> {
       annotatedPoints,
       selectedPoints,
       colorByCategory,
-      handleResetContextPtSelection,
       handleSelectingContextPts,
       handleUnselectTableRows,
     } = this.props;
@@ -108,8 +106,7 @@ export default class CellignerGraph extends React.Component<Props, State> {
       pointSize.CL,
       pointSize.tumor,
       handleUnselectTableRows,
-      handleSelectingContextPts,
-      handleResetContextPtSelection
+      handleSelectingContextPts
     );
 
     this.plotElement!.on("plotly_relayout", this.onPlotRelayout);

--- a/frontend/packages/portal-frontend/src/celligner/components/CellignerGraph.tsx
+++ b/frontend/packages/portal-frontend/src/celligner/components/CellignerGraph.tsx
@@ -269,10 +269,11 @@ export default class CellignerGraph extends React.Component<Props, State> {
       (_, i) => tumorLegendPointVisibilty[i] && colorLegendPointVisibilty[i]
     );
 
-    const selectedPtsForContext = new Set([
-      ...lassoOrBoxSelectedPoints,
+    const intersectionOfSelectionMethods = [
       ...sidePanelSelectedPoints,
-    ]);
+    ].filter((value) => [...lassoOrBoxSelectedPoints].includes(value));
+
+    const selectedPtsForContext = new Set([...intersectionOfSelectionMethods]);
 
     const selectedModelIds = alignments.sampleId.filter(
       (_, index) =>

--- a/frontend/packages/portal-frontend/src/celligner/components/CellignerPage.tsx
+++ b/frontend/packages/portal-frontend/src/celligner/components/CellignerPage.tsx
@@ -223,6 +223,7 @@ export default class CellignerPage extends React.Component<Props, State> {
 
     const selectedPoints: Array<number> = [];
     const filteredSelectedPoints: Array<number> = [];
+
     alignmentsArr.lineage.forEach((lineage, i) => {
       if (lineage === selectedPrimarySite) {
         if (lassoOrBoxSelectedPts.size === 0 || lassoOrBoxSelectedPts.has(i)) {
@@ -237,14 +238,16 @@ export default class CellignerPage extends React.Component<Props, State> {
       }
     });
 
+    const newSidePanelPoints =
+      filteredSelectedPoints.length < alignmentsArr.lineage.length
+        ? new Set(filteredSelectedPoints)
+        : new Set([]);
+
     this.setState(
       {
         selectedPrimarySite,
         selectedPoints,
-        sidePanelSelectedPts:
-          filteredSelectedPoints.length < alignmentsArr.lineage.length
-            ? new Set(filteredSelectedPoints)
-            : new Set([]),
+        sidePanelSelectedPts: newSidePanelPoints,
         cellLineDistances: null,
         colorByCategory: selectedPrimarySite ? "subtype" : "lineage",
       },
@@ -294,6 +297,7 @@ export default class CellignerPage extends React.Component<Props, State> {
     const cellLineIndex = alignmentsArr.sampleId.findIndex(
       (sampleId) => sampleId === selectedSampleId
     );
+    console.log("handleCellLineSelected");
     this.dapi
       .getCellignerDistancesToCellLine(selectedSampleId, kNeighbors)
       .then((e) => {
@@ -369,6 +373,11 @@ export default class CellignerPage extends React.Component<Props, State> {
     const handleResetContextPtSelection = () => {
       this.setState({
         lassoOrBoxSelectedPts: new Set<number>([]),
+        sidePanelSelectedPts: getValidSelectedPoints(
+          new Set<number>([]),
+          sidePanelSelectedPts,
+          selectedPoints
+        ),
       });
     };
 
@@ -395,12 +404,22 @@ export default class CellignerPage extends React.Component<Props, State> {
 
       return this.setState({
         lassoOrBoxSelectedPts: out,
+        sidePanelSelectedPts: getValidSelectedPoints(
+          out,
+          sidePanelSelectedPts,
+          selectedPoints
+        ),
       });
     };
 
     const handleDeselectLassoOrBoxPts = () => {
       this.setState({
         lassoOrBoxSelectedPts: new Set([]),
+        sidePanelSelectedPts: getValidSelectedPoints(
+          new Set([]),
+          sidePanelSelectedPts,
+          selectedPoints
+        ),
       });
     };
 
@@ -608,13 +627,6 @@ export default class CellignerPage extends React.Component<Props, State> {
               columns={tumorsForCellLinesColumns}
               sorted={[{ id: "distance", desc: true }]}
               onChangeSelections={handleChangeCellLineTableSelections}
-              selectedTableLabels={
-                new Set(
-                  [...annotatedPoints].map(
-                    (i: number) => alignmentsArr.displayName[i]
-                  )
-                )
-              }
               allowDownloadFromTableData
               hideSelectAllCheckbox
             />

--- a/frontend/packages/portal-frontend/src/celligner/utilities/plot.ts
+++ b/frontend/packages/portal-frontend/src/celligner/utilities/plot.ts
@@ -320,8 +320,7 @@ export function buildPlot(
   cellLinePointSize: number,
   tumorPointSize: number,
   unselectTableRows: () => void = () => {},
-  onSelected: (pointIndexes: number[]) => void = () => {},
-  onClickResetSelection: () => void = () => {}
+  onSelected: (pointIndexes: number[]) => void = () => {}
 ) {
   const plotlyData: Array<Partial<Plotly.ScatterData>> = [
     {
@@ -449,10 +448,6 @@ export function buildPlot(
     const pointIndexes = e.points.map((point) => point.pointIndex);
 
     onSelected(pointIndexes);
-  });
-
-  on("plotly_deselect", () => {
-    onClickResetSelection();
   });
 
   // WORKAROUND: Double-click is supposed to reset the zoom but it only works

--- a/frontend/packages/portal-frontend/src/celligner/utilities/plot.ts
+++ b/frontend/packages/portal-frontend/src/celligner/utilities/plot.ts
@@ -321,9 +321,7 @@ export function buildPlot(
   tumorPointSize: number,
   unselectTableRows: () => void = () => {},
   onSelected: (pointIndexes: number[]) => void = () => {},
-  onClickResetSelection: () => void = () => {},
-  lassoOrBoxSelectedPoints: Set<number>,
-  sidePanelSelectedPoints: Set<number>
+  onClickResetSelection: () => void = () => {}
 ) {
   const plotlyData: Array<Partial<Plotly.ScatterData>> = [
     {
@@ -410,10 +408,7 @@ export function buildPlot(
   const zoom = (val: "in" | "out" | "reset") => {
     getButton("zoom", val).click();
 
-    // This redraw fixes a very strange bug where setting the drag mode to
-    // select (or lasso) with a filter also applied causes all of the points
-    // to disappear.
-    Plotly.redraw(plotElement);
+    Plotly.relayout(plotElement, {});
   };
 
   // Add a few non-standard methods to the plot for convenience.
@@ -464,14 +459,6 @@ export function buildPlot(
   // actually intermittently so we'll do it ourselves.
   on("plotly_doubleclick", () => {
     plotElement.resetZoom();
-  });
-
-  // WORKAROUND: For some reason, autosize only works
-  // with width so we'll calculate the height as well.
-  on("plotly_autosize", () => {
-    setTimeout(() => {
-      Plotly.redraw(plotElement);
-    });
   });
 
   // https://github.com/plotly/plotly.js/blob/55dda47/src/lib/prepare_regl.js


### PR DESCRIPTION
These changes fix the bug [Celligner: lasso selection adds unexpected models when viewing lineage subtypes](https://app.asana.com/1/9513920295503/project/1165651979405609/task/1208933396588256).

Previously, the side panel selection and lasso/box selection were treated as additive. The changes will now get the intersection of the two selection methods, and also allow for undoing 1 form of selection at a time. For example, if the user selects Bone, all bone points will be selected. If the user then lassos a specific section of the plot, all bone models within that section will be selection. If the user clicks the "x" on the lineage dropdown selector, all points within the lasso will then be selected.