### PR TITLE
Remove IC50 references from portal-backend

### DIFF
--- a/frontend/packages/portal-frontend/src/compound/components/DoseResponseTab.tsx
+++ b/frontend/packages/portal-frontend/src/compound/components/DoseResponseTab.tsx
@@ -271,13 +271,6 @@ class DoseResponseTab extends React.Component<DoseResponseProps, State> {
       : [];
     columns.sort((a, b) => parseFloat(a.key) - parseFloat(b.key));
     const table = this.state.doseResponseTable;
-    if (table && "ic50" in table[0]) {
-      columns.unshift({
-        key: "ic50",
-        type: "continuous",
-        displayName: "IC50",
-      });
-    }
     columns.unshift({
       key: "auc",
       type: "continuous",

--- a/portal-backend/depmap/cli_commands/db_load_commands.py
+++ b/portal-backend/depmap/cli_commands/db_load_commands.py
@@ -1000,16 +1000,13 @@ def load_sample_data(
             DependencyEnum.RNAi_Nov_DEM,
             DependencyEnum.RNAi_merged,
             DependencyEnum.GDSC1_AUC,
-            DependencyEnum.GDSC1_IC50,
             DependencyEnum.GDSC2_AUC,
-            DependencyEnum.GDSC2_IC50,
             DependencyEnum.CTRP_AUC,
             DependencyEnum.Repurposing_secondary_AUC,
             DependencyEnum.Repurposing_secondary_dose,
             DependencyEnum.Rep1M,
             DependencyEnum.Rep_all_single_pt,
             DependencyEnum.Prism_oncology_AUC,
-            DependencyEnum.Prism_oncology_IC50,
         ]
 
     if load_taiga_dependencies:

--- a/portal-backend/depmap/compound/views/executive.py
+++ b/portal-backend/depmap/compound/views/executive.py
@@ -287,7 +287,7 @@ def format_availability_tile(compound: Compound):
     appears in. This does NOT load the full list of datasets, but instead
     returns a curated subset that users are most interested in. 
     For example, we want to show whether there is "Repurposing" data, but don't need
-    to list all of the oncref datasets (AUC, IC50, etc.).
+    to list all of the oncref datasets (AUC, etc.).
     """
     compound_id = compound.compound_id
     # First, load ALL portal datasets containing the compound (for performance reasons).

--- a/portal-backend/depmap/compound/views/index.py
+++ b/portal-backend/depmap/compound/views/index.py
@@ -413,7 +413,6 @@ def dose_table(dataset_name, xref_full):
               "9-2":0.1122418195,
               "cell_line_display_name":"HT29",
               "auc":0.8729583436,
-              "ic50":null  # ic50 may optionally not be present if there is no ic50 dataset
            },
            "ACH-000279":{
               ...
@@ -476,11 +475,6 @@ def dose_table(dataset_name, xref_full):
     if auc_data is not None:
         df = df.merge(auc_data, left_index=True, right_index=True, how="left")
 
-    #### IC50
-    ic50_data = get_ic50_data(dataset_name, compound_experiment)
-    if ic50_data is not None:
-        df = df.merge(ic50_data, left_index=True, right_index=True, how="left")
-
     df = df.T
     return df.to_json()
 
@@ -505,31 +499,6 @@ def get_auc_data(dataset_name, compound_experiment):
         )
         auc_data.index.name = "depmap_id"
         return auc_data
-    else:
-        return None
-
-
-def get_ic50_data(dataset_name, compound_experiment):
-    dataset_to_ic50 = {
-        DependencyEnum.GDSC1_dose_replicate.name: DependencyEnum.GDSC1_IC50,
-        DependencyEnum.GDSC2_dose_replicate.name: DependencyEnum.GDSC2_IC50,
-        DependencyEnum.Prism_oncology_IC50.name: DependencyEnum.Prism_oncology_IC50,
-    }
-    if dataset_name in dataset_to_ic50 and DependencyDataset.has_entity(
-        dataset_to_ic50[dataset_name], compound_experiment.entity_id
-    ):
-        ic50_dataset_name = dataset_to_ic50[dataset_name].name
-        ic50_dataset = Dataset.get_dataset_by_name(ic50_dataset_name)
-        assert ic50_dataset is not None
-        ic50_matrix = ic50_dataset.matrix
-        ic50_data = ic50_matrix.get_cell_line_values_and_depmap_ids(
-            compound_experiment.entity_id
-        )
-        ic50_data = pd.DataFrame.from_dict(
-            ic50_data.to_dict(), orient="index", columns=["ic50"]
-        )
-        ic50_data.index.name = "depmap_id"
-        return ic50_data
     else:
         return None
 

--- a/portal-backend/depmap/context_explorer/box_plot_utils.py
+++ b/portal-backend/depmap/context_explorer/box_plot_utils.py
@@ -551,8 +551,8 @@ def get_compound_experiment_and_dataset_name_from_compound(compound: Compound):
     compound_experiment_and_datasets = [
         x
         for x in compound_experiment_and_datasets
-        if not x[1].is_ic50 and not x[1].is_dose_replicate
-    ]  # filter for non ic50 or dose replicate datasets"
+        if not x[1].is_dose_replicate
+    ]  # filter for non dose replicate datasets"
     best_ce_and_d = temp_get_compound_experiment_dataset(
         compound_experiment_and_datasets
     )

--- a/portal-backend/depmap/dataset/models.py
+++ b/portal-backend/depmap/dataset/models.py
@@ -109,10 +109,6 @@ class Dataset(Model):
         return DATASET_METADATA[self.name].nominal_range
 
     @property
-    def is_ic50(self):
-        return self.units == "log2(IC50) (μM)" or self.units == "ln(IC50) (μM)"
-
-    @property
     def is_compound_experiment(self):
         return enums.DependencyEnum.is_compound_experiment_enum(self.name)
 

--- a/portal-backend/depmap/enums.py
+++ b/portal-backend/depmap/enums.py
@@ -34,8 +34,6 @@ class DependencyEnum(DatasetEnum):
     # Drug datasets
     GDSC1_AUC = "GDSC1_AUC"
     GDSC2_AUC = "GDSC2_AUC"
-    GDSC1_IC50 = "GDSC1_IC50"
-    GDSC2_IC50 = "GDSC2_IC50"
     CTRP_AUC = "CTRP_AUC"
     Repurposing_secondary_AUC = "Repurposing_secondary_AUC"
 
@@ -47,7 +45,6 @@ class DependencyEnum(DatasetEnum):
     Rep1M = "Rep1M"
     Rep_all_single_pt = "Rep_all_single_pt"
     Prism_oncology_AUC = "Prism_oncology_AUC"
-    Prism_oncology_IC50 = "Prism_oncology_IC50"
     Prism_oncology_dose_replicate = "Prism_oncology_dose_replicate"
 
     @staticmethod
@@ -62,15 +59,12 @@ class DependencyEnum(DatasetEnum):
         # TODO: Unhardcode
         return dataset_enum in {
             DependencyEnum.GDSC1_AUC,
-            DependencyEnum.GDSC1_IC50,
             DependencyEnum.GDSC2_AUC,
-            DependencyEnum.GDSC2_IC50,
             DependencyEnum.CTRP_AUC,
             DependencyEnum.Repurposing_secondary_AUC,
             DependencyEnum.Rep1M,
             DependencyEnum.Rep_all_single_pt,
             DependencyEnum.Prism_oncology_AUC,
-            DependencyEnum.Prism_oncology_IC50,
         }
 
 

--- a/portal-backend/depmap/settings/dev.py
+++ b/portal-backend/depmap/settings/dev.py
@@ -34,16 +34,8 @@ additional_dev_metadata = {
         "matrix_file_name_root": "dataset/gdsc1-auc",
         "taiga_id": "placeholder-gdsc-id.1",
     },
-    DependencyEnum.GDSC1_IC50: {
-        "matrix_file_name_root": "dataset/gdsc1-ic50",
-        "taiga_id": "placeholder-gdsc-id.1",
-    },
     DependencyEnum.GDSC2_AUC: {
         "matrix_file_name_root": "dataset/gdsc2-auc",
-        "taiga_id": "placeholder-gdsc-id.1",
-    },
-    DependencyEnum.GDSC2_IC50: {
-        "matrix_file_name_root": "dataset/gdsc2-ic50",
         "taiga_id": "placeholder-gdsc-id.1",
     },
     DependencyEnum.GDSC1_dose_replicate: {
@@ -92,10 +84,6 @@ additional_dev_metadata = {
     },
     DependencyEnum.Prism_oncology_AUC: {
         "matrix_file_name_root": "dataset/prism-oncology-auc",
-        "taiga_id": "placeholder-onc-id.1",
-    },
-    DependencyEnum.Prism_oncology_IC50: {
-        "matrix_file_name_root": "dataset/prism-oncology-ic50",
         "taiga_id": "placeholder-onc-id.1",
     },
     DependencyEnum.Prism_oncology_dose_replicate: {

--- a/portal-backend/depmap/settings/shared.py
+++ b/portal-backend/depmap/settings/shared.py
@@ -282,21 +282,11 @@ DATASET_METADATA: Dict[
         data_type=DataTypeEnum.drug_screen,
         nominal_range=(0, 1.1),
     ),
-    DependencyEnum.GDSC1_IC50: DepDatasetMeta(
-        display_name="Drug sensitivity IC50 (Sanger GDSC1)",
-        units="ln(IC50) (μM)",
-        data_type=DataTypeEnum.drug_screen,
-    ),
     DependencyEnum.GDSC2_AUC: DepDatasetMeta(
         display_name="Drug sensitivity AUC (Sanger GDSC2)",
         units="AUC",
         data_type=DataTypeEnum.drug_screen,
         nominal_range=(0, 1.1),
-    ),
-    DependencyEnum.GDSC2_IC50: DepDatasetMeta(
-        display_name="Drug sensitivity IC50 (Sanger GDSC2)",
-        units="ln(IC50) (μM)",
-        data_type=DataTypeEnum.drug_screen,
     ),
     DependencyEnum.GDSC1_dose_replicate: DepDatasetMeta(
         display_name="Drug sensitivity replicate-level dose (Sanger GDSC1)",
@@ -359,11 +349,6 @@ DATASET_METADATA: Dict[
         data_type=DataTypeEnum.drug_screen,
         nominal_range=(0, 1.1),
         priority=1,
-    ),
-    DependencyEnum.Prism_oncology_IC50: DepDatasetMeta(
-        display_name="PRISM OncRef IC50",  # display name overridden by dataset display name artifact
-        units="log2(IC50) (μM)",
-        data_type=DataTypeEnum.drug_screen,
     ),
     DependencyEnum.Prism_oncology_dose_replicate: DepDatasetMeta(
         display_name="PRISM OncRef Dose Replicate",

--- a/portal-backend/depmap/static/morpheus/morpheus-latest.min.js
+++ b/portal-backend/depmap/static/morpheus/morpheus-latest.min.js
@@ -11585,11 +11585,6 @@
           help: "CCLE Reverse Phase Protein Array (RPPA) data"
         });
         depMapDatasets.push({
-          name: "DRUG SENSITIVITY IC50",
-          file: "portal-GDSC_IC50-2018-05-07.csv",
-          help: "Fitted dose response data, log(IC50) values"
-        });
-        depMapDatasets.push({
           name: "DRUG SENSITIVITY AUC",
           file: "portal-GDSC_AUC-2018-05-07.csv",
           help: "Fitted dose response data, AUC values"

--- a/portal-backend/depmap/tile/views.py
+++ b/portal-backend/depmap/tile/views.py
@@ -92,8 +92,8 @@ def render_tile(subject_type, tile_name, identifier):
         compound_experiment_and_datasets = [
             x
             for x in compound_experiment_and_datasets
-            if not x[1].is_ic50 and not x[1].is_dose_replicate
-        ]  # filter for non ic50 or dose replicate datasets
+            if not x[1].is_dose_replicate
+        ]  # filter for non dose replicate datasets
 
         rendered_tile = render_compound_tile(
             tile_name, compound, compound_experiment_and_datasets, args_dict

--- a/portal-backend/loader/dataset_loader/single_input_file_dependency_loader.py
+++ b/portal-backend/loader/dataset_loader/single_input_file_dependency_loader.py
@@ -14,7 +14,7 @@ def load_single_input_file_dependency_dataset(
 ):
     """
     This is used for loading things in the config that are in the dep_datasets list
-    These include CRISPR and RNAi datasets with gene entities, and AUC and IC50 datasets with compound experiment entities
+    These include CRISPR and RNAi datasets with gene entities, and AUC datasets with compound experiment entities
     This is NOT used for loading e.g. compound dose replicate datasets, even though they have a DependencyDataset enum
     """
     if "matrix_file_name_root" in dataset_metadata:

--- a/portal-backend/tests/conftest.py
+++ b/portal-backend/tests/conftest.py
@@ -485,24 +485,12 @@ def load_populated_db_data():
                 "matrix_file_name_root": "dataset/gdsc1-auc",
                 "taiga_id": "placeholder-taiga-id.1",
             },
-            DependencyDataset.DependencyEnum.GDSC1_IC50: {
-                "matrix_file_name_root": "dataset/gdsc1-auc",
-                "taiga_id": "placeholder-taiga-id.1",
-            },
             DependencyDataset.DependencyEnum.GDSC2_AUC: {
-                "matrix_file_name_root": "dataset/gdsc2-auc",
-                "taiga_id": "placeholder-taiga-id.1",
-            },
-            DependencyDataset.DependencyEnum.GDSC2_IC50: {
                 "matrix_file_name_root": "dataset/gdsc2-auc",
                 "taiga_id": "placeholder-taiga-id.1",
             },
             DependencyDataset.DependencyEnum.Prism_oncology_AUC: {
                 "matrix_file_name_root": "dataset/prism-oncology-auc",
-                "taiga_id": "placeholder-taiga-id.1",
-            },
-            DependencyDataset.DependencyEnum.Prism_oncology_IC50: {
-                "matrix_file_name_root": "dataset/prism-oncology-ic50",
                 "taiga_id": "placeholder-taiga-id.1",
             },
             DependencyDataset.DependencyEnum.Avana: {

--- a/portal-backend/tests/depmap/compound/views/test_index.py
+++ b/portal-backend/tests/depmap/compound/views/test_index.py
@@ -62,7 +62,7 @@ def test_format_compound_summary(empty_db_mock_downloads):
 
     matrix = MatrixFactory(entities=[compound_exp_1, compound_exp_2])
     dataset = DependencyDatasetFactory(
-        matrix=matrix, name=DependencyDataset.DependencyEnum.GDSC1_IC50
+        matrix=matrix, name=DependencyDataset.DependencyEnum.GDSC1_AUC
     )  # no dose dataset
     empty_db_mock_downloads.session.flush()
     interactive_test_utils.reload_interactive_config()
@@ -236,17 +236,13 @@ def test_format_dose_curve_multiple_curves(empty_db_mock_downloads):
     assert len(curve_params) == 2
 
 
-@pytest.mark.parametrize(
-    "has_ic50_dataset, has_ic50_row", [(True, True), (True, False), (False, False),],
-)
-def test_dose_table(empty_db_mock_downloads, app, has_ic50_dataset, has_ic50_row):
+def test_dose_table(empty_db_mock_downloads, app):
     # define inputs to factories and function calls
     cell_line_name = "CADOES1_BONE"
     cell_line_display_name = "CADOES1"
     xref_type = "CTRP"
     xref = "606135"
     xref_full = xref_type + ":" + xref
-    ic50_value = 0.4
 
     model = DepmapModelFactory(
         cell_line_name=cell_line_name, stripped_cell_line_name=cell_line_display_name
@@ -290,24 +286,6 @@ def test_dose_table(empty_db_mock_downloads, app, has_ic50_dataset, has_ic50_row
             using_depmap_model_table=True,
         ),
     )
-
-    if has_ic50_dataset:
-        if has_ic50_row:
-            matrix = MatrixFactory(
-                entities=[cpd_exp],
-                cell_lines=[model],
-                data=pd.DataFrame(
-                    {model.cell_line_name: [ic50_value]},
-                    index=["cpd_exp"]
-                    # I believe this index doesn't do anything? has to do with order that entities=[] is passed in?
-                ),
-                using_depmap_model_table=True,
-            )
-        else:
-            matrix = MatrixFactory()
-        ic50_dataset = DependencyDatasetFactory(
-            name=DependencyDataset.DependencyEnum.GDSC1_IC50, matrix=matrix
-        )
 
     auc_dataset = DependencyDatasetFactory(
         name=DependencyDataset.DependencyEnum.GDSC1_AUC,
@@ -368,9 +346,6 @@ def test_dose_table(empty_db_mock_downloads, app, has_ic50_dataset, has_ic50_row
                 "auc": 0.5,
             }
         }
-
-        if has_ic50_dataset and has_ic50_row:
-            expected[model.model_id]["ic50"] = ic50_value
 
         assert response == expected
 

--- a/portal-backend/tests/factories.py
+++ b/portal-backend/tests/factories.py
@@ -688,9 +688,7 @@ class DependencyDatasetFactory(DatasetFactory):
             lambda: "gene",
             {
                 DependencyDataset.DependencyEnum.GDSC1_AUC: "compound_experiment",
-                DependencyDataset.DependencyEnum.GDSC1_IC50: "compound_experiment",
                 DependencyDataset.DependencyEnum.GDSC2_AUC: "compound_experiment",
-                DependencyDataset.DependencyEnum.GDSC2_IC50: "compound_experiment",
                 DependencyDataset.DependencyEnum.CTRP_AUC: "compound_experiment",
                 DependencyDataset.DependencyEnum.Rep_all_single_pt: "compound_experiment",
                 DependencyDataset.DependencyEnum.Repurposing_secondary_AUC: "compound_experiment",
@@ -698,7 +696,6 @@ class DependencyDatasetFactory(DatasetFactory):
                 DependencyDataset.DependencyEnum.Repurposing_secondary_dose_replicate: "compound_dose_replicate",
                 DependencyDataset.DependencyEnum.CTRP_dose_replicate: "compound_dose_replicate",
                 DependencyDataset.DependencyEnum.Prism_oncology_AUC: "compound_experiment",
-                DependencyDataset.DependencyEnum.Prism_oncology_IC50: "compound_experiment",
                 DependencyDataset.DependencyEnum.Prism_oncology_dose_replicate: "compound_dose_replicate",
             },
         )[o.name]


### PR DESCRIPTION
[Asana](https://app.asana.com/1/9513920295503/project/1165651979405609/task/1210880278875823?focus=true)

These changes remove all references to "IC50" from both the `portal-backend` and the `frontend` code. It seems like the AUC drug screen datasets were already being used as the default in all of the cases I've seen - and will continue to be used as the default data for those features. 

These IC50 drug screen datasets have already been removed from breadbox, and the next step will be to remove them from the pipeline as well. 