### PR TITLE
Misc heatmap improvements

### DIFF
--- a/frontend/packages/portal-frontend/src/compound/CompoundDoseViability.scss
+++ b/frontend/packages/portal-frontend/src/compound/CompoundDoseViability.scss
@@ -28,11 +28,6 @@
       grid-area: "selections";
     }
 
-    .mainContentGridErrorMessage {
-      grid-area: "plot / plot / selections / selections";
-      width: "100%";
-    }
-
     @media (max-width: 950px) {
       grid-template-areas:
         "selections"

--- a/frontend/packages/portal-frontend/src/compound/doseCurvesTab/DoseCurvesMainContent.tsx
+++ b/frontend/packages/portal-frontend/src/compound/doseCurvesTab/DoseCurvesMainContent.tsx
@@ -181,13 +181,13 @@ function DoseCurvesMainContent({
           information. Click on items to select from the plot or table.
         </p>
       </div>
-      <div className={styles.mainContentGrid}>
-        {error ? (
-          <div className={styles.mainContentGridErrorMessage}>
-            Error loading dose curve data.
-          </div>
-        ) : (
-          <>
+      {error ? (
+        <div className={styles.errorMessage}>
+          Error loading dose curve data.
+        </div>
+      ) : (
+        <>
+          <div className={styles.mainContentGrid}>
             <div style={styles.plot}>
               <DoseCurvesPlotSection
                 isLoading={isLoading}
@@ -220,9 +220,9 @@ function DoseCurvesMainContent({
                 }
               />
             </div>
-          </>
-        )}
-      </div>
+          </div>{" "}
+        </>
+      )}
       <hr className={styles.mainContentHr} />
       <div className={styles.mainContentCellLines}>
         <h3>Cell Lines</h3>

--- a/frontend/packages/portal-frontend/src/compound/doseCurvesTab/DoseCurvesPlotSection.tsx
+++ b/frontend/packages/portal-frontend/src/compound/doseCurvesTab/DoseCurvesPlotSection.tsx
@@ -53,8 +53,20 @@ function DoseCurvesPlotSection({
     [curvesData]
   );
 
+  // HACK: so that Plotly will resize the plot when the user switches to this tab.
+  // Without this hack, if the plot loads while this tab is inactive, Plotly does not
+  // properly calculate plot size, and this can cause the plot to drastically overflow its bounds.
+  const [key, setKey] = React.useState(0);
+
+  React.useEffect(() => {
+    const handler = () => setKey((k) => k + 1);
+    window.addEventListener("changeTab:dose-curves-new", handler);
+    return () =>
+      window.removeEventListener("changeTab:dose-curves-new", handler);
+  }, []);
+
   return (
-    <div className={styles.PlotSection}>
+    <div className={styles.PlotSection} key={key}>
       <div className={styles.sectionHeader}>
         {plotElement && (
           <PlotControls

--- a/frontend/packages/portal-frontend/src/compound/heatmapTab/HeatmapPlotSection.tsx
+++ b/frontend/packages/portal-frontend/src/compound/heatmapTab/HeatmapPlotSection.tsx
@@ -121,8 +121,19 @@ function HeatmapPlotSection({
     handleSetSelectedPlotModels(next);
   };
 
+  // HACK: so that Plotly will resize the plot when the user switches to this tab.
+  // Without this hack, if the plot loads while this tab is inactive, Plotly does not
+  // properly calculate plot size, and this can cause the plot to drastically overflow its bounds.
+  const [key, setKey] = React.useState(0);
+
+  React.useEffect(() => {
+    const handler = () => setKey((k) => k + 1);
+    window.addEventListener("changeTab:heatmap", handler);
+    return () => window.removeEventListener("changeTab:heatmap", handler);
+  }, []);
+
   return (
-    <div className={styles.PlotSection}>
+    <div className={styles.PlotSection} key={key}>
       <div className={styles.sectionHeader}>
         {plotElement && (
           <PlotControls

--- a/frontend/packages/portal-frontend/src/compound/heatmapTab/HeatmapTabMainContent.tsx
+++ b/frontend/packages/portal-frontend/src/compound/heatmapTab/HeatmapTabMainContent.tsx
@@ -160,38 +160,46 @@ function HeatmapTabMainContent({
           plot or table.
         </p>
       </div>
-      <div className={styles.mainContentGrid}>
+      {error ? (
+        <div className={styles.errorMessage}>Error loading heatmap data.</div>
+      ) : (
         <>
-          <div className={styles.plotArea}>
-            <HeatmapPlotSection
-              isLoading={isLoading}
-              compoundName={compoundName}
-              plotElement={plotElement}
-              heatmapFormattedData={heatmapFormattedData}
-              doseMin={doseMin}
-              doseMax={doseMax}
-              doseUnits={doseUnits}
-              selectedModelIds={selectedModelIds}
-              handleSetSelectedPlotModels={handleSetSelectedPlotModels}
-              handleSetPlotElement={setPlotElement}
-              displayNameModelIdMap={displayNameModelIdMap}
-              visibleZIndexes={visibleZIndexes}
-              showUnselectedLines={showUnselectedLines}
-            />
-          </div>
-          <div className={styles.selectionsArea}>
-            <CompoundPlotSelections
-              selectedIds={selectedModelIds}
-              selectedLabels={new Set(selectedLabels)}
-              onClickSaveSelectionAsContext={handleClickSaveSelectionAsContext}
-              onClickClearSelection={handleClearSelection}
-              onClickSetSelectionFromContext={
-                heatmapFormattedData ? handleSetSelectionFromContext : undefined
-              }
-            />
-          </div>
+          <div className={styles.mainContentGrid}>
+            <div className={styles.plotArea}>
+              <HeatmapPlotSection
+                isLoading={isLoading}
+                compoundName={compoundName}
+                plotElement={plotElement}
+                heatmapFormattedData={heatmapFormattedData}
+                doseMin={doseMin}
+                doseMax={doseMax}
+                doseUnits={doseUnits}
+                selectedModelIds={selectedModelIds}
+                handleSetSelectedPlotModels={handleSetSelectedPlotModels}
+                handleSetPlotElement={setPlotElement}
+                displayNameModelIdMap={displayNameModelIdMap}
+                visibleZIndexes={visibleZIndexes}
+                showUnselectedLines={showUnselectedLines}
+              />
+            </div>
+            <div className={styles.selectionsArea}>
+              <CompoundPlotSelections
+                selectedIds={selectedModelIds}
+                selectedLabels={new Set(selectedLabels)}
+                onClickSaveSelectionAsContext={
+                  handleClickSaveSelectionAsContext
+                }
+                onClickClearSelection={handleClearSelection}
+                onClickSetSelectionFromContext={
+                  heatmapFormattedData
+                    ? handleSetSelectionFromContext
+                    : undefined
+                }
+              />
+            </div>
+          </div>{" "}
         </>
-      </div>
+      )}
       <hr className={styles.mainContentHr} />
       <div className={styles.mainContentCellLines}>
         <h3>Cell Lines</h3>


### PR DESCRIPTION
### Misc. Heatmap Improvements:
- **Needed an error message instead of an infinite plot spinner.** Also fixed the styling of the error message so that it is consistent between the dose curve and heatmap plot and table.
- **Add back and improved responsiveness of heatmap plot** - this was accidentally removed at one point. I discovered setting `autosize: true` on the plot layout is better than setting `responsiveness: true` because, in this case, we can keep the height of the plot constant. `responsiveness: true` caused the plot to jump around nonsensically on minimize/maximize of the page.
- **Added back the changeTab even listener hack for so that plotly can properly size hidden plots** - I had thought I could remove the changeTab event listener hack for sizing the plots. This was added so that Plotly will only try to size the plot when the user clicks on the tab. I thought lazy loading the tabs avoided this problem, but the problem still exists in this use case: if you resize your window on one tab after dose curves has already been loaded, then switch back to dose curves, the plot will be too small.


**Upcoming in a future PR:** Resetting plot/table selections on switch of the selected dataset.
 