### PR TITLE
improvements to dose/viability heatmap prototype

### DIFF
--- a/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
+++ b/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
@@ -116,6 +116,25 @@ const ReactTableV7 = React.forwardRef(
       [idProp, selections, onChangeSelections]
     );
 
+    const modifiedColumns = useMemo(() => {
+      return columns.map((column) => {
+        const { accessor, ...rest } = column;
+
+        return {
+          ...rest,
+          // WORKAROUND: WideTable wants `accessor` to always be a string but
+          // react-table treats an `accessor` string that has a dot in a
+          // special way. For our purposes that only causes bugs. Below  we
+          // redefine `accessor` as a basic function without that special
+          // behavior so that our keys can contain dots. See this issue for
+          // more details:
+          // https://github.com/TanStack/table/issues/1671
+          id: accessor as string,
+          accessor: (d: Record<string, any>) => d[accessor as string],
+        };
+      });
+    }, [columns]);
+
     const {
       getTableProps,
       getTableBodyProps,
@@ -126,7 +145,7 @@ const ReactTableV7 = React.forwardRef(
       ...rest
     } = useTable(
       {
-        columns,
+        columns: modifiedColumns,
         data,
         defaultColumn,
         autoResetSortBy: false,

--- a/frontend/packages/portal-frontend/src/doseViabilityPrototype/components/DoseViabilityPrototypePage.tsx
+++ b/frontend/packages/portal-frontend/src/doseViabilityPrototype/components/DoseViabilityPrototypePage.tsx
@@ -3,26 +3,46 @@ import { Spinner } from "@depmap/common-components";
 import WideTable from "@depmap/wide-table";
 import PrototypeBrushableHeatmap from "src/doseViabilityPrototype/components/PrototypeBrushableHeatmap";
 import useData from "src/doseViabilityPrototype/hooks/useData";
+import styles from "src/doseViabilityPrototype/styles/DoseViabilityPrototypePage.scss";
 
 function DoseViabilityPrototypePage() {
   const compoundName = "ETOPOSIDE";
+  const compoundNameFormatted = `${compoundName[0].toUpperCase()}${compoundName
+    .slice(1)
+    .toLowerCase()}`;
 
-  const { heatmapFormattedData, tableFormattedData, isLoading } = useData(
-    compoundName
-  );
+  const {
+    heatmapFormattedData,
+    tableFormattedData,
+    doseColumnNames,
+    isLoading,
+  } = useData(compoundName);
 
-  const [selectedCells, setSelectedCells] = useState<Set<string>>(new Set());
+  const [selectedModels, setSelectedModels] = useState(new Set<string>());
+  const selectedColumns = useMemo(() => {
+    const out = new Set<number>();
+
+    heatmapFormattedData?.modelIds.forEach((id, index) => {
+      if (selectedModels.has(id)) {
+        out.add(index);
+      }
+    });
+
+    return out;
+  }, [selectedModels, heatmapFormattedData]);
 
   const tableConfig = useMemo(() => {
     return {
       columns: [
-        { accessor: "dose" },
-        { accessor: "model" },
-        { accessor: "viability" },
+        { accessor: "Cell Line" },
+        ...doseColumnNames.map((name) => ({
+          id: name,
+          accessor: name,
+        })),
       ],
-      sorted: [{ id: "dose", desc: false }],
+      sorted: [{ id: "Cell Line", desc: false }],
     };
-  }, []);
+  }, [doseColumnNames]);
 
   if (isLoading || !tableFormattedData || !heatmapFormattedData) {
     return <Spinner />;
@@ -30,34 +50,33 @@ function DoseViabilityPrototypePage() {
 
   return (
     <div>
-      <div style={{ padding: "30px 30px 0 26px", marginBottom: -40 }}>
+      <div className={styles.heatmapContainer}>
         <PrototypeBrushableHeatmap
           data={heatmapFormattedData}
           xAxisTitle="Cell Lines"
-          yAxisTitle="Dose (μM)"
+          yAxisTitle={`${compoundNameFormatted} Dose (μM)`}
           legendTitle="Viability"
-          selectedCells={selectedCells}
-          onClickColumn={(x: number, shiftKey: boolean) => {
-            const columnCells = heatmapFormattedData.y.map(
-              (_, y: number) => `${x},${y}`
-            );
+          hovertemplate={[
+            "Cell line: %{x}",
+            "Dose: %{y} µM",
+            "Viability: %{z}",
+            "<extra></extra>",
+          ].join("<br>")}
+          selectedColumns={selectedColumns}
+          onClearSelection={() => setSelectedModels(new Set())}
+          onSelectColumnRange={(
+            start: number,
+            end: number,
+            shiftKey: boolean
+          ) => {
+            setSelectedModels((prev) => {
+              const next: Set<string> = shiftKey ? new Set(prev) : new Set();
 
-            setSelectedCells((prev) => {
-              if (shiftKey) {
-                const next = new Set(prev);
-
-                columnCells.forEach((cell) => {
-                  if (prev.has(columnCells[0])) {
-                    next.delete(cell);
-                  } else {
-                    next.add(cell);
-                  }
-                });
-
-                return next;
+              for (let i = start; i <= end; i += 1) {
+                next.add(heatmapFormattedData.modelIds[i]);
               }
 
-              return new Set(columnCells);
+              return next;
             });
           }}
         />

--- a/frontend/packages/portal-frontend/src/doseViabilityPrototype/components/PrototypeBrushableHeatmap/HeatmapBrush.tsx
+++ b/frontend/packages/portal-frontend/src/doseViabilityPrototype/components/PrototypeBrushableHeatmap/HeatmapBrush.tsx
@@ -18,12 +18,14 @@ function HeatmapBrush({
   onChangeRange,
 }: Props) {
   const height = 20;
-  const leftMargin = 90;
+  const leftMargin = 82;
   const handleSize = 8;
   const brushRef: React.ComponentProps<typeof Brush>["innerRef"] = useRef(null);
   const width = containerWidth ? containerWidth - leftMargin : 1000;
 
-  const xScale = scaleLinear().domain([-2, dataLength]).range([0, width]);
+  // Create a mapping of data indices to on screen pixels.
+  const xScale = scaleLinear().domain([0, dataLength]).range([0, width]);
+  // This is a dummy scale that just sets a fixed height.
   const yScale = scaleLinear().domain([0, height]).range([0, height]);
 
   return (
@@ -73,6 +75,9 @@ function HeatmapBrush({
 
                 onChangeRange([start, end]);
               } else if (brushRef.current) {
+                // WORKAROUND: If you click outside the brush, `range` is null
+                // and the brush just disappears! Instead of that weird
+                // behavior, we'll reset it to its initial range.
                 brushRef.current.updateBrush((prev) => {
                   return {
                     ...prev,

--- a/frontend/packages/portal-frontend/src/doseViabilityPrototype/components/PrototypeBrushableHeatmap/customizeDragLayer.ts
+++ b/frontend/packages/portal-frontend/src/doseViabilityPrototype/components/PrototypeBrushableHeatmap/customizeDragLayer.ts
@@ -1,0 +1,179 @@
+import type { PlotlyHTMLElement } from "plotly.js";
+
+interface Props {
+  plot: PlotlyHTMLElement;
+  onMouseOut: () => void;
+  onChangeInProgressSelection: (start: number, end: number) => void;
+  onSelectColumnRange: (start: number, end: number, shiftKey: boolean) => void;
+  onClearSelection: () => void;
+}
+
+// Hide all of Plotly's default zoom/pan controls that show up on hover
+// (since we have our own custom zoom controls).
+const hideStandardPlotlyZoomHandles = (plot: PlotlyHTMLElement) => {
+  const dragLayer = plot.querySelector(".draglayer") as SVGGElement;
+
+  const rects = dragLayer.querySelectorAll(
+    ".drag:not(.nsewdrag)"
+  ) as NodeListOf<SVGRectElement>;
+
+  [...rects].forEach((el) => {
+    el.style.setProperty("display", "none");
+  });
+};
+
+const addMouseListeners = ({
+  plot,
+  onMouseOut,
+  onChangeInProgressSelection,
+  onSelectColumnRange,
+  onClearSelection,
+}: Props) => {
+  const dragLayer = plot.querySelector(".draglayer") as SVGGElement;
+  const zoomLayer = plot.querySelector(".zoomlayer") as SVGGElement;
+
+  dragLayer.addEventListener("mouseout", onMouseOut);
+
+  const createSelectionOutlinePath = (outlineClass: string) => {
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    const className = `select-outline ${outlineClass} select-outline-xy`;
+    path.setAttribute("class", className);
+    path.setAttribute("fill-rule", "evenodd");
+    return path;
+  };
+
+  const createSelectionPath = (
+    x: number,
+    y: number,
+    width: number,
+    height: number
+  ): string => {
+    return `M${x},${y}L${x},${y + height}L${x + width},${y + height}L${
+      x + width
+    },${y}Z`;
+  };
+
+  let isSelecting = false;
+  let hasStartedDragging = false;
+  let startX = 0;
+  let startY = 0;
+  let selectionBoxes: SVGPathElement[] = [];
+
+  function getMousePosition(event: MouseEvent) {
+    const rect = plot.getBoundingClientRect();
+
+    return {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top,
+    };
+  }
+
+  function getRangeFromMousePosition(pos: { x: number }) {
+    const x1 = Math.min(startX, pos.x);
+    const x2 = x1 + Math.abs(pos.x - startX);
+
+    const dragLayerOffset =
+      dragLayer.getBoundingClientRect().left -
+      plot.getBoundingClientRect().left;
+
+    const firstCol = Math.round(
+      (plot as any)._fullLayout.xaxis.p2l(x1 - dragLayerOffset)
+    );
+
+    const lastCol = Math.round(
+      (plot as any)._fullLayout.xaxis.p2l(x2 - dragLayerOffset)
+    );
+
+    return {
+      firstCol: Math.max(0, firstCol),
+      lastCol: Math.min((plot as any).data[0].x.length - 1, lastCol),
+    };
+  }
+
+  dragLayer.addEventListener("mousedown", (event) => {
+    if (event.button !== 0) return; // Only left mouse button
+
+    isSelecting = true;
+    hasStartedDragging = false;
+    const pos = getMousePosition(event);
+    startX = pos.x;
+    startY = pos.y;
+
+    selectionBoxes = [
+      zoomLayer.appendChild(createSelectionOutlinePath("select-outline-1")),
+      zoomLayer.appendChild(createSelectionOutlinePath("select-outline-2")),
+    ];
+
+    event.preventDefault();
+  });
+
+  document.addEventListener("mousemove", (event: MouseEvent) => {
+    if (!isSelecting || selectionBoxes.length === 0) return;
+
+    if (!event.shiftKey && !hasStartedDragging) {
+      onClearSelection();
+    }
+
+    hasStartedDragging = true;
+
+    const pos = getMousePosition(event);
+    const { firstCol, lastCol } = getRangeFromMousePosition(pos);
+    onChangeInProgressSelection(firstCol, lastCol);
+
+    const currentX = pos.x;
+    const currentY = pos.y;
+
+    // Calculate rectangle bounds
+    const x = Math.min(startX, currentX);
+    const y = Math.min(startY, currentY);
+    const width = Math.abs(currentX - startX);
+    const height = Math.abs(currentY - startY);
+
+    // Update selection boxes
+    selectionBoxes.forEach((path) => {
+      path.setAttribute("d", createSelectionPath(x, y, width, height));
+    });
+  });
+
+  document.addEventListener("mouseup", (event) => {
+    if (!isSelecting || selectionBoxes.length === 0) return;
+
+    const pos = getMousePosition(event);
+    const { firstCol, lastCol } = getRangeFromMousePosition(pos);
+    onSelectColumnRange(firstCol, lastCol, event.shiftKey);
+
+    const [box1, box2] = selectionBoxes;
+    selectionBoxes = [];
+    box1.parentElement?.removeChild(box1);
+    box2.parentElement?.removeChild(box2);
+
+    isSelecting = false;
+    hasStartedDragging = false;
+  });
+};
+
+function customizeDragLayer({
+  plot,
+  onMouseOut,
+  onSelectColumnRange,
+  onChangeInProgressSelection,
+  onClearSelection,
+}: Props) {
+  if ((plot as any).alreadyConfigured) {
+    return;
+  }
+
+  hideStandardPlotlyZoomHandles(plot);
+  addMouseListeners({
+    plot,
+    onMouseOut,
+    onChangeInProgressSelection,
+    onSelectColumnRange,
+    onClearSelection,
+  });
+
+  // eslint-disable-next-line
+  (plot as any).alreadyConfigured = true;
+}
+
+export default customizeDragLayer;

--- a/frontend/packages/portal-frontend/src/doseViabilityPrototype/components/PrototypeBrushableHeatmap/index.tsx
+++ b/frontend/packages/portal-frontend/src/doseViabilityPrototype/components/PrototypeBrushableHeatmap/index.tsx
@@ -9,18 +9,26 @@ import type {
 import PlotlyLoader from "src/plot/components/PlotlyLoader";
 import usePlotResizer from "src/doseViabilityPrototype/hooks/usePlotResizer";
 import HeatmapBrush from "src/doseViabilityPrototype/components/PrototypeBrushableHeatmap/HeatmapBrush";
+import customizeDragLayer from "src/doseViabilityPrototype/components/PrototypeBrushableHeatmap/customizeDragLayer";
+import { generateTickLabels } from "src/doseViabilityPrototype/components/PrototypeBrushableHeatmap/utils";
 
 interface Props {
   data: {
-    x: string[];
-    y: string[];
+    x: (string | number)[];
+    y: (string | number)[];
     z: (number | null)[][];
   };
   xAxisTitle: string;
   yAxisTitle: string;
   legendTitle: string;
-  selectedCells: Set<string>;
-  onClickColumn: (index: number, shiftKey: boolean) => void;
+  selectedColumns: Set<number>;
+  onSelectColumnRange: (start: number, end: number, shiftKey: boolean) => void;
+  onClearSelection: () => void;
+  hovertemplate?: string | string[];
+  // Optionally set a min/max for the color scale. If left undefined, these
+  // will default to the min and max of values contained in `data.z`
+  zmin?: number;
+  zmax?: number;
 }
 
 type PlotlyType = typeof import("plotly.js");
@@ -38,22 +46,46 @@ function PrototypeBrushableHeatmap({
   xAxisTitle,
   yAxisTitle,
   legendTitle,
-  selectedCells,
-  onClickColumn,
+  selectedColumns,
+  onSelectColumnRange,
+  onClearSelection,
+  hovertemplate = undefined,
+  zmin = undefined,
+  zmax = undefined,
   Plotly,
 }: Props & { Plotly: PlotlyType }) {
   const ref = useRef<PlotElement>(null);
   usePlotResizer(Plotly, ref);
 
   const initialRange: [number, number] = useMemo(() => {
-    return [-1, Math.min(100, data.x.length - 1)];
+    return [0, data.x.length - 1];
   }, [data]);
 
   const [selectedRange, setSelectedRange] = useState(initialRange);
   const [containerWidth, setContainerWidth] = useState(0);
+  const [hoveredColumns, setHoveredColumns] = useState<number[]>([]);
+
+  const pixelDistanceBetweenColumns = useMemo(() => {
+    if (ref.current) {
+      const dataToPiixels = (ref.current as any)._fullLayout.xaxis.l2p;
+      return dataToPiixels(1) - dataToPiixels(0);
+    }
+
+    return 0;
+    // eslint-disable-next-line
+  }, [selectedRange]);
+
+  const xAxisTickLabels = useMemo(() => {
+    return generateTickLabels(
+      data.x.map(String),
+      selectedColumns,
+      pixelDistanceBetweenColumns
+    );
+  }, [data.x, selectedColumns, pixelDistanceBetweenColumns]);
 
   useEffect(() => {
     const plot = ref.current as PlotElement;
+    const deltaRange = selectedRange[1] - selectedRange[0];
 
     const plotlyData: PlotlyData[] = [
       {
@@ -62,17 +94,25 @@ function PrototypeBrushableHeatmap({
         colorscale: "YlOrRd",
         xaxis: "x",
         yaxis: "y",
-        // Add some undocumented features (unfortunately these won't type check)
-        // https://github.com/plotly/plotly.js/blob/041c8dc/src/traces/heatmap/attributes.js
-        ...{ hoverongaps: false, xgap: 1, ygap: 1 },
+        zmin,
+        zmax,
+        hovertemplate,
+        // We only want there to be gaps between cells once the user has
+        // zoomed in a little. When the plot is fulled zoomed out, it should
+        // look like a smooth gradient with no gaps.
+        // While we could set a threshold where gaps suddenly appear, that
+        // would be a litt jarring. Instead we'll use some fancy math to
+        // gradually increase the gap size as a function of the zoom level.
+        xgap: 3 * (1 - deltaRange / data.x.length) ** 2,
+        ygap: 1 * (1 - deltaRange / data.x.length) ** 2,
 
         colorbar: {
-          x: -0.004,
+          x: -0.009,
           y: -0.3,
           len: 0.2,
           ypad: 0,
           xanchor: "left",
-          // More undocumented features
+          // These features are undocumented and won't type check properly.
           ...({
             orientation: "h",
             title: {
@@ -93,9 +133,8 @@ function PrototypeBrushableHeatmap({
 
       xaxis: {
         side: "top",
-        tickvals: data.x.map((val, i) =>
-          selectedCells.has(`${i},0`) ? val : ""
-        ),
+        tickvals: xAxisTickLabels.map((label, i) => (label ? data.x[i] : "")),
+        ticktext: xAxisTickLabels,
         title: xAxisTitle,
         range: selectedRange,
       },
@@ -110,55 +149,54 @@ function PrototypeBrushableHeatmap({
         },
       },
 
-      // We use `shapes` to draw the selected cells.
-      shapes: [...selectedCells]
-        .map((cellAsString) => {
-          const cell = cellAsString.split(",").map(Number);
-          const shouldDrawTop = !selectedCells.has(`${cell[0]},${cell[1] - 1}`);
-          const shouldDrawBottom = !selectedCells.has(
-            `${cell[0]},${cell[1] + 1}`
-          );
+      // We use `shapes` to draw the hovered and selected columns
+      shapes: [
+        // Outline
+        [...selectedColumns].map((colIndex) => ({
+          type: "path" as const,
+          line: { width: 2, color: "black" },
+          path: (() => {
+            const x0 = colIndex - 0.5;
+            const x1 = colIndex + 0.5;
+            const y0 = -0.5;
+            const y1 = data.y.length - 0.5;
+            const shouldDrawLeft = !selectedColumns.has(colIndex! - 1);
+            const shouldDrawRight = !selectedColumns.has(colIndex! + 1);
 
-          return [
-            // Outline
-            {
-              type: "path" as const,
-              line: { width: 2, color: "black" },
-              path: (() => {
-                const p1 = [0.5 + cell[0], 0.5 + cell[1]].join(" ");
-                const p2 = [-0.5 + cell[0], 0.5 + cell[1]].join(" ");
-                const p3 = [-0.5 + cell[0], -0.5 + cell[1]].join(" ");
-                const p4 = [0.5 + cell[0], -0.5 + cell[1]].join(" ");
+            const segments: string[] = [];
 
-                const segments: string[] = [];
+            if (shouldDrawLeft) {
+              segments.push(`M ${x0} ${y0}`);
+              segments.push(`L ${x0} ${y1}`);
+            }
 
-                if (shouldDrawBottom) {
-                  segments.push(`M ${p1} L ${p2}`);
-                }
+            segments.push(`M ${x0} ${y1}`);
+            segments.push(`L ${x1} ${y1}`);
+            segments.push(`M ${x1} ${y0}`);
+            segments.push(`L ${x0} ${y0}`);
 
-                segments.push(`M ${p2} L ${p3}`);
-                segments.push(`M ${p4} L ${p1}`);
+            if (shouldDrawRight) {
+              segments.push(`M ${x1} ${y1}`);
+              segments.push(`L ${x1} ${y0}`);
+            }
 
-                if (shouldDrawTop) {
-                  segments.push(`M ${p3} L ${p4}`);
-                }
+            return segments.join(" ");
+          })(),
+        })),
 
-                return segments.join(" ");
-              })(),
-            },
-            // Fill
-            {
-              type: "rect" as const,
-              x0: cell[0] - 0.5,
-              x1: cell[0] + 0.5,
-              y0: cell[1] - 0.5,
-              y1: cell[1] + 0.5,
-              line: { width: 0 },
-              fillcolor: "rgba(0, 0, 0, 0.1)",
-            },
-          ];
-        })
-        .flat(),
+        // Fill
+        [...new Set([...hoveredColumns, ...selectedColumns])].map(
+          (colIndex) => ({
+            type: "rect" as const,
+            x0: colIndex - 0.5,
+            x1: colIndex + 0.5,
+            y0: -0.5,
+            y1: data.y.length - 0.5,
+            line: { width: 0 },
+            fillcolor: "rgba(0, 0, 0, 0.15)",
+          })
+        ),
+      ].flat(),
     };
 
     const config: Partial<Config> = {
@@ -178,20 +216,28 @@ function PrototypeBrushableHeatmap({
       listeners.push([eventName, callback]);
     };
 
-    on("plotly_click", (e: any) => {
-      onClickColumn?.(e.points[0].pointIndex[1], e.event.shiftKey);
+    on("plotly_afterplot", () => {
+      setContainerWidth(plot.clientWidth);
+
+      customizeDragLayer({
+        plot,
+        onMouseOut: () => setHoveredColumns([]),
+        onChangeInProgressSelection: (start, end) => {
+          const range = [];
+          for (let i = start; i <= end; i += 1) {
+            range.push(i);
+          }
+          setHoveredColumns(range);
+        },
+        onSelectColumnRange: (start, end, shiftKey) => {
+          onSelectColumnRange(start, end, shiftKey);
+        },
+        onClearSelection,
+      });
     });
 
-    on("plotly_afterplot", () => {
-      const dragLayers = plot.querySelectorAll(
-        ".draglayer .drag:not(.nsewdrag)"
-      ) as NodeListOf<HTMLDivElement>;
-
-      [...dragLayers].forEach((el) => {
-        el?.style.setProperty("display", "none");
-      });
-
-      setContainerWidth(plot.clientWidth);
+    on("plotly_hover", (e: any) => {
+      setHoveredColumns([e.points[0].pointIndex[1]]);
     });
 
     return () => {
@@ -205,8 +251,14 @@ function PrototypeBrushableHeatmap({
     yAxisTitle,
     legendTitle,
     selectedRange,
-    selectedCells,
-    onClickColumn,
+    selectedColumns,
+    hoveredColumns,
+    onSelectColumnRange,
+    onClearSelection,
+    hovertemplate,
+    zmin,
+    zmax,
+    xAxisTickLabels,
     Plotly,
   ]);
 

--- a/frontend/packages/portal-frontend/src/doseViabilityPrototype/components/PrototypeBrushableHeatmap/utils.ts
+++ b/frontend/packages/portal-frontend/src/doseViabilityPrototype/components/PrototypeBrushableHeatmap/utils.ts
@@ -1,0 +1,47 @@
+export function generateTickLabels(
+  columnNames: string[],
+  selectedColumnIndices: Set<number>,
+  pixelDistanceBetweenColumns: number
+): string[] {
+  // Initialize output array with empty strings
+  const tickvals: string[] = new Array(columnNames.length).fill("");
+
+  if (selectedColumnIndices.size === 0) {
+    return tickvals;
+  }
+
+  // Convert Set to sorted array for easier processing
+  const sortedIndices = Array.from(selectedColumnIndices).sort((a, b) => a - b);
+
+  // Find contiguous subsets
+  const contiguousSubsets: number[][] = [];
+  let currentSubset: number[] = [sortedIndices[0]];
+
+  for (let i = 1; i < sortedIndices.length; i++) {
+    if (sortedIndices[i] === sortedIndices[i - 1] + 1) {
+      // Contiguous - add to current subset
+      currentSubset.push(sortedIndices[i]);
+    } else {
+      // Not contiguous - start new subset
+      contiguousSubsets.push(currentSubset);
+      currentSubset = [sortedIndices[i]];
+    }
+  }
+  // Don't forget the last subset
+  contiguousSubsets.push(currentSubset);
+
+  // For each subset, find middle index and place subset size there
+  contiguousSubsets.forEach((subset) => {
+    if (subset.length === 1 || pixelDistanceBetweenColumns > 20) {
+      subset.forEach((j) => {
+        tickvals[j] = columnNames[j];
+      });
+    } else {
+      const middleIndex = Math.floor((subset.length - 1) / 2);
+      const actualColumnIndex = subset[middleIndex];
+      tickvals[actualColumnIndex] = `(${subset.length.toString()})`;
+    }
+  });
+
+  return tickvals;
+}

--- a/frontend/packages/portal-frontend/src/doseViabilityPrototype/hooks/useData.ts
+++ b/frontend/packages/portal-frontend/src/doseViabilityPrototype/hooks/useData.ts
@@ -12,14 +12,16 @@ const fetchDimensionTypes = async () => {
   return response.json() as Promise<DimensionType[]>;
 };
 
-const fetchMetadata = async (feature_type_name: string) => {
+const fetchMetadata = async <T>(feature_type_name: string) => {
   const dimensionTypes = await fetchDimensionTypes();
 
   const dimType = dimensionTypes.find((t) => t.name === feature_type_name);
   const url = "../breadbox/datasets/tabular/" + dimType!.metadata_dataset_id;
 
   const response = await fetch(url, { method: "POST" });
-  return response.json();
+  const json = await response.json();
+
+  return json as T;
 };
 
 function useData(compoundName: string) {
@@ -32,6 +34,7 @@ function useData(compoundName: string) {
     tableFormattedData,
     setTableFormattedData,
   ] = useState<TableFormattedData | null>(null);
+  const [doseColumnNames, setDoseColumnNames] = useState<string[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
@@ -62,42 +65,105 @@ function useData(compoundName: string) {
           }
         );
 
-        const data: CompoundDoseViability = await response.json();
-        const metadata = await fetchMetadata("oncref_collapsed_metadata");
+        const viabilityAtDose: CompoundDoseViability = await response.json();
 
-        const tableData: TableFormattedData = [];
+        const oncrefMetadata = await fetchMetadata<{
+          Dose: Record<string, number>;
+          DoseUnit: Record<string, string>;
+        }>("oncref_collapsed_metadata");
 
-        Object.entries(data).forEach(([label, modelValues]) => {
+        const modelMetadata = await fetchMetadata<{
+          CellLineName: Record<string, string>;
+        }>("depmap_model");
+
+        const flatData: {
+          dose: number;
+          model: string;
+          viability: number;
+        }[] = [];
+        const tableLookup: Record<string, Record<string, number>> = {};
+
+        Object.entries(viabilityAtDose).forEach(([label, modelValues]) => {
           Object.entries(modelValues).forEach(([model, viability]) => {
             if (viability !== null) {
-              const dose = metadata.Dose[label];
-              tableData.push({ model, dose, viability });
+              const dose = oncrefMetadata.Dose[label];
+              const unit = oncrefMetadata.DoseUnit[label];
+              flatData.push({ model, dose, viability });
+
+              tableLookup[model] = tableLookup[model] || {};
+              tableLookup[model][`${dose} ${unit}`] = viability;
             }
           });
         });
 
-        const x = [...new Set(tableData.map((d) => d.model))].sort();
-        const y = [...new Set(tableData.map((d) => d.dose))]
-          .sort((a, b) => a - b)
-          .map(String);
-        const z = Array.from({ length: x.length }, () =>
-          Array(y.length).fill(null)
+        const meanViabilityByModel: Record<string, number> = {};
+        const tableData: TableFormattedData = [];
+
+        Object.entries(tableLookup).forEach(([depmapId, doseMap]) => {
+          tableData.push({
+            "Cell Line": modelMetadata.CellLineName[depmapId],
+            depmapId,
+            ...doseMap,
+          });
+
+          const values = Object.values(doseMap);
+          meanViabilityByModel[depmapId] =
+            values.reduce((sum, val) => sum + val, 0) / values.length;
+        });
+
+        const uniqueModels = [...new Set(flatData.map((d) => d.model))];
+        const uniqueDoses = [...new Set(flatData.map((d) => d.dose))].sort(
+          (a, b) => a - b
         );
 
-        const modelIndex = Object.fromEntries(x.map((m, i) => [m, i]));
-        const doseIndex = Object.fromEntries(y.map((d, i) => [d, i]));
+        const sortedModels = uniqueModels.sort(
+          (a, b) => meanViabilityByModel[a] - meanViabilityByModel[b]
+        );
 
-        for (let i = 0; i < tableData.length; i++) {
-          const dose = tableData[i].dose;
-          const model = tableData[i].model;
-          const viability = tableData[i].viability;
+        const zMatrix = Array.from({ length: uniqueDoses.length }, () =>
+          Array(sortedModels.length).fill(null)
+        ) as (number | null)[][];
+
+        const modelIndex = Object.fromEntries(
+          sortedModels.map((m, i) => [m, i])
+        );
+        const doseIndex = Object.fromEntries(uniqueDoses.map((d, i) => [d, i]));
+
+        flatData.forEach(({ dose, model, viability }) => {
           const row = doseIndex[dose];
           const col = modelIndex[model];
-          z[row][col] = viability;
-        }
+          zMatrix[row][col] = viability;
+        });
 
         setTableFormattedData(tableData);
-        setHeatmapFormattedData({ x, y, z });
+
+        setDoseColumnNames(
+          Object.keys(tableData[0])
+            .filter((key) => key !== "Cell Line" && key !== "depmapId")
+            .sort((a, b) => parseFloat(a) - parseFloat(b))
+        );
+
+        const seen = new Set<string>();
+
+        const cellLineNames = sortedModels.map((id) => {
+          let name = modelMetadata.CellLineName[id];
+
+          if (seen.has(name)) {
+            window.console.warn(`Warning: duplicate cell line name "${name}"!`);
+            name += ` (${id})`;
+          }
+
+          seen.add(name);
+          return name;
+        });
+
+        setHeatmapFormattedData({
+          modelIds: sortedModels,
+          x: cellLineNames,
+          y: uniqueDoses,
+          z: zMatrix,
+        });
+
         setIsLoading(false);
       } catch (e) {
         window.console.error(e);
@@ -105,7 +171,12 @@ function useData(compoundName: string) {
     })();
   }, [sharedApi, compoundName]);
 
-  return { isLoading, heatmapFormattedData, tableFormattedData };
+  return {
+    isLoading,
+    heatmapFormattedData,
+    doseColumnNames,
+    tableFormattedData,
+  };
 }
 
 export default useData;

--- a/frontend/packages/portal-frontend/src/doseViabilityPrototype/styles/DoseViabilityPrototypePage.scss
+++ b/frontend/packages/portal-frontend/src/doseViabilityPrototype/styles/DoseViabilityPrototypePage.scss
@@ -1,0 +1,4 @@
+.heatmapContainer {
+  padding: 30px 30px 0 26px;
+  min-height: 530px;
+}

--- a/frontend/packages/portal-frontend/src/doseViabilityPrototype/types.ts
+++ b/frontend/packages/portal-frontend/src/doseViabilityPrototype/types.ts
@@ -1,15 +1,29 @@
-type DrugDoseLabel = `${string} (${string}) @${number} uM`;
-type Viability = number;
-export type CompoundDoseViability = Record<DrugDoseLabel, Viability>;
+type PRCid = string;
+type ModelID = string;
+type CompoundName = string;
+type Viability = number | null;
+type CellLineName = string;
+type DoseWithUnits = `${number} uM`;
+type DoseWithoutUnits = number;
 
-export type TableFormattedData = {
-  dose: number;
-  model: string;
-  viability: number;
-}[];
+export type DrugDoseLabel = `${CompoundName} (${PRCid}) @${DoseWithUnits}`;
 
+export type CompoundDoseViability = Record<
+  DrugDoseLabel,
+  Record<ModelID, Viability>
+>;
+
+type TableRow = {
+  depmapId: string;
+  "Cell Line": CellLineName;
+} & {
+  [K in DoseWithUnits]: Viability;
+};
+
+export type TableFormattedData = TableRow[];
 export type HeatmapFormattedData = {
-  x: string[];
-  y: string[];
-  z: (number | null)[][];
+  modelIds: ModelID[];
+  x: CellLineName[];
+  y: DoseWithoutUnits[];
+  z: Viability[][];
 };


### PR DESCRIPTION
- Heatmap now displays cell line names (instead of DepMap IDs)
- Cell lines in heatmap are now sorted by mean viability
- No gaps displayed between columns when fully zoomed out
  - Results in a smooth gradient
- Table now has columns for each dose
- You can now click & drag to select multiple cell lines
- Added hover state to heatmap columns
- Improved info shown on hover
  - Now using readable labels instead of x, y, z