### PR TITLE
Get rid of little minor tick numbers on old Dose Curves page

### DIFF
--- a/frontend/packages/portal-frontend/src/compound/components/DoseResponsePlot.tsx
+++ b/frontend/packages/portal-frontend/src/compound/components/DoseResponsePlot.tsx
@@ -197,6 +197,7 @@ export class DoseResponsePlot extends React.Component<PlotProps> {
       xaxis: {
         title: this.props.xLabel,
         type: "log",
+        dtick: 1,
       },
       yaxis: {
         title: this.props.yLabel,


### PR DESCRIPTION
Specified dtick = 1 so that ticks are set every 10^(n"dtick) where n is the tick number.
https://plot.ly/javascript/reference/#layout-xaxis-dtick 

Example of what we don't want (the little 2 and 5 numbers):
![Screenshot 2025-06-13 at 4 15 03 PM](https://github.com/user-attachments/assets/418a01f9-ea5c-4d27-abd6-46214f5cb327)
