### PR TITLE
Fix error caused by heatmap/dose curves if dataset does not exist in breadbox

### DIFF
--- a/portal-backend/depmap/compound/views/index.py
+++ b/portal-backend/depmap/compound/views/index.py
@@ -221,7 +221,9 @@ def format_dose_curve_options_new_tab_if_available(compound_label: str):
     valid_options = []
     if show_new_dose_curves_tab:
         for drc_dataset in drc_compound_datasets:
-            if data_access.valid_bb_row(
+            if data_access.dataset_exists(
+                drc_dataset.auc_dataset_given_id
+            ) and data_access.valid_row(
                 drc_dataset.auc_dataset_given_id, compound_label
             ):
                 # TODO: Take this check out once the legacy db old drug datasets are updated to use the processed taiga ids.
@@ -242,7 +244,9 @@ def format_heatmap_options_new_tab_if_available(compound_label: str):
     valid_options = []
     if show_heatmap_tab:
         for drc_dataset in drc_compound_datasets:
-            if data_access.valid_bb_row(
+            if data_access.dataset_exists(
+                drc_dataset.auc_dataset_given_id
+            ) and data_access.valid_row(
                 drc_dataset.auc_dataset_given_id, compound_label
             ):
                 # TODO: Take this check out once the legacy db old drug datasets are updated to use the processed taiga ids.

--- a/portal-backend/depmap/compound/views/index.py
+++ b/portal-backend/depmap/compound/views/index.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 from typing import Any, List, Optional
 import zipfile
+from depmap.interactive import interactive_utils
 import requests
 import urllib.parse
 
@@ -219,6 +220,7 @@ def format_dose_curve_options_new_tab_if_available(compound_label: str):
     ].new_compound_page_tabs
 
     valid_options = []
+
     if show_new_dose_curves_tab:
         for drc_dataset in drc_compound_datasets:
             if data_access.dataset_exists(
@@ -242,6 +244,7 @@ def format_heatmap_options_new_tab_if_available(compound_label: str):
     show_heatmap_tab = current_app.config["ENABLED_FEATURES"].new_compound_page_tabs
 
     valid_options = []
+
     if show_heatmap_tab:
         for drc_dataset in drc_compound_datasets:
             if data_access.dataset_exists(

--- a/portal-backend/depmap/compound/views/index.py
+++ b/portal-backend/depmap/compound/views/index.py
@@ -4,7 +4,6 @@ import os
 import tempfile
 from typing import Any, List, Optional
 import zipfile
-from depmap.interactive import interactive_utils
 import requests
 import urllib.parse
 
@@ -220,7 +219,6 @@ def format_dose_curve_options_new_tab_if_available(compound_label: str):
     ].new_compound_page_tabs
 
     valid_options = []
-
     if show_new_dose_curves_tab:
         for drc_dataset in drc_compound_datasets:
             if data_access.dataset_exists(
@@ -244,7 +242,6 @@ def format_heatmap_options_new_tab_if_available(compound_label: str):
     show_heatmap_tab = current_app.config["ENABLED_FEATURES"].new_compound_page_tabs
 
     valid_options = []
-
     if show_heatmap_tab:
         for drc_dataset in drc_compound_datasets:
             if data_access.dataset_exists(

--- a/portal-backend/depmap/compound/views/index.py
+++ b/portal-backend/depmap/compound/views/index.py
@@ -221,7 +221,9 @@ def format_dose_curve_options_new_tab_if_available(compound_label: str):
     valid_options = []
     if show_new_dose_curves_tab:
         for drc_dataset in drc_compound_datasets:
-            if data_access.valid_row(drc_dataset.auc_dataset_given_id, compound_label):
+            if data_access.valid_bb_row(
+                drc_dataset.auc_dataset_given_id, compound_label
+            ):
                 # TODO: Take this check out once the legacy db old drug datasets are updated to use the processed taiga ids.
                 if (
                     drc_dataset.auc_dataset_given_id == "Prism_oncology_AUC_collapsed"
@@ -240,7 +242,9 @@ def format_heatmap_options_new_tab_if_available(compound_label: str):
     valid_options = []
     if show_heatmap_tab:
         for drc_dataset in drc_compound_datasets:
-            if data_access.valid_row(drc_dataset.auc_dataset_given_id, compound_label):
+            if data_access.valid_bb_row(
+                drc_dataset.auc_dataset_given_id, compound_label
+            ):
                 # TODO: Take this check out once the legacy db old drug datasets are updated to use the processed taiga ids.
                 if (
                     drc_dataset.auc_dataset_given_id == "Prism_oncology_AUC_collapsed"

--- a/portal-backend/depmap/data_access/__init__.py
+++ b/portal-backend/depmap/data_access/__init__.py
@@ -18,6 +18,7 @@ from .interface import (
     get_slice_data,
     is_categorical,
     is_continuous,
+    dataset_exists,
     # compound-specific methods
     get_all_datasets_containing_compound,
     get_subsetted_df_by_labels_compound_friendly,
@@ -32,6 +33,4 @@ from .interface import (
     get_custom_cell_lines_dataset,
     get_metadata_dataset_id,
     has_config,
-    # Breadbox specific
-    valid_bb_row,
 )

--- a/portal-backend/depmap/data_access/__init__.py
+++ b/portal-backend/depmap/data_access/__init__.py
@@ -32,4 +32,6 @@ from .interface import (
     get_custom_cell_lines_dataset,
     get_metadata_dataset_id,
     has_config,
+    # Breadbox specific
+    valid_bb_row,
 )

--- a/portal-backend/depmap/data_access/interface.py
+++ b/portal-backend/depmap/data_access/interface.py
@@ -262,7 +262,7 @@ def valid_row(dataset_id: str, row_name: str) -> bool:
     """
     Check whether the given entity label exists in the given dataset.
     """
-    if is_breadbox_id(dataset_id):
+    if breadbox_dao.is_breadbox_id(dataset_id):
         return breadbox_dao.valid_row(dataset_id, row_name)
     return interactive_utils.valid_row(dataset_id, row_name)
 

--- a/portal-backend/depmap/data_access/interface.py
+++ b/portal-backend/depmap/data_access/interface.py
@@ -249,6 +249,15 @@ def is_continuous(dataset_id: str) -> bool:
     return interactive_utils.is_continuous(dataset_id)
 
 
+def dataset_exists(dataset_id: str) -> bool:
+    """
+    Check whether the given dataset exists in either the legacy or breadbox databases.
+    """
+    return interactive_utils.has_config(dataset_id) or breadbox_dao.is_breadbox_id(
+        dataset_id
+    )
+
+
 def valid_row(dataset_id: str, row_name: str) -> bool:
     """
     Check whether the given entity label exists in the given dataset.
@@ -367,16 +376,6 @@ def get_subsetted_df_by_labels_compound_friendly(dataset_id: str) -> pd.DataFram
 ##################################################
 # METHODS BELOW ARE ONLY SUPPORTABLE BY BREADBOX #
 ##################################################
-
-
-def valid_bb_row(dataset_id: str, row_name: str) -> bool:
-    """
-    Check whether a breadbox dataset exists with the given entity label in the given dataset.
-    """
-    if is_breadbox_id(dataset_id):
-        return breadbox_dao.valid_row(dataset_id, row_name)
-
-    return False
 
 
 def get_tabular_dataset_column(dataset_id: str, column_name: str) -> pd.Series:

--- a/portal-backend/depmap/data_access/interface.py
+++ b/portal-backend/depmap/data_access/interface.py
@@ -369,6 +369,16 @@ def get_subsetted_df_by_labels_compound_friendly(dataset_id: str) -> pd.DataFram
 ##################################################
 
 
+def valid_bb_row(dataset_id: str, row_name: str) -> bool:
+    """
+    Check whether a breadbox dataset exists with the given entity label in the given dataset.
+    """
+    if is_breadbox_id(dataset_id):
+        return breadbox_dao.valid_row(dataset_id, row_name)
+
+    return False
+
+
 def get_tabular_dataset_column(dataset_id: str, column_name: str) -> pd.Series:
     """
     Get a column of values from the given tabular dataset. 

--- a/portal-backend/tests/depmap/compound/views/test_index.py
+++ b/portal-backend/tests/depmap/compound/views/test_index.py
@@ -41,7 +41,7 @@ def test_render_view_compound(populated_db, monkeypatch):
         def mock_valid_row(a, b):
             return True
 
-        monkeypatch.setattr(data_access, "valid_row", mock_valid_row)
+        monkeypatch.setattr(data_access, "valid_bb_row", mock_valid_row)
         for compound in Compound.query.all():
             r = c.get(url_for("compound.view_compound", name=compound.label))
             assert r.status_code == 200, "{} with response code {}".format(

--- a/portal-backend/tests/depmap/compound/views/test_index.py
+++ b/portal-backend/tests/depmap/compound/views/test_index.py
@@ -41,11 +41,16 @@ def test_render_view_compound(populated_db, monkeypatch):
         def mock_valid_row(a, b):
             return True
 
-        def mock_dataset_exists(dataset_id):
+        def mock_has_config(dataset_id):
+            return False
+
+        def mock_is_breadbox_id(dataset_id):
             return True
 
-        monkeypatch.setattr(data_access, "valid_row", mock_valid_row)
-        monkeypatch.setattr(data_access, "dataset_exists", mock_dataset_exists)
+        monkeypatch.setattr(breadbox_dao, "valid_row", mock_valid_row)
+        monkeypatch.setattr(breadbox_dao, "is_breadbox_id", mock_is_breadbox_id)
+        monkeypatch.setattr(interactive_utils, "has_config", mock_has_config)
+
         for compound in Compound.query.all():
             r = c.get(url_for("compound.view_compound", name=compound.label))
             assert r.status_code == 200, "{} with response code {}".format(
@@ -461,11 +466,16 @@ def test_format_dose_curve_and_heatmap_options_new_tab_if_available_true(
         def mock_valid_row(a, b):
             return True
 
-        def mock_dataset_exists(dataset_id):
+        def mock_has_config(dataset_id):
+            return False
+
+        def mock_is_breadbox_id(dataset_id):
             return True
 
-        monkeypatch.setattr(data_access, "valid_row", mock_valid_row)
-        monkeypatch.setattr(data_access, "dataset_exists", mock_dataset_exists)
+        monkeypatch.setattr(breadbox_dao, "valid_row", mock_valid_row)
+        monkeypatch.setattr(breadbox_dao, "is_breadbox_id", mock_is_breadbox_id)
+        monkeypatch.setattr(interactive_utils, "has_config", mock_has_config)
+
         result = format_dose_curve_options_new_tab_if_available(CompoundFactory().label)
         assert isinstance(result, list)
 
@@ -487,11 +497,16 @@ def test_format_heatmap_options_new_tab_if_available_true(app, monkeypatch):
         def mock_valid_row(a, b):
             return True
 
-        def mock_dataset_exists(dataset_id):
+        def mock_has_config(dataset_id):
+            return False
+
+        def mock_is_breadbox_id(dataset_id):
             return True
 
-        monkeypatch.setattr(data_access, "valid_row", mock_valid_row)
-        monkeypatch.setattr(data_access, "dataset_exists", mock_dataset_exists)
+        monkeypatch.setattr(breadbox_dao, "valid_row", mock_valid_row)
+        monkeypatch.setattr(breadbox_dao, "is_breadbox_id", mock_is_breadbox_id)
+        monkeypatch.setattr(interactive_utils, "has_config", mock_has_config)
+
         # TODO: Update when more datasets are available and the legacy db has been
         # updated with the processed versions of older drug datasets.
         result = format_heatmap_options_new_tab_if_available(CompoundFactory().label)
@@ -526,11 +541,16 @@ def test_dose_curve_options_all_datasets_available(app, monkeypatch):
         def mock_valid_row(a, b):
             return True
 
-        def mock_dataset_exists(dataset_id):
+        def mock_has_config(dataset_id):
+            return False
+
+        def mock_is_breadbox_id(dataset_id):
             return True
 
-        monkeypatch.setattr(data_access, "valid_row", mock_valid_row)
-        monkeypatch.setattr(data_access, "dataset_exists", mock_dataset_exists)
+        monkeypatch.setattr(breadbox_dao, "valid_row", mock_valid_row)
+        monkeypatch.setattr(breadbox_dao, "is_breadbox_id", mock_is_breadbox_id)
+        monkeypatch.setattr(interactive_utils, "has_config", mock_has_config)
+
         result = format_dose_curve_options_new_tab_if_available(CompoundFactory().label)
         assert isinstance(result, list)
         assert result == drc_compound_datasets

--- a/portal-backend/tests/depmap/compound/views/test_index.py
+++ b/portal-backend/tests/depmap/compound/views/test_index.py
@@ -1,3 +1,5 @@
+from depmap.data_access import breadbox_dao
+from depmap.interactive import interactive_utils
 from depmap.settings.settings import TestConfig
 import pandas as pd
 import pytest
@@ -455,7 +457,7 @@ def test_format_dose_curve_and_heatmap_options_new_tab_if_available_true(
         def mock_valid_row(a, b):
             return True
 
-        monkeypatch.setattr(data_access, "valid_row", mock_valid_row)
+        monkeypatch.setattr(data_access, "valid_bb_row", mock_valid_row)
         result = format_dose_curve_options_new_tab_if_available(CompoundFactory().label)
         assert isinstance(result, list)
 
@@ -477,7 +479,7 @@ def test_format_heatmap_options_new_tab_if_available_true(app, monkeypatch):
         def mock_valid_row(a, b):
             return True
 
-        monkeypatch.setattr(data_access, "valid_row", mock_valid_row)
+        monkeypatch.setattr(data_access, "valid_bb_row", mock_valid_row)
         # TODO: Update when more datasets are available and the legacy db has been
         # updated with the processed versions of older drug datasets.
         result = format_heatmap_options_new_tab_if_available(CompoundFactory().label)
@@ -512,7 +514,7 @@ def test_dose_curve_options_all_datasets_available(app, monkeypatch):
         def mock_valid_row(a, b):
             return True
 
-        monkeypatch.setattr(data_access, "valid_row", mock_valid_row)
+        monkeypatch.setattr(data_access, "valid_bb_row", mock_valid_row)
         result = format_dose_curve_options_new_tab_if_available(CompoundFactory().label)
         assert isinstance(result, list)
         assert result == drc_compound_datasets

--- a/portal-backend/tests/depmap/compound/views/test_index.py
+++ b/portal-backend/tests/depmap/compound/views/test_index.py
@@ -41,7 +41,11 @@ def test_render_view_compound(populated_db, monkeypatch):
         def mock_valid_row(a, b):
             return True
 
-        monkeypatch.setattr(data_access, "valid_bb_row", mock_valid_row)
+        def mock_dataset_exists(dataset_id):
+            return True
+
+        monkeypatch.setattr(data_access, "valid_row", mock_valid_row)
+        monkeypatch.setattr(data_access, "dataset_exists", mock_dataset_exists)
         for compound in Compound.query.all():
             r = c.get(url_for("compound.view_compound", name=compound.label))
             assert r.status_code == 200, "{} with response code {}".format(
@@ -457,7 +461,11 @@ def test_format_dose_curve_and_heatmap_options_new_tab_if_available_true(
         def mock_valid_row(a, b):
             return True
 
-        monkeypatch.setattr(data_access, "valid_bb_row", mock_valid_row)
+        def mock_dataset_exists(dataset_id):
+            return True
+
+        monkeypatch.setattr(data_access, "valid_row", mock_valid_row)
+        monkeypatch.setattr(data_access, "dataset_exists", mock_dataset_exists)
         result = format_dose_curve_options_new_tab_if_available(CompoundFactory().label)
         assert isinstance(result, list)
 
@@ -479,7 +487,11 @@ def test_format_heatmap_options_new_tab_if_available_true(app, monkeypatch):
         def mock_valid_row(a, b):
             return True
 
-        monkeypatch.setattr(data_access, "valid_bb_row", mock_valid_row)
+        def mock_dataset_exists(dataset_id):
+            return True
+
+        monkeypatch.setattr(data_access, "valid_row", mock_valid_row)
+        monkeypatch.setattr(data_access, "dataset_exists", mock_dataset_exists)
         # TODO: Update when more datasets are available and the legacy db has been
         # updated with the processed versions of older drug datasets.
         result = format_heatmap_options_new_tab_if_available(CompoundFactory().label)
@@ -514,7 +526,11 @@ def test_dose_curve_options_all_datasets_available(app, monkeypatch):
         def mock_valid_row(a, b):
             return True
 
-        monkeypatch.setattr(data_access, "valid_bb_row", mock_valid_row)
+        def mock_dataset_exists(dataset_id):
+            return True
+
+        monkeypatch.setattr(data_access, "valid_row", mock_valid_row)
+        monkeypatch.setattr(data_access, "dataset_exists", mock_dataset_exists)
         result = format_dose_curve_options_new_tab_if_available(CompoundFactory().label)
         assert isinstance(result, list)
         assert result == drc_compound_datasets


### PR DESCRIPTION
Jessica brought to my attention that data_access.valid_row will throw an error if the dataset is not a Breadbox dataset:
`ValueError: Invalid dataset GDSC2_AUC_collapsed; not in the config`.

I realized the drc_compound_datasets are only ever Breadbox datasets, so I solved this problem by adding a Breadbox specific data_access.valid_bb_row. The goal was to return False if (1) the dataset does not exist at all in Breadbox, or (2) the compound does not exist in that particular dataset.

I'm open to suggestions if people would prefer we do this differently.