### PR TITLE
fix bug where Cell Line Selector could get stuck in loading state

### DIFF
--- a/frontend/packages/portal-frontend/src/index.tsx
+++ b/frontend/packages/portal-frontend/src/index.tsx
@@ -2,10 +2,9 @@ import "src/public-path";
 
 import React from "react";
 import ReactDOM from "react-dom";
-import {
-  CustomList,
-  renderCellLineSelectorModal,
-} from "@depmap/cell-line-selector";
+// TODO: uncomment this when merging into master
+// import { legacyPortalAPI, LegacyPortalApiResponse } from "@depmap/api";
+import { CustomList } from "@depmap/cell-line-selector";
 import { toStaticUrl } from "@depmap/globals";
 
 import { getQueryParams } from "@depmap/utils";
@@ -103,12 +102,6 @@ const renderWithErrorBoundary = (
   ReactDOM.render(<ErrorBoundary>{element}</ErrorBoundary>, container);
 };
 
-export function launchCellLineSelectorModal() {
-  const container = document.getElementById("cell_line_selector_modal"); // defined in layout.html
-
-  renderCellLineSelectorModal(getDapi, container);
-}
-
 export function showTermsAndConditionsModal() {
   const container = document.getElementById("modal-container");
   ReactDOM.render(<TermsAndConditionsModal />, container);
@@ -135,6 +128,13 @@ export function launchContextManagerModal(options?: {
     </React.Suspense>,
     container
   );
+}
+
+export function launchCellLineSelectorModal() {
+  launchContextManagerModal({
+    initialContextType: "depmap_model",
+    showHelpText: true,
+  });
 }
 
 export function editContext(context: DataExplorerContext, hash: string) {


### PR DESCRIPTION
This would only happen when you reached it from Featured Tools section on the homepage. That opened the old (and rather broken) version of Cell Line Selector.

The solution is to modify the behavior so it takes you Context Manager instead. This is better because it launches in a mode that explains how Context Manager and Cell Line Selector have merged into one tool.