### PR TITLE
Wide Table: Prevent row selection from auto resetting column filters

### DIFF
--- a/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
+++ b/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
@@ -149,6 +149,7 @@ const ReactTableV7 = React.forwardRef(
         data,
         defaultColumn,
         autoResetSortBy: false,
+        autoResetFilters: false,
         initialState: {
           // https://github.com/TanStack/table/blob/v7/docs/src/pages/docs/api/useSortBy.md#table-options
           sortBy: initialSortBy,


### PR DESCRIPTION
Some of our Wide Table implementations allow users to select a row using a checkbox. Previously, if you filtered and then tried to select a row, everything would reset causing confusion as mentioned in this Asana task: https://app.asana.com/1/9513920295503/inbox/1200970789241572/item/1210835904454143/story/1210835800459550

Setting autoResetFilters to false lets a user filter and select rows without resetting the internal filter state.