### PR TITLE
perf(breadbox): Fix memory performance issue on data type conversion

### DIFF
--- a/breadbox/breadbox/io/data_validation.py
+++ b/breadbox/breadbox/io/data_validation.py
@@ -214,9 +214,6 @@ def _read_parquet(file, value_type: ValueType) -> pd.DataFrame:
     # to > 30GB and would take down breadbox. However, using fastparquet seems to avoid this problem.
     df = pd.read_parquet(file, engine="fastparquet").convert_dtypes()
 
-    # the first column will be treated as the index. Make sure it's of type string
-    df[df.columns[0]] = df[df.columns[0]].astype("string")
-
     # parquet files have the types encoded in the file, so we'll convert after the fact
     if value_type == ValueType.continuous:
         dtype = "Float64"
@@ -225,7 +222,9 @@ def _read_parquet(file, value_type: ValueType) -> pd.DataFrame:
     else:
         raise ValueError(f"Invalid value type: {value_type}")
 
-    df[df.columns[1:]] = df[df.columns[1:]].astype(dtype)
+    cols = df.columns
+    # the first column will be treated as the index. Make sure it's of type string
+    df = df.astype({col: ("string" if i == 0 else dtype) for i, col in enumerate(cols)})
     return df
 
 


### PR DESCRIPTION
@pgm  Quite honestly, I feel like I've been chasing a red herring. In my notebook, I created a test DF of similar size and wrote to disk as a parquet file. I then noticed that reading the parquet file to a pandas DF with `pyarrow` engine was faster than `fastparquet`. The memory readout also didn't seem too terrible. However, when testing my changes with the breadbox loader, I noticed that I did indeed see my system's memory usage balloon to >40GB! I am not sure why that is.

However, I did tackle the main issue where reassigning the df was taking up the majority of the time/memory in the original implementation. I found an article [here](https://medium.com/@bacharliav/the-hidden-cost-of-dtype-conversion-and-reassignment-in-pandas-dataframe-strategies-for-optimized-a72a7d9b6c77) which may do a better job explaining what is happening behind the scenes in pandas.

It's a bit anticlimatic and unfortunate I spent a lot of time focusing on trying to optimize reading the parquet file but the good news is that the transcript matrix takes in total about 5 minutes to upload as a dataset to breadbox which is several times faster than before!