### PR TITLE
fix(breadbox): Make dimension type optional for associated datasets

### DIFF
--- a/breadbox/breadbox/schemas/associations.py
+++ b/breadbox/breadbox/schemas/associations.py
@@ -1,11 +1,11 @@
 from pydantic import BaseModel
-from typing import List
+from typing import List, Optional
 
 
 class DatasetSummary(BaseModel):
     id: str
     name: str
-    dimension_type: str
+    dimension_type: Optional[str] = None
     dataset_id: str
 
 

--- a/breadbox/breadbox/service/associations.py
+++ b/breadbox/breadbox/service/associations.py
@@ -37,6 +37,8 @@ def get_associations(
     dim_label_cache = {}
 
     def _get_dimension_label(dimension_type, given_id):
+        if not dimension_type:
+            return None
         if dimension_type not in dim_label_cache:
             dim_label_cache[dimension_type] = get_dimension_type_labels_by_id(
                 db, dimension_type

--- a/breadbox/breadbox/service/associations.py
+++ b/breadbox/breadbox/service/associations.py
@@ -37,8 +37,9 @@ def get_associations(
     dim_label_cache = {}
 
     def _get_dimension_label(dimension_type, given_id):
+        # if the dimension type is None, we use the dataset's dimension given_id as the label
         if not dimension_type:
-            return None
+            return given_id
         if dimension_type not in dim_label_cache:
             dim_label_cache[dimension_type] = get_dimension_type_labels_by_id(
                 db, dimension_type
@@ -47,6 +48,7 @@ def get_associations(
         if given_id in labels_by_id:
             return labels_by_id[given_id]
         else:
+            # there is a dimension type, and all valid given_ids are defined in that dimension type. If given_id is not included in the dimension type, we want act like that dimension doesn't exist
             return None
 
     for precomputed_assoc_table in precomputed_assoc_tables:


### PR DESCRIPTION
I encountered an error when trying to fetch associations for OncRef dataset. After looking into it, it seems like we are making assumptions that all associated datasets will have a feature type. This assumption breaks for the associated dataset "Subtype Matrix" since its feature type is `None`. 

@pgm I'm not too familiar with the original intention of your associations implementation and this particular dataset (It does feel a bit strange to say a compound is associated with `None`) but my following changes helped to unblock me