### PR TITLE
Added drc_datset_label to DoseResponseCurve

### DIFF
--- a/pipeline/reformat_repurposing_data.conseq
+++ b/pipeline/reformat_repurposing_data.conseq
@@ -44,6 +44,7 @@ rule reformat_curve_params_secondary_repurposing_data:
         taiga_token={"type": "config-file", "name": "taiga-token"}
     outputs: {
         "type": 'dose-response-curve-params',
+        "label": "repurposing_per_curve",
         "orig_dataset_id": "{{ inputs.data.dataset_id }}",
         "filename": {"$filename": "curves.csv"} },
         {"type": 'dep-matrix',

--- a/portal-backend/depmap/cli_commands/db_load_commands.py
+++ b/portal-backend/depmap/cli_commands/db_load_commands.py
@@ -77,6 +77,7 @@ from depmap.gene.models import Gene
 from depmap.public.resources import refresh_all_category_topics, read_forum_api_key
 from depmap.discourse.client import DiscourseClient
 from breadbox_facade import BBClient, BreadboxException, ColumnMetadata, AnnotationType
+from depmap.compound.models import drc_compound_datasets
 
 
 def _recreate_td_predictive_model():
@@ -587,7 +588,13 @@ def _load_real_data(
                 curve_params_file_path = gcsc_depmap.download_to_cache(
                     curve["filename"]
                 )
-                dataset_loader.load_curve_parameters_csv(curve_params_file_path)
+                # make sure that the label for the DRC dataset is in drc_compound_datasets if we're loading data for it
+                assert curve["label"] in [
+                    x.drc_dataset_label for x in drc_compound_datasets
+                ]
+                dataset_loader.load_curve_parameters_csv(
+                    curve_params_file_path, curve["label"]
+                )
 
     def get_subtype_context_file():
         metadata = gcsc_depmap.read_json("metadata/subtype_context_matrix_out.json")[
@@ -1127,19 +1134,21 @@ def load_sample_data(
 
         log.info("adding dose response curve parameter data")
         dataset_loader.load_curve_parameters_csv(
-            "sample_data/compound/ctd2_per_curve.csv"
+            "sample_data/compound/ctd2_per_curve.csv", "ctd2_per_curve"
         )
         dataset_loader.load_curve_parameters_csv(
-            "sample_data/compound/gdsc1_per_curve.csv"
+            "sample_data/compound/gdsc1_per_curve.csv", "GDSC1"
         )
         dataset_loader.load_curve_parameters_csv(
-            "sample_data/compound/gdsc2_per_curve.csv"
+            "sample_data/compound/gdsc2_per_curve.csv", "GDSC2"
         )
         dataset_loader.load_curve_parameters_csv(
-            "sample_data/compound/repurposing_secondary_per_curve.csv"
+            "sample_data/compound/repurposing_secondary_per_curve.csv",
+            "repurposing_per_curve",
         )
         dataset_loader.load_curve_parameters_csv(
-            "sample_data/compound/prism_oncology_per_curve.csv"
+            "sample_data/compound/prism_oncology_per_curve.csv",
+            "Prism_oncology_per_curve",
         )
     with transaction():
         log.info("Adding biomarker data")

--- a/portal-backend/depmap/compound/models.py
+++ b/portal-backend/depmap/compound/models.py
@@ -16,6 +16,46 @@ from depmap.cell_line.models import CellLine
 from depmap.gene.models import Gene
 import pandas as pd
 import re
+from dataclasses import dataclass
+
+
+@dataclass
+class DRCCompoundDataset:
+    drc_dataset_label: str
+    viability_dataset_given_id: str
+    display_name: str
+
+
+# An association of the dataset_labels which appear in the DoseResponseCurve table, and
+# the given_id of the corresponding viabilitiy dataset in breadbox, as well as how this
+# dataset should be referred to in drop down menus.
+drc_compound_datasets = [
+    DRCCompoundDataset(
+        drc_dataset_label="Prism_oncology_per_curve",
+        viability_dataset_given_id="Prism_oncology_viability",
+        display_name="PRISM OncRef",
+    ),
+    DRCCompoundDataset(
+        drc_dataset_label="GDSC2",
+        viability_dataset_given_id="GDSC2_Viability",
+        display_name="GDSC2",
+    ),
+    DRCCompoundDataset(
+        drc_dataset_label="GDSC1",
+        viability_dataset_given_id="GDSC1_Viability",
+        display_name="GDSC1",
+    ),
+    DRCCompoundDataset(
+        drc_dataset_label="ctd2_per_curve",
+        viability_dataset_given_id="CTRP_Viability",
+        display_name="CTD^2",
+    ),
+    DRCCompoundDataset(
+        drc_dataset_label="repurposing_per_curve",
+        viability_dataset_given_id="REPURPOSING_Viability",
+        display_name="PRISM Drug Repurposing",
+    ),
+]
 
 gene_compound_target_association = db.Table(
     "gene_compound_target_association",
@@ -391,7 +431,7 @@ class DoseResponseCurve(Model):
         String, ForeignKey("cell_line.depmap_id"), nullable=False, index=True
     )
     cell_line = relationship("CellLine", backref=__tablename__)
-
+    drc_dataset_label = Column(String, nullable=False)
     compound_exp_id = Column(Integer, ForeignKey("entity.entity_id"), index=True)
     compound_exp = relationship(
         "CompoundExperiment", foreign_keys="DoseResponseCurve.compound_exp_id"

--- a/portal-backend/loader/dataset_loader/compound_dose_replicate_loader.py
+++ b/portal-backend/loader/dataset_loader/compound_dose_replicate_loader.py
@@ -91,7 +91,7 @@ def _read_perturbation_index_mapping(perturbation_csv_file):
 
 
 # must load after all compound_experiments have been loaded
-def load_curve_parameters_csv(filename):
+def load_curve_parameters_csv(filename, label):
     # each row of the file includes cell line name, compound name, ec50, slope, upper asymptote, and lower asymptote
 
     # use cell line name to look up the corresponding cell line in the CellLine table
@@ -138,6 +138,7 @@ def load_curve_parameters_csv(filename):
                 row["cell_line_name"], row["compound_name"], row["ec50"]
             )
             entry_dict = dict(
+                drc_dataset_label=label,
                 depmap_id=cell_line.depmap_id,
                 compound_exp_id=lookup_compound_exp.get(row["compound_name"]).entity_id,
                 ec50=row["ec50"],

--- a/portal-backend/pyright-ratchet-errors.txt
+++ b/portal-backend/pyright-ratchet-errors.txt
@@ -538,7 +538,6 @@ views.py: error: Argument of type "Literal['logerror']" cannot be assigned to pa
 views.py: error: Argument of type "Literal['opt_in']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 views.py: error: Argument of type "Literal['primarySite']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 views.py: error: Argument of type "Literal['release']" cannot be assigned to parameter "__key" of type "_KT@dict" in function "__setitem__"
-views.py: error: Argument of type "Literal['sampleId']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 views.py: error: Argument of type "Literal['subtype']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 views.py: error: Argument of type "Literal['units']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 views.py: error: Argument of type "Literal['url']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"

--- a/portal-backend/tests/factories.py
+++ b/portal-backend/tests/factories.py
@@ -312,6 +312,7 @@ class DoseResponseCurveFactory(SQLAlchemyModelFactory):
     slope = 0
     upper_asymptote = 0
     lower_asymptote = 0
+    drc_dataset_label = "GDSC1"
 
 
 class GeneFactory(SQLAlchemyModelFactory):

--- a/portal-backend/tests/loader/test_dataset_loader.py
+++ b/portal-backend/tests/loader/test_dataset_loader.py
@@ -105,7 +105,7 @@ def test_load_curve_parameters_csv(empty_db_mock_downloads):
     )
     cell_line = CellLineFactory(cell_line_name="CADOES1_BONE")
     empty_db_mock_downloads.session.flush()
-    load_curve_parameters_csv("sample_data/compound/ctd2_per_curve.csv")
+    load_curve_parameters_csv("sample_data/compound/ctd2_per_curve.csv", "dataset")
 
     curve = DoseResponseCurve.query.filter(
         DoseResponseCurve.compound_exp == cpd_exp,
@@ -115,6 +115,7 @@ def test_load_curve_parameters_csv(empty_db_mock_downloads):
     assert curve.slope == -1
     assert curve.upper_asymptote == 2
     assert curve.lower_asymptote == 1
+    assert curve.drc_dataset_label == "dataset"
 
 
 def test_load_and_access_viability(empty_db_mock_downloads):


### PR DESCRIPTION
These changes are to assist with the creation of the new dose response tab: A set of changes to allows us to find the set of DoseResponseCurves associated with a particular viability dataset.

I created drc_compound_datasets so we could match the `drc_dataset_label` with the corresponding viability dataset and also have a meaningful label to show users.

This lead me to discover that the repurposing screen was getting loaded without a `label` on the artifact, so I also added that.

Currently the DRC are all being loaded indexed by `CompoundExperiment` and not `Compound` but that is something we can tackle in the future. For the time being we can build out the new DRC page using oncref which has a 1:1 relationship between CompoundExperiment and Compound.
