### PR TITLE
feat(breadbox): Updated add_matrix_dataset to take an optional data_parquet field

### DIFF
--- a/breadbox-client/breadbox_facade/client.py
+++ b/breadbox-client/breadbox_facade/client.py
@@ -369,6 +369,7 @@ class BBClient:
 
         if upload_parquet:
             if data_parquet is None:
+                assert data_df is not None
                 with tempfile.NamedTemporaryFile() as tmp:
                     log_status(f"writing parquet")
                     data_df.to_parquet(tmp.name, index=False)
@@ -381,6 +382,7 @@ class BBClient:
 
             data_file_format=MatrixDatasetParamsDataFileFormat.PARQUET
         else:
+            assert data_df is not None, "If not using parquet, you must provide a dataframe"
             log_status("Writing CSV")
             buffer = io.BytesIO(data_df.to_csv(index=False).encode("utf8"))
             log_status(f"Uploading CSV")


### PR DESCRIPTION
A small change to breadbox_facade to allow us to provide a parquet file instead of a dataframe for those cases where the
dataset won't fit in memory at one time.

If data_parquet=filename and data_df=None, then it will upload the file directly instead of writing data_df to a temp file and uploading that.

Ideally, I'd make data_df optional and defaulted to None, but I'd need to change the signature of callers outside of this project.