### PR TITLE
Fix context explorer boxplot urls

### DIFF
--- a/frontend/packages/portal-frontend/src/contextExplorer/components/boxPlots/BoxPlot.tsx
+++ b/frontend/packages/portal-frontend/src/contextExplorer/components/boxPlots/BoxPlot.tsx
@@ -231,9 +231,9 @@ export default function LazyBoxPlot({
                   {isLevel0 && (
                     <span
                       style={{
-                        paddingRight: "4px",
+                        paddingRight: "10px",
                         paddingTop: box.name === selectedCode ? "0px" : "12px",
-                        fontSize: "12px",
+                        fontSize: "16px",
                         color: "#4479B2",
                       }}
                       className={

--- a/frontend/packages/portal-frontend/src/contextExplorer/components/boxPlots/BoxPlotHeaderTitle.tsx
+++ b/frontend/packages/portal-frontend/src/contextExplorer/components/boxPlots/BoxPlotHeaderTitle.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import styles from "./styles.scss";
+
+interface BoxPlotHeaderTitleProps {
+  subtypeCode: string;
+  selectedCode: string | undefined;
+  url: string;
+}
+
+export function BoxPlotHeaderTitle({
+  subtypeCode,
+  selectedCode,
+  url,
+}: BoxPlotHeaderTitleProps) {
+  return selectedCode === subtypeCode ? (
+    <span className={styles.unlinkedBoxPlotTitle}>{subtypeCode}</span>
+  ) : (
+    <a className={styles.linkedBoxPlotTitle} href={url}>
+      {subtypeCode}
+    </a>
+  );
+}

--- a/frontend/packages/portal-frontend/src/contextExplorer/components/boxPlots/SelectedContextBoxPlotPanel.tsx
+++ b/frontend/packages/portal-frontend/src/contextExplorer/components/boxPlots/SelectedContextBoxPlotPanel.tsx
@@ -6,8 +6,10 @@ import {
   BOX_PLOT_BOTTOM_MARGIN,
   BOX_PLOT_TOP_MARGIN,
   BOX_THICKNESS,
+  getNewContextUrl,
 } from "src/contextExplorer/utils";
 import BoxPlot from "./BoxPlot";
+import { BoxPlotHeaderTitle } from "./BoxPlotHeaderTitle";
 
 interface SelectedContextBoxPlotPanelProps {
   topContextNameInfo: ContextNameInfo;
@@ -88,24 +90,6 @@ interface PanelTitleNoChildPlotsProps {
   activeKey: string | null;
 }
 
-interface Props {
-  subtypeCode: string;
-  selectedCode: string | undefined;
-}
-function SelectedLabel({ subtypeCode, selectedCode }: Props) {
-  return (
-    <span
-      style={{
-        fontSize: "12px",
-        fontWeight: selectedCode === subtypeCode ? "600" : "normal",
-        color: selectedCode === subtypeCode ? "#333333" : "#4479B2",
-      }}
-    >
-      {subtypeCode}
-    </span>
-  );
-}
-
 const PanelHeading = ({
   topContextNameInfo,
   selectedLevelZeroBoxData,
@@ -120,14 +104,15 @@ const PanelHeading = ({
 }: PanelTitleNoChildPlotsProps) => {
   return (
     <Panel.Heading>
-      <Panel.Title toggle>
+      <Panel.Toggle componentClass="a">
         <div>
           {selectedLevelZeroBoxData !== null && activeKey === "SELECTED" && (
             <span
               style={{
-                paddingRight: "4px",
+                paddingRight: "12px",
+                paddingBottom: "2px",
                 paddingTop: activeKey === "SELECTED" ? "0px" : "12px",
-                fontSize: "12px",
+                fontSize: "16px",
                 color: "#4479B2",
               }}
               className={"glyphicon glyphicon-chevron-up"}
@@ -158,14 +143,19 @@ const PanelHeading = ({
           ) : (
             selectedLevelZeroBoxData &&
             activeKey === "SELECTED" && (
-              <SelectedLabel
+              <BoxPlotHeaderTitle
                 subtypeCode={topContextNameInfo!.subtype_code}
                 selectedCode={selectedCode}
+                url={getNewContextUrl(
+                  topContextNameInfo!.subtype_code,
+                  urlPrefix,
+                  tab
+                )}
               />
             )
           )}
         </div>
-      </Panel.Title>
+      </Panel.Toggle>
     </Panel.Heading>
   );
 };

--- a/frontend/packages/portal-frontend/src/contextExplorer/components/boxPlots/SignificantBoxPlotCardPanel.tsx
+++ b/frontend/packages/portal-frontend/src/contextExplorer/components/boxPlots/SignificantBoxPlotCardPanel.tsx
@@ -5,8 +5,10 @@ import {
   BOX_PLOT_BOTTOM_MARGIN,
   BOX_PLOT_TOP_MARGIN,
   BOX_THICKNESS,
+  getNewContextUrl,
 } from "src/contextExplorer/utils";
 import BoxPlot from "src/contextExplorer/components/boxPlots/BoxPlot";
+import { BoxPlotHeaderTitle } from "./BoxPlotHeaderTitle";
 
 interface SignificantBoxPlotsPanelProps {
   activeKey: string | null;
@@ -46,15 +48,15 @@ const SignificantPlotPanelHeading = ({
 }: SignificantPlotPanelHeadingProps) => {
   return (
     <Panel.Heading>
-      <Panel.Title toggle>
+      <Panel.Toggle componentClass="a">
         <div>
           {activeKey === level0Code &&
             card[level0Code].subContextInfo.length > 0 && (
               <span
                 style={{
-                  paddingRight: "8px",
+                  paddingRight: "12px",
                   paddingTop: activeKey === level0Code ? "0px" : "12px",
-                  fontSize: "12px",
+                  fontSize: "16px",
                   color: "#4479B2",
                 }}
                 className={"glyphicon glyphicon-chevron-up"}
@@ -82,19 +84,15 @@ const SignificantPlotPanelHeading = ({
             />
           ) : (
             activeKey === level0Code && (
-              <span
-                style={{
-                  fontSize: "12px",
-                  fontWeight: selectedCode === level0Code ? "600" : "normal",
-                  color: selectedCode === level0Code ? "#333333" : "#4479B2",
-                }}
-              >
-                {level0Code}
-              </span>
+              <BoxPlotHeaderTitle
+                subtypeCode={level0Code}
+                selectedCode={selectedCode}
+                url={getNewContextUrl(level0Code, urlPrefix, tab)}
+              />
             )
           )}
         </div>
-      </Panel.Title>
+      </Panel.Toggle>
     </Panel.Heading>
   );
 };

--- a/frontend/packages/portal-frontend/src/contextExplorer/components/boxPlots/styles.scss
+++ b/frontend/packages/portal-frontend/src/contextExplorer/components/boxPlots/styles.scss
@@ -1,0 +1,13 @@
+.linkedBoxPlotTitle {
+  font-size: 12px;
+  font-weight: normal;
+  color: #4479b2;
+}
+
+// When the title of the box plot is equal to the context the user is
+// on, this styling is used.
+.unlinkedBoxPlotTitle {
+  font-size: 12px;
+  font-weight: 600;
+  color: #333333;
+}

--- a/frontend/packages/portal-frontend/src/contextExplorer/utils.ts
+++ b/frontend/packages/portal-frontend/src/contextExplorer/utils.ts
@@ -663,12 +663,16 @@ export function getNewContextUrl(
   const currentUrl = new URL(currentLocation);
 
   const currentContext = currentUrl.searchParams.get("context");
+
   const newUrl = currentContext
-    ? currentLocation.replace(
-        `&context=${encodeURIComponent(currentContext)}`,
-        `&context=${encodeURIComponent(newCode)}`
+    ? // Do not include & in the string replacement. Cannot guarantee that the context query string
+      // will come after the tab query string.
+      currentLocation.replace(
+        `context=${encodeURIComponent(currentContext)}`,
+        `context=${encodeURIComponent(newCode)}`
       )
-    : currentLocation.concat(`&context=${encodeURIComponent(newCode)}`);
+    : // & is okay here because no context query string exists yet, but a tab will always exist.
+      currentLocation.concat(`&context=${encodeURIComponent(newCode)}`);
 
   return newUrl;
 }


### PR DESCRIPTION
These changes are to fix a problem with the Context Explorer box plot urls. 

The Context Explorer box plots render as a series of collapsible panels. The title/header portion of the collapsible panel is always "level 0" (e.g. the level we used to always refer to as lineage). 

Expanding the panel shows contexts at deeper/more specific levels. Each context gets its own box plot, and each box plots is labeled with the path to that context. Each context in the path is linked to its corresponding Context Explorer page.

### THE BUG:

This bug had 2 causes.

(1) If the user navigated to Context Explorer from the global search bar and did NOT use any of the Context Explorer navigation tools on the left side of the page, context links would be incorrect. This is was because the code linking the axes was looking to replace &context={oldContext} with &context={newContext}. This worked when navigating within Context Explorer because the "context" url query param always came 2nd like this: `?tab=overview&context=BONE`. When navigating to a context from global search, the context param came first and therefore did not have the & and was not caught by the string replace logic.
- **Solution:** instead of looking to replace `&context={oldContext}`, these changes look to replace `context={oldContext}`

(2) The 2nd problem was that react-bootstrap <Panel.Title toggle> relies on rendering as an <a>, which caused confusing links to appear when hovering over the title panel of the Context Explorer box plots. For example, if the user was on the Ewing Sarcoma context and hovered over the BONE title box plot panel, unless the user hovered exactly over the "BONE" text, the user would see something like this: 
https://cds.team/depmap/context_explorer/?tab=geneDependency&context=ES/#
- **Solution**: use `Panel.Toggle` instead of `Panel.Title` (documentation: https://react-bootstrap-v3.netlify.app/components/panel/#panels-collapsible) --> After this change, there is no link unless the user hovers directly over the "BONE" text for purposes of navigating from the ES page to the BONE page. When hovering elsewhere and then clicking, the user can toggle the collapsible panel.
- Note - some minor styling adjustments were also necessary to make this solution look nice.