### PR TITLE
Fix Wide Table sorting bug 

### DIFF
--- a/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
+++ b/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
@@ -129,6 +129,7 @@ const ReactTableV7 = React.forwardRef(
         columns,
         data,
         defaultColumn,
+        autoResetSortBy: false,
         initialState: {
           // https://github.com/TanStack/table/blob/v7/docs/src/pages/docs/api/useSortBy.md#table-options
           sortBy: initialSortBy,


### PR DESCRIPTION
This fixes a bug with the interaction between WideTable sorting and row selection. To reproduce:

1. Use the WideTable headers to sort by a specific column.
2. Select a row in the table using that row's checkbox.
3. Notice the sorting has now been reset.

@GoldenLA noticed this bug in Celligner, but it affects everywhere WideTable is used.

