### PR TITLE
Fix context explorer heatmap sorting bug

### DIFF
--- a/frontend/packages/portal-frontend/src/contextExplorer/utils.ts
+++ b/frontend/packages/portal-frontend/src/contextExplorer/utils.ts
@@ -445,6 +445,17 @@ function mergeDataAvailability(
     (item) => item[1]
   );
 
+  const orderedModelIds = allContextDatasetDataAvail.all_depmap_ids.filter(
+    (indexedModel) => selectedModelIds.includes(indexedModel[1])
+  );
+  const indexedOrderedModelIds: [
+    number,
+    string
+  ][] = orderedModelIds.map((modelId: [number, string], index: number) => [
+    index,
+    modelId[1],
+  ]);
+
   const vals: number[][] = [];
   const dataTypes: string[] = [];
   allContextDatasetDataAvail.values.forEach((row: number[], index: number) => {
@@ -458,7 +469,7 @@ function mergeDataAvailability(
   const orderedDataTypes = [...dataTypes];
   const orderedVals = [...vals];
   const mergedDataAvail = {
-    all_depmap_ids: subtypeDataAvail.all_depmap_ids,
+    all_depmap_ids: indexedOrderedModelIds,
     data_types: [...orderedDataTypes, ...subtypeDataAvail.data_types].reverse(),
     values: [...orderedVals, ...subtypeDataAvail.values].reverse(),
   };

--- a/portal-backend/depmap/context_explorer/api.py
+++ b/portal-backend/depmap/context_explorer/api.py
@@ -326,7 +326,14 @@ def _get_overview_table_data(
         summary_df_by_model_id=summary_df_by_model_id,
     )
 
-    return overview_data
+    # This keeps the initial sort order of the overview table
+    # equal to the order of the overview heatmap columns
+    sort_order = summary_df.columns.tolist()
+    sorted_overview_data = sorted(
+        overview_data, key=lambda x: sort_order.index(x["model_id"])
+    )
+
+    return sorted_overview_data
 
 
 def get_context_explorer_lineage_trees_and_table_data(

--- a/portal-backend/tests/depmap/context_explorer/test_api.py
+++ b/portal-backend/tests/depmap/context_explorer/test_api.py
@@ -203,6 +203,11 @@ def test_get_context_summary(populated_db):
             "lineage": "bone",
             "primary_disease": "Ewing Sarcoma",
         } in context_summary["table"]
+        table_model_ids = [record["model_id"] for record in context_summary["table"]]
+        overview_graph_model_ids = [
+            model_id for _, model_id in context_summary["summary"]["all_depmap_ids"]
+        ]
+        assert table_model_ids == overview_graph_model_ids
 
         r = c.get(
             url_for(
@@ -398,6 +403,12 @@ def test_get_context_summary(populated_db):
             "lineage": "lung",
             "primary_disease": "Non-Small Cell Lung Cancer",
         } in context_summary["table"]
+
+        table_model_ids = [record["model_id"] for record in context_summary["table"]]
+        overview_graph_model_ids = [
+            model_id for _, model_id in context_summary["summary"]["all_depmap_ids"]
+        ]
+        assert table_model_ids == overview_graph_model_ids
 
 
 def test_unknown_context_analysis_data(populated_db):


### PR DESCRIPTION
Fixed Context Explorer heatmap bug. On the overview page, if the user selected a row in the heatmap, the table was filtered to the incorrect rows. These changes add sorting logic to keep track of and maintain the order of the original set of models loaded into the overview graph.