### PR TITLE
add new @depmap/react-table package

### DIFF
--- a/frontend/packages/@depmap/react-table/README.md
+++ b/frontend/packages/@depmap/react-table/README.md
@@ -1,0 +1,292 @@
+# ReactTable Component Documentation
+
+## Overview
+
+`ReactTable` is a lightweight wrapper around `@tanstack/react-table` (v8) that provides virtualization, column resizing, sorting, row selection, and sticky columns functionality. This component is currently in an experimental stage and is designed to be a more modern alternative to our existing `wide-table` component (which is built on react-table v7).
+
+**Current Usage**: This component is currently only used by the `slice-table` component and serves as a foundation for potentially rebuilding `wide-table` in the future.
+
+## Key Features
+
+- **Virtualization**: Efficiently handles large datasets using `@tanstack/react-virtual`
+- **Column Resizing**: Interactive column resizing with auto-sizing for unspecified columns
+- **Sorting**: Click-to-sort functionality with visual indicators
+- **Row Selection**: Single or multi-row selection with checkboxes/radio buttons
+- **Sticky Columns**: Optional sticky first column and selection column
+- **Synchronized Scrolling**: Header and body scroll in sync
+- **Responsive Auto-sizing**: Automatically distributes available width among columns
+
+## Props
+
+### Required Props
+
+| Prop      | Type                          | Description                                        |
+| --------- | ----------------------------- | -------------------------------------------------- |
+| `columns` | `ColumnDef<TData, unknown>[]` | Column definitions following TanStack Table format |
+| `data`    | `TData[]`                     | Array of data objects to display                   |
+
+### Optional Props
+
+| Prop                      | Type                | Default     | Description                                              |
+| ------------------------- | ------------------- | ----------- | -------------------------------------------------------- |
+| `height`                  | `number \| "100%"`  | `400`       | Table height in pixels or percentage of parent           |
+| `enableRowSelection`      | `boolean`           | `false`     | Enable row selection functionality                       |
+| `enableMultiRowSelection` | `boolean`           | `true`      | Allow multiple rows to be selected (vs single selection) |
+| `rowSelection`            | `RowSelectionState` | `{}`        | Controlled row selection state                           |
+| `onRowSelectionChange`    | `function`          | `undefined` | Callback for row selection changes                       |
+| `getRowId`                | `function`          | `undefined` | Function to generate unique row IDs                      |
+| `enableStickyFirstColumn` | `boolean`           | `false`     | Make the first data column sticky                        |
+| `defaultSort`             | `function`          | `undefined` | Custom sort function when no column sorts are active     |
+| `tableRef`                | `React.RefObject`   | `undefined` | Ref to expose table methods                              |
+
+## Usage Examples
+
+### Basic Usage
+
+```tsx
+import ReactTable from "./ReactTable";
+import { ColumnDef } from "@tanstack/react-table";
+
+interface User {
+  id: string;
+  name: string;
+  email: string;
+  age: number;
+}
+
+const columns: ColumnDef<User>[] = [
+  {
+    accessorKey: "name",
+    header: "Name",
+    size: 200,
+  },
+  {
+    accessorKey: "email",
+    header: "Email",
+    // No size specified - will auto-size
+  },
+  {
+    accessorKey: "age",
+    header: "Age",
+    size: 80,
+  },
+];
+
+const data: User[] = [
+  { id: "1", name: "John Doe", email: "john@example.com", age: 30 },
+  { id: "2", name: "Jane Smith", email: "jane@example.com", age: 25 },
+];
+
+function UserTable() {
+  return <ReactTable columns={columns} data={data} height={500} />;
+}
+```
+
+### With Row Selection
+
+```tsx
+import { useState } from "react";
+
+function SelectableTable() {
+  const [rowSelection, setRowSelection] = useState({});
+
+  return (
+    <ReactTable
+      columns={columns}
+      data={data}
+      enableRowSelection={true}
+      enableMultiRowSelection={true}
+      rowSelection={rowSelection}
+      onRowSelectionChange={setRowSelection}
+      getRowId={(row) => row.id}
+    />
+  );
+}
+```
+
+### With Sticky First Column
+
+```tsx
+function StickyColumnTable() {
+  return (
+    <ReactTable
+      columns={columns}
+      data={data}
+      enableStickyFirstColumn={true}
+      enableRowSelection={true}
+      height="100%"
+    />
+  );
+}
+```
+
+### With Custom Default Sort
+
+```tsx
+function CustomSortTable() {
+  const defaultSort = (a: User, b: User) => {
+    // Sort by name when no column sorts are active
+    return a.name.localeCompare(b.name);
+  };
+
+  return <ReactTable columns={columns} data={data} defaultSort={defaultSort} />;
+}
+```
+
+### With Table Methods Access
+
+```tsx
+import { useRef } from "react";
+
+function TableWithMethods() {
+  const tableRef = useRef<{
+    resetColumnResizing: () => void;
+    manuallyResizedColumns: Set<string>;
+  }>(null);
+
+  const handleResetSizing = () => {
+    tableRef.current?.resetColumnResizing();
+  };
+
+  return (
+    <div>
+      <button onClick={handleResetSizing}>Reset Column Sizing</button>
+      <ReactTable columns={columns} data={data} tableRef={tableRef} />
+    </div>
+  );
+}
+```
+
+## Important Data Handling Notes
+
+### Undefined vs Null Values
+
+**Important**: Use `undefined` instead of `null` for empty values in your data. React Table has built-in functionality to sort `undefined` values last, but no equivalent functionality for `null` values.
+
+```tsx
+// ✅ Good - undefined values will sort last
+const data = [
+  { name: "John", age: 30 },
+  { name: "Jane", age: undefined },
+];
+
+// ❌ Avoid - null values won't sort properly
+const data = [
+  { name: "John", age: 30 },
+  { name: "Jane", age: null },
+];
+```
+
+## Column Auto-sizing Behavior
+
+The component implements intelligent column auto-sizing:
+
+1. **Explicit Size**: Columns with a `size` property maintain their specified width
+2. **Auto-sizing**: Columns without a `size` property automatically share available space
+3. **Manual Resize**: Once a user manually resizes a column, it's excluded from auto-sizing
+4. **Responsive**: Auto-sized columns redistribute when container width changes
+
+### Column Size Examples
+
+```tsx
+const columns: ColumnDef<User>[] = [
+  {
+    accessorKey: "id",
+    header: "ID",
+    size: 80, // Fixed width
+  },
+  {
+    accessorKey: "name",
+    header: "Name",
+    // Will auto-size to fill available space
+  },
+  {
+    accessorKey: "email",
+    header: "Email",
+    // Will auto-size to fill available space
+  },
+  {
+    accessorKey: "actions",
+    header: "Actions",
+    size: 120, // Fixed width
+  },
+];
+```
+
+## Height Configuration
+
+The `height` prop is flexible and works well in various layouts:
+
+```tsx
+// Fixed height
+<ReactTable height={400} />
+
+// Fill parent container (useful in flex layouts)
+<ReactTable height="100%" />
+
+// Examples of parent containers where height="100%" works well:
+<div style={{ height: '600px' }}>
+  <ReactTable height="100%" />
+</div>
+
+<div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+  <div style={{ flex: 1 }}>
+    <ReactTable height="100%" />
+  </div>
+</div>
+```
+
+## Performance Considerations
+
+- **Virtualization**: Only visible rows are rendered, enabling smooth performance with large datasets
+- **Memoization**: Column definitions should be memoized to prevent unnecessary re-renders
+- **Data Stability**: Ensure data array reference is stable or memoized
+
+```tsx
+// ✅ Good - memoized columns
+const columns = useMemo(
+  () => [
+    { accessorKey: "name", header: "Name" },
+    { accessorKey: "email", header: "Email" },
+  ],
+  []
+);
+
+// ✅ Good - stable data reference
+const data = useMemo(() => fetchedData, [fetchedData]);
+```
+
+## Styling
+
+The component uses CSS modules with the following structure:
+
+- `styles.tableContainer` - Main container
+- `styles.headerScrollContainer` - Header scroll container
+- `styles.table` - Table element
+- `styles.virtualScroll` - Virtual scroll container
+- `styles.selectedRow` / `styles.unselectedRow` - Row selection states
+- `styles.stickyCell` - Sticky column cells
+- `styles.thContent` - Header cell content
+- `styles.sortIcon` - Sort indicator container
+- `styles.sortArrowActive` - Active sort arrow
+- `styles.resizer` - Column resize handle
+
+## Relationship to wide-table
+
+This `ReactTable` component is intended as a modern foundation that could eventually replace or be used to rebuild the `wide-table` component. Key differences:
+
+- **React Table Version**: Uses v8 (modern) vs v7 (legacy)
+- **Bundle Size**: More lightweight with fewer built-in features
+- **Extensibility**: Designed to be extended rather than feature-complete
+- **Performance**: Better virtualization and modern React patterns
+
+## Current Limitations
+
+As this is an experimental component, some features available in `wide-table` may not be present:
+
+- Advanced filtering capabilities
+- Column visibility controls
+- Export functionality
+- Complex cell editing
+
+These features can be added as needed when migrating from `wide-table` or can be implemented in consumer components.

--- a/frontend/packages/@depmap/react-table/index.ts
+++ b/frontend/packages/@depmap/react-table/index.ts
@@ -1,0 +1,12 @@
+export { default } from "./src/components/ReactTable";
+
+// Re-export specific types from @tanstack/react-table
+export type {
+  RowSelectionState,
+  ColumnDef,
+  RowData,
+  SortingState,
+  Row,
+  Column,
+  Table,
+} from "@tanstack/react-table";

--- a/frontend/packages/@depmap/react-table/package.json
+++ b/frontend/packages/@depmap/react-table/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@depmap/react-table",
+  "version": "1.0.0",
+  "main": "index.ts",
+  "license": "MIT",
+  "scripts": {
+    "test": "echo 'no tests to run'"
+  },
+  "dependencies": {
+    "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.13.10",
+    "classnames": "^2.3.1"
+  },
+  "peerDependencies": {
+    "react": "^16.9.35",
+    "react-dom": "^16.9.8"
+  }
+}

--- a/frontend/packages/@depmap/react-table/src/@types/global.d.ts
+++ b/frontend/packages/@depmap/react-table/src/@types/global.d.ts
@@ -1,0 +1,1 @@
+declare module "*.scss";

--- a/frontend/packages/@depmap/react-table/src/components/ReactTable.tsx
+++ b/frontend/packages/@depmap/react-table/src/components/ReactTable.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import type {
+  RowData,
+  ColumnDef,
+  RowSelectionState,
+} from "@tanstack/react-table";
+import { TableHeader } from "./TableHeader";
+import { TableBody } from "./TableBody";
+import { useTableInstance } from "./useTableInstance";
+import styles from "../styles/ReactTable.scss";
+
+type TableProps<TData extends RowData> = {
+  columns: ColumnDef<TData, unknown>[];
+  // NOTE: Use `undefined` instead of `null` for empty values. react-table has
+  // built-in functionality that can sort `undefined` values last but no
+  // equivalent functionality for nulls.
+  data: TData[];
+  // Set the height in pixels, or allow the table to grow to 100% of its parent
+  // height. Useful when the parent container already has a height defined,
+  // e.g., inside:
+  //  - A flex child with `flex: 1`
+  //  - A grid cell with `height: 100%`
+  //  - A div with `height: 600px`
+  height?: number | "100%";
+  // Selection props
+  enableRowSelection?: boolean;
+  enableMultiRowSelection?: boolean;
+  rowSelection?: RowSelectionState;
+  onRowSelectionChange?: (
+    updater: RowSelectionState | ((old: RowSelectionState) => RowSelectionState)
+  ) => void;
+  getRowId?: (row: TData) => string;
+  // Sticky columns option
+  enableStickyFirstColumn?: boolean;
+  // Custom default sort function that applies when no column sorts are active
+  defaultSort?: (a: TData, b: TData) => number;
+  // Optional ref to expose table methods
+  tableRef?: React.RefObject<{
+    resetColumnResizing: () => void;
+    manuallyResizedColumns: Set<string>;
+  }>;
+};
+
+function ReactTable<TData extends RowData>({
+  columns,
+  data,
+  height = 400,
+  enableRowSelection = false,
+  enableMultiRowSelection = true,
+  rowSelection = {},
+  onRowSelectionChange = undefined,
+  getRowId = undefined,
+  enableStickyFirstColumn = false,
+  defaultSort = undefined,
+  tableRef = undefined,
+}: TableProps<TData>) {
+  const {
+    table,
+    parentRef,
+    containerRef,
+    tableWidth,
+    virtualRows,
+    totalSize,
+    resetColumnResizing,
+    manuallyResizedColumns,
+    headerScrollRef,
+    syncScroll,
+    stickyColumnsInfo,
+  } = useTableInstance(columns, data, {
+    enableRowSelection,
+    enableMultiRowSelection,
+    rowSelection,
+    onRowSelectionChange,
+    getRowId,
+    defaultSort,
+    enableStickyFirstColumn,
+  });
+
+  // Expose methods via ref if provided
+  React.useImperativeHandle(
+    tableRef,
+    () => ({
+      resetColumnResizing,
+      manuallyResizedColumns,
+    }),
+    [resetColumnResizing, manuallyResizedColumns]
+  );
+
+  return (
+    <div ref={containerRef} className={styles.tableContainer}>
+      <div ref={headerScrollRef} className={styles.headerScrollContainer}>
+        <table className={styles.table} style={{ width: tableWidth }}>
+          <TableHeader table={table} stickyColumnsInfo={stickyColumnsInfo} />
+        </table>
+      </div>
+      <TableBody
+        table={table}
+        parentRef={parentRef}
+        virtualRows={virtualRows}
+        totalSize={totalSize}
+        tableWidth={tableWidth}
+        height={height}
+        onScroll={syncScroll}
+        stickyColumnsInfo={stickyColumnsInfo}
+      />
+    </div>
+  );
+}
+
+export default ReactTable;

--- a/frontend/packages/@depmap/react-table/src/components/TableBody.tsx
+++ b/frontend/packages/@depmap/react-table/src/components/TableBody.tsx
@@ -1,0 +1,126 @@
+import React, { RefObject } from "react";
+import { flexRender, Table } from "@tanstack/react-table";
+import styles from "../styles/ReactTable.scss";
+
+type StickyColumnsInfo = {
+  selectColumnWidth: number;
+  firstColumnWidth: number;
+  hasSelectColumn: boolean;
+  hasStickyFirstColumn: boolean;
+};
+
+type TableBodyProps<T> = {
+  table: Table<T>;
+  parentRef: RefObject<HTMLDivElement>;
+  virtualRows: { index: number; size: number; start: number }[];
+  totalSize: number;
+  tableWidth: number;
+  height: number | "100%";
+  onScroll?: (scrollLeft: number) => void;
+  stickyColumnsInfo: StickyColumnsInfo;
+};
+
+export function TableBody<T>({
+  table,
+  parentRef,
+  virtualRows,
+  totalSize,
+  tableWidth,
+  height,
+  onScroll = () => {},
+  stickyColumnsInfo,
+}: TableBodyProps<T>) {
+  const rows = table.getRowModel().rows;
+  const {
+    selectColumnWidth,
+    hasSelectColumn,
+    hasStickyFirstColumn,
+  } = stickyColumnsInfo;
+
+  const handleScroll = (e: React.UIEvent<HTMLDivElement>) => {
+    onScroll(e.currentTarget.scrollLeft);
+  };
+
+  return (
+    <div
+      ref={parentRef}
+      className={styles.virtualScroll}
+      style={{ height }}
+      onScroll={handleScroll}
+    >
+      <div style={{ height: `${totalSize}px`, position: "relative" }}>
+        <table className={styles.table} style={{ width: tableWidth }}>
+          <tbody>
+            {virtualRows.map((virtualRow) => {
+              const row = rows[virtualRow.index];
+              const isSelected = row.getIsSelected();
+
+              return (
+                <tr
+                  key={row.id}
+                  className={
+                    isSelected ? styles.selectedRow : styles.unselectedRow
+                  }
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    transform: `translateY(${virtualRow.start}px)`,
+                    height: `${virtualRow.size}px`,
+                    width: tableWidth,
+                    display: "table",
+                    tableLayout: "fixed",
+                    cursor: row.getCanSelect() ? "pointer" : "default",
+                  }}
+                  onClick={() => {
+                    if (row.getCanSelect()) {
+                      row.toggleSelected();
+                    }
+                  }}
+                >
+                  {row.getVisibleCells().map((cell, index) => {
+                    // Check if this is the select column
+                    const isSelectColumn = cell.column.id === "select";
+
+                    // Check if this is the first data column (after selection column if present)
+                    const isFirstDataColumn =
+                      hasStickyFirstColumn &&
+                      ((hasSelectColumn && index === 1) ||
+                        (!hasSelectColumn && index === 0));
+
+                    // Determine sticky positioning
+                    let stickyLeft: number | undefined;
+                    if (isSelectColumn) {
+                      stickyLeft = 0;
+                    } else if (isFirstDataColumn) {
+                      stickyLeft = hasSelectColumn ? selectColumnWidth : 0;
+                    }
+
+                    const isSticky = isSelectColumn || isFirstDataColumn;
+
+                    return (
+                      <td
+                        key={cell.id}
+                        className={isSticky ? styles.stickyCell : undefined}
+                        style={{
+                          width: cell.column.getSize(),
+                          ...(isSticky && stickyLeft !== undefined
+                            ? { left: stickyLeft }
+                            : {}),
+                        }}
+                      >
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/frontend/packages/@depmap/react-table/src/components/TableHeader.tsx
+++ b/frontend/packages/@depmap/react-table/src/components/TableHeader.tsx
@@ -1,0 +1,120 @@
+/* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
+import React from "react";
+import cx from "classnames";
+import { flexRender, Table } from "@tanstack/react-table";
+import styles from "../styles/ReactTable.scss";
+
+type StickyColumnsInfo = {
+  selectColumnWidth: number;
+  hasSelectColumn: boolean;
+  hasStickyFirstColumn: boolean;
+};
+
+type TableHeaderProps<T> = {
+  table: Table<T>;
+  stickyColumnsInfo: StickyColumnsInfo;
+};
+
+export function TableHeader<T>({
+  table,
+  stickyColumnsInfo,
+}: TableHeaderProps<T>) {
+  const {
+    selectColumnWidth,
+    hasSelectColumn,
+    hasStickyFirstColumn,
+  } = stickyColumnsInfo;
+
+  return (
+    <thead>
+      {table.getHeaderGroups().map((headerGroup) => {
+        return (
+          <tr key={headerGroup.id}>
+            {headerGroup.headers.map((header, index) => {
+              const canResize = header.column.getCanResize();
+              const resizeHandler = header.getResizeHandler();
+
+              // Check if this is the select column
+              const isSelectColumn = header.column.id === "select";
+
+              // Check if this is the first data column (after selection column if present)
+              const isFirstDataColumn =
+                hasStickyFirstColumn &&
+                ((hasSelectColumn && index === 1) ||
+                  (!hasSelectColumn && index === 0));
+
+              // Determine sticky positioning
+              let stickyLeft: number | undefined;
+              if (isSelectColumn) {
+                stickyLeft = 0;
+              } else if (isFirstDataColumn) {
+                stickyLeft = hasSelectColumn ? selectColumnWidth : 0;
+              }
+
+              const isSticky = isSelectColumn || isFirstDataColumn;
+
+              return (
+                <th
+                  key={header.id}
+                  className={isSticky ? styles.stickyCell : undefined}
+                  style={{
+                    width: header.getSize(),
+                    ...(isSticky && stickyLeft !== undefined
+                      ? { left: stickyLeft }
+                      : {}),
+                  }}
+                >
+                  <div
+                    className={styles.thContent}
+                    onClick={
+                      !isSelectColumn
+                        ? header.column.getToggleSortingHandler()
+                        : undefined
+                    }
+                    style={{
+                      cursor:
+                        !isSelectColumn && header.column.getCanSort()
+                          ? "pointer"
+                          : "default",
+                    }}
+                  >
+                    {flexRender(
+                      header.column.columnDef.header,
+                      header.getContext()
+                    )}
+                    {!isSelectColumn && (
+                      <div className={styles.sortIcon}>
+                        <span
+                          className={cx("glyphicon glyphicon-triangle-top", {
+                            [styles.sortArrowActive]:
+                              header.column.getIsSorted() === "asc",
+                          })}
+                        />
+                        <span
+                          className={cx("glyphicon glyphicon-triangle-bottom", {
+                            [styles.sortArrowActive]:
+                              header.column.getIsSorted() === "desc",
+                          })}
+                        />
+                      </div>
+                    )}
+
+                    {canResize && (
+                      <div
+                        className={styles.resizer}
+                        onDoubleClick={() => header.column.resetSize()}
+                        onMouseDown={resizeHandler}
+                        onTouchStart={resizeHandler}
+                        onClick={(e) => e.stopPropagation()}
+                      />
+                    )}
+                  </div>
+                </th>
+              );
+            })}
+          </tr>
+        );
+      })}
+    </thead>
+  );
+}

--- a/frontend/packages/@depmap/react-table/src/components/useTableInstance.ts
+++ b/frontend/packages/@depmap/react-table/src/components/useTableInstance.ts
@@ -1,0 +1,435 @@
+import React, {
+  useCallback,
+  useState,
+  useRef,
+  useMemo,
+  useEffect,
+} from "react";
+import {
+  ColumnDef,
+  RowData,
+  SortingState,
+  RowSelectionState,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+} from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+
+type SelectionOptions<TData> = {
+  enableRowSelection?: boolean;
+  enableMultiRowSelection?: boolean;
+  rowSelection?: RowSelectionState;
+  onRowSelectionChange?: (
+    updater: RowSelectionState | ((old: RowSelectionState) => RowSelectionState)
+  ) => void;
+  getRowId?: (row: TData) => string;
+  enableStickyFirstColumn?: boolean;
+  defaultSort?: (a: TData, b: TData) => number;
+};
+
+export function useTableInstance<TData extends RowData>(
+  columns: ColumnDef<TData, unknown>[],
+  data: TData[],
+  selectionOptions: SelectionOptions<TData> = {}
+) {
+  const {
+    enableRowSelection = false,
+    enableMultiRowSelection = true,
+    rowSelection: controlledRowSelection,
+    onRowSelectionChange,
+    getRowId,
+    enableStickyFirstColumn = false,
+    defaultSort = undefined,
+  } = selectionOptions;
+
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [
+    internalRowSelection,
+    setInternalRowSelection,
+  ] = useState<RowSelectionState>({});
+  const [containerWidth, setContainerWidth] = useState<number>(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Track manually resized columns, previous column count, and column sizing state
+  const [manuallyResizedColumns, setManuallyResizedColumns] = useState<
+    Set<string>
+  >(new Set());
+  const previousColumnCount = useRef<number>(0);
+  const [columnSizing, setColumnSizing] = useState<Record<string, number>>({});
+
+  // ResizeObserver ref to track container width changes
+  const resizeObserverRef = useRef<ResizeObserver | null>(null);
+
+  // Refs for synchronized scrolling
+  const headerScrollRef = useRef<HTMLDivElement>(null);
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  // Use controlled selection if provided, otherwise use internal state
+  const rowSelection = controlledRowSelection ?? internalRowSelection;
+  const handleRowSelectionChange =
+    onRowSelectionChange ?? setInternalRowSelection;
+
+  // Function to synchronize header scroll with body scroll
+  const syncScroll = useCallback((scrollLeft: number) => {
+    if (headerScrollRef.current) {
+      headerScrollRef.current.scrollLeft = scrollLeft;
+    }
+  }, []);
+
+  // Helper function to safely get column ID
+  const getColumnId = useCallback((col: ColumnDef<TData, unknown>): string => {
+    if (col.id) return col.id;
+    if ("accessorKey" in col && col.accessorKey) {
+      return col.accessorKey.toString();
+    }
+    return Math.random().toString(36).substr(2, 9); // fallback random ID
+  }, []);
+
+  // Create columns with selection column if needed (no auto-sizing here)
+  const enhancedColumns = useMemo(() => {
+    const baseColumns = enableRowSelection
+      ? [
+          {
+            id: "select",
+            header: ({ table }: { table: any }) => {
+              if (!enableMultiRowSelection) {
+                return null;
+              }
+              return React.createElement("input", {
+                type: "checkbox",
+                checked: table.getIsAllRowsSelected(),
+                ref: (input: HTMLInputElement | null) => {
+                  if (input) {
+                    // eslint-disable-next-line no-param-reassign
+                    input.indeterminate = table.getIsSomeRowsSelected();
+                  }
+                },
+                onChange: table.getToggleAllRowsSelectedHandler(),
+              });
+            },
+            cell: ({ row }: { row: any }) => {
+              return React.createElement("input", {
+                type: enableMultiRowSelection ? "checkbox" : "radio",
+                name: enableMultiRowSelection ? undefined : "row-selection",
+                checked: row.getIsSelected(),
+                disabled: !row.getCanSelect(),
+                onChange: row.getToggleSelectedHandler(),
+                onClick: (e: React.MouseEvent) => e.stopPropagation(),
+              });
+            },
+            size: 38,
+            minSize: 38,
+            maxSize: 38,
+            enableSorting: false,
+            enableResizing: false,
+          },
+          ...columns,
+        ]
+      : columns;
+
+    // Ensure all columns have a default size if not specified
+    return baseColumns.map((col) => {
+      if (col.size !== undefined) {
+        return col;
+      }
+      return {
+        ...col,
+        size: 150, // default size
+      };
+    });
+  }, [columns, enableRowSelection, enableMultiRowSelection]);
+
+  // Apply custom default sort when no column sorts are active
+  const sortedData = useMemo(() => {
+    // If there are active column sorts, let TanStack Table handle it
+    if (sorting.length > 0 || !defaultSort) {
+      return data;
+    }
+
+    // Apply custom default sort
+    return [...data].sort(defaultSort);
+  }, [data, sorting, defaultSort]);
+
+  const table = useReactTable({
+    data: sortedData,
+    columns: enhancedColumns,
+    state: {
+      sorting,
+      rowSelection,
+      columnSizing,
+    },
+    onSortingChange: setSorting,
+    onRowSelectionChange: handleRowSelectionChange,
+    onColumnSizingChange: (updater) => {
+      if (typeof updater === "function") {
+        const newSizing = updater(columnSizing);
+        setColumnSizing(newSizing);
+
+        // Track which columns have been manually resized
+        for (const [columnId, newSize] of Object.entries(newSizing)) {
+          if (columnSizing[columnId] !== newSize) {
+            setManuallyResizedColumns((prev) => new Set([...prev, columnId]));
+          }
+        }
+      } else {
+        setColumnSizing(updater);
+        // Track all columns in the sizing object as manually resized
+        for (const columnId of Object.keys(updater)) {
+          setManuallyResizedColumns((prev) => new Set([...prev, columnId]));
+        }
+      }
+    },
+    columnResizeMode: "onChange",
+    columnResizeDirection: "ltr",
+    enableColumnResizing: true,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    enableRowSelection,
+    enableMultiRowSelection,
+    getRowId,
+    defaultColumn: {
+      sortUndefined: "last",
+      size: 150,
+      minSize: 100,
+      maxSize: 500,
+    },
+  });
+
+  // Store table reference
+  const tableRef = useRef(table);
+  tableRef.current = table;
+
+  // Calculate sticky columns information
+  const stickyColumnsInfo = useMemo(() => {
+    const hasSelectColumn = enableRowSelection;
+    const selectColumn = hasSelectColumn ? table.getColumn("select") : null;
+    const selectColumnWidth = selectColumn ? selectColumn.getSize() : 0;
+
+    // Get the first data column (after selection if present)
+    const allColumns = table.getAllColumns();
+    const firstDataColumn = hasSelectColumn ? allColumns[1] : allColumns[0];
+    const firstColumnWidth = firstDataColumn ? firstDataColumn.getSize() : 0;
+
+    return {
+      selectColumnWidth,
+      firstColumnWidth,
+      hasSelectColumn,
+      hasStickyFirstColumn: enableStickyFirstColumn,
+    };
+  }, [table, enableRowSelection, enableStickyFirstColumn]);
+
+  // Rest of the existing logic remains the same...
+  // [Previous auto-sizing and ResizeObserver logic continues unchanged]
+
+  const redistributeAutoSizeableColumns = useCallback(
+    (newContainerWidth: number) => {
+      if (newContainerWidth <= 0 || !table) return;
+
+      // Calculate available width for auto-sized columns
+      let explicitSizesTotal = 0;
+      let autoSizeColumnCount = 0;
+
+      enhancedColumns.forEach((col) => {
+        const colId = getColumnId(col);
+        const hasExplicitSize = col.size !== undefined && col.size !== 150; // 150 is our default
+        const wasManuallyResized = manuallyResizedColumns.has(colId);
+
+        if (hasExplicitSize) {
+          explicitSizesTotal += col.size!;
+        } else if (!wasManuallyResized) {
+          // This column needs auto-sizing
+          autoSizeColumnCount++;
+        } else {
+          // Manually resized - get current size from table
+          const currentSize = table.getColumn(colId)?.getSize() || 150;
+          explicitSizesTotal += currentSize;
+        }
+      });
+
+      // Calculate equal width for auto-sized columns
+      const availableWidth = newContainerWidth - explicitSizesTotal;
+      const autoColumnWidth =
+        autoSizeColumnCount > 0
+          ? Math.max(100, availableWidth / autoSizeColumnCount)
+          : 150;
+
+      // Set column sizes using TanStack Table's method
+      const newSizing: Record<string, number> = {};
+
+      enhancedColumns.forEach((col) => {
+        const colId = getColumnId(col);
+        const hasExplicitSize = col.size !== undefined && col.size !== 150;
+        const wasManuallyResized = manuallyResizedColumns.has(colId);
+
+        if (!hasExplicitSize && !wasManuallyResized) {
+          // Auto-size this column
+          newSizing[colId] = autoColumnWidth;
+        }
+      });
+
+      // Apply the new sizing if we have changes
+      if (Object.keys(newSizing).length > 0) {
+        setColumnSizing((prev) => ({ ...prev, ...newSizing }));
+      }
+    },
+    [enhancedColumns, getColumnId, manuallyResizedColumns, table]
+  );
+
+  // Set up ResizeObserver to watch container width changes
+  useEffect(() => {
+    if (!containerRef.current) {
+      return () => {};
+    }
+
+    // Initial width calculation
+    const calculateInitialWidth = () => {
+      if (!containerRef.current) return;
+
+      // Walk up the DOM to find a stable width reference
+      let element = containerRef.current.parentElement;
+      let width = 0;
+
+      // Try to find a parent with explicit width or use viewport as fallback
+      while (element && !width) {
+        const computedStyle = getComputedStyle(element);
+        const elementWidth = element.clientWidth;
+
+        // If this element has explicit width or is the body, use it
+        if (
+          computedStyle.width !== "auto" ||
+          element.tagName === "BODY" ||
+          !element.parentElement
+        ) {
+          width = elementWidth;
+          break;
+        }
+        element = element.parentElement;
+      }
+
+      // Fallback to viewport width if we can't find anything
+      if (!width) {
+        width = window.innerWidth - 32; // Account for some padding
+      }
+
+      setContainerWidth(width);
+    };
+
+    // Set up ResizeObserver to watch for container size changes
+    const setupResizeObserver = () => {
+      if (typeof ResizeObserver === "undefined") {
+        // Fallback for browsers without ResizeObserver support
+        calculateInitialWidth();
+        return;
+      }
+
+      resizeObserverRef.current = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          const newWidth = entry.contentRect.width;
+          if (newWidth > 0 && newWidth !== containerWidth) {
+            setContainerWidth(newWidth);
+          }
+        }
+      });
+
+      // Find the parent element to observe
+      let elementToObserve = containerRef.current?.parentElement;
+
+      // Walk up to find a suitable parent container to observe
+      while (elementToObserve) {
+        const computedStyle = getComputedStyle(elementToObserve);
+
+        // Observe this element if it has explicit dimensions or is a flex/grid child
+        if (
+          computedStyle.width !== "auto" ||
+          computedStyle.flexGrow !== "0" ||
+          computedStyle.gridColumn !== "auto" ||
+          elementToObserve.tagName === "BODY"
+        ) {
+          resizeObserverRef.current.observe(elementToObserve);
+          break;
+        }
+
+        elementToObserve = elementToObserve.parentElement;
+      }
+
+      // If we couldn't find a suitable parent, observe the container itself
+      if (!elementToObserve && containerRef.current) {
+        resizeObserverRef.current.observe(containerRef.current);
+      }
+
+      // Set initial width
+      calculateInitialWidth();
+    };
+
+    setupResizeObserver();
+
+    // Cleanup function
+    return () => {
+      if (resizeObserverRef.current) {
+        resizeObserverRef.current.disconnect();
+        resizeObserverRef.current = null;
+      }
+    };
+  }, [containerWidth]); // Only run once on mount
+
+  // Auto-sizing effect - runs when columns are added OR when container width changes
+  useEffect(() => {
+    const currentColumnCount = enhancedColumns.length;
+    const columnsWereAdded = currentColumnCount > previousColumnCount.current;
+    previousColumnCount.current = currentColumnCount;
+
+    // Trigger redistribution when:
+    // 1. Columns were added (existing behavior)
+    // 2. Container width changed and we have auto-sizeable columns
+    const shouldRedistribute =
+      columnsWereAdded ||
+      (containerWidth > 0 &&
+        enhancedColumns.some((col) => {
+          const colId = getColumnId(col);
+          const hasExplicitSize = col.size !== undefined && col.size !== 150;
+          const wasManuallyResized = manuallyResizedColumns.has(colId);
+          return !hasExplicitSize && !wasManuallyResized;
+        }));
+
+    if (shouldRedistribute) {
+      redistributeAutoSizeableColumns(containerWidth);
+    }
+  }, [
+    enhancedColumns,
+    containerWidth,
+    getColumnId,
+    manuallyResizedColumns,
+    redistributeAutoSizeableColumns,
+  ]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: table.getRowModel().rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 35,
+    overscan: 5,
+  });
+
+  // Calculate table width: just use the table's natural width since all columns have explicit sizes
+  const tableWidth = table.getCenterTotalSize();
+
+  return {
+    table,
+    parentRef,
+    containerRef,
+    tableWidth,
+    virtualRows: rowVirtualizer.getVirtualItems(),
+    totalSize: rowVirtualizer.getTotalSize(),
+    // Expose methods for managing auto-sizing
+    resetColumnResizing: () => {
+      setManuallyResizedColumns(new Set());
+      setColumnSizing({});
+    },
+    manuallyResizedColumns,
+    // New exports for synchronized scrolling
+    headerScrollRef,
+    syncScroll,
+    // Export sticky columns info
+    stickyColumnsInfo,
+  };
+}

--- a/frontend/packages/@depmap/react-table/src/styles/ReactTable.scss
+++ b/frontend/packages/@depmap/react-table/src/styles/ReactTable.scss
@@ -1,0 +1,202 @@
+// https://stackoverflow.com/a/34299947
+@mixin scroll-shadow {
+  background:
+    /* Top and bottom fade covers to blend with background */ linear-gradient(
+      white 30%,
+      rgba(255, 255, 255, 0)
+    ),
+    linear-gradient(rgba(255, 255, 255, 0), white 70%) 0 100%,
+    /* Flatter, moderately subtle shadows */
+      linear-gradient(to bottom, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0)),
+    linear-gradient(to top, rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0)) 0 100%;
+
+  background-repeat: no-repeat;
+  background-color: white;
+  background-size: 100% 40px, 100% 40px, 100% 34px, 100% 34px;
+  background-attachment: local, local, scroll, scroll;
+}
+
+.tableContainer {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  border: 1px solid #ccc;
+  border-bottom: 2px solid #ccc;
+  overflow: hidden;
+  contain: layout;
+}
+
+.headerScrollContainer {
+  background-color: #f0f0f0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  flex-shrink: 0;
+  position: relative; /* Create stacking context for sticky elements */
+
+  /* Hide scrollbar for header to avoid double scrollbars */
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* IE and Edge */
+
+  &::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Opera */
+  }
+}
+
+.tableHeaderWrapper {
+  background-color: #f0f0f0;
+}
+
+.sortIcon {
+  display: flex;
+  flex-direction: column;
+  color: lightgrey;
+  font-size: 12px;
+  margin-right: 5px;
+
+  &:hover {
+    color: darkgray;
+  }
+}
+
+.sortArrowActive {
+  color: black;
+}
+
+.virtualScroll {
+  overflow-y: auto;
+  overflow-x: auto;
+  width: 100%;
+  flex: 1;
+  position: relative; /* Create stacking context for sticky elements */
+  @include scroll-shadow;
+
+  /* This ensures the scrollbar doesn't push content */
+  scrollbar-gutter: stable overlay;
+
+  /* Chrome, Edge */
+  &::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 0.3);
+    border-radius: 4px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  /* Firefox */
+  & {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(0, 0, 0, 0.3) transparent;
+  }
+}
+
+.table {
+  table-layout: fixed;
+  border-collapse: collapse;
+  width: 100%;
+  max-width: 100%;
+  min-width: fit-content;
+}
+
+.table th,
+.table td {
+  border: 1px solid #ccc;
+  padding: 7px 12px;
+  text-align: left;
+}
+
+.table td {
+  border-bottom: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.table th {
+  border-top: none;
+  border-bottom: 2px solid #ccc;
+  background-color: #f0f0f0;
+  font-weight: bold;
+}
+
+.thContent {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  position: relative;
+}
+
+.stickyCell {
+  position: sticky;
+  left: 0;
+  z-index: 20;
+  outline: 1px solid #ccc;
+
+  /* Ensure background is properly set for sticky positioning */
+  background-color: #f0f0f0; /* Default header background */
+
+  /* Override background colors based on context */
+  .selectedRow & {
+    background-color: #e3f2fd;
+  }
+
+  .selectedRow:hover & {
+    background-color: #bbdefb;
+  }
+
+  .unselectedRow & {
+    background-color: #fff;
+  }
+
+  .unselectedRow:hover & {
+    background-color: #f1f1f1;
+  }
+
+  /* Special handling for header sticky cells */
+  thead & {
+    background-color: #f0f0f0;
+  }
+}
+
+.selectedRow {
+  background-color: #e3f2fd;
+}
+
+.selectedRow:hover {
+  background-color: #bbdefb;
+}
+
+.unselectedRow {
+  /* Background handled by stickyCell styles */
+}
+
+.unselectedRow:hover {
+  background-color: #f1f1f1;
+}
+
+.resizer {
+  position: absolute;
+  right: -17px;
+  top: -8px;
+  height: calc(100% + 18px);
+  width: 9px;
+  cursor: col-resize;
+  user-select: none; /* avoid text selection during resize */
+  /* Optional: add a visible line or slight background for the handle */
+  background-color: rgba(0, 0, 0, 0);
+  transition: background-color 0.2s ease;
+  z-index: 1;
+}
+
+.resizer:hover,
+.resizer:active {
+  background-color: rgba(0, 0, 0, 0.2);
+}

--- a/frontend/packages/@depmap/react-table/tsconfig.json
+++ b/frontend/packages/@depmap/react-table/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "references": []
+}

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3204,6 +3204,30 @@
   resolved "https://registry.yarnpkg.com/@swc/types/-/types-0.1.4.tgz#8d647e111dc97a8e2881bf71c2ee2d011698ff10"
   integrity sha512-z/G02d+59gyyUb7KYhKi9jOhicek6QD2oMaotUyG+lUkybpXoV49dY9bj7Ah5Q+y7knK2jU67UTX9FyfGzaxQg==
 
+"@tanstack/react-table@^8.21.3":
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-table/-/react-table-8.21.3.tgz#2c38c747a5731c1a07174fda764b9c2b1fb5e91b"
+  integrity sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==
+  dependencies:
+    "@tanstack/table-core" "8.21.3"
+
+"@tanstack/react-virtual@^3.13.10":
+  version "3.13.12"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz#d372dc2783739cc04ec1a728ca8203937687a819"
+  integrity sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==
+  dependencies:
+    "@tanstack/virtual-core" "3.13.12"
+
+"@tanstack/table-core@8.21.3":
+  version "8.21.3"
+  resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.21.3.tgz#2977727d8fc8dfa079112d9f4d4c019110f1732c"
+  integrity sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==
+
+"@tanstack/virtual-core@3.13.12":
+  version "3.13.12"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz#1dff176df9cc8f93c78c5e46bcea11079b397578"
+  integrity sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==
+
 "@testing-library/dom@^7.28.1":
   version "7.31.2"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.31.2.tgz#df361db38f5212b88555068ab8119f5d841a8c4a"


### PR DESCRIPTION
This is a wrapper around V8 of @tanstack/react-table. That library is "headless" which means you have to implement the UI elements yourself, which I've done here.

This component is still at an experimental stage. Eventually it will serve as the basis for a new version of wide-table (which is still using V7 of @tanstack/react-table).