### PR TITLE
Add shift click to the Heatmap plot

### DIFF
--- a/frontend/packages/portal-frontend/src/compound/doseCurvesTab/DoseCurvesMainContent.tsx
+++ b/frontend/packages/portal-frontend/src/compound/doseCurvesTab/DoseCurvesMainContent.tsx
@@ -176,6 +176,7 @@ function DoseCurvesMainContent({
           Each cell line is represented as a line, with doses on the x axis and
           viability on the y axis. Hover over plot points for tooltip
           information. Click on items to select from the plot or table.
+          Shift-click to select multiple items from the plot.
         </p>
       </div>
       {error ? (

--- a/frontend/packages/portal-frontend/src/compound/doseCurvesTab/DoseCurvesTab.tsx
+++ b/frontend/packages/portal-frontend/src/compound/doseCurvesTab/DoseCurvesTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useState } from "react";
+import React, { useCallback, useState } from "react";
 import DoseCurvesMainContent from "./DoseCurvesMainContent";
 import FiltersPanel from "./FiltersPanel";
 import { DRCDatasetOptions } from "@depmap/types";
@@ -20,22 +20,18 @@ function DoseCurvesTab({
   compoundName,
   compoundId,
 }: DoseCurvesTabProps) {
-  const [
-    selectedDataset,
-    setSelectedDataset,
-  ] = useState<DRCDatasetOptions | null>(null);
+  const [selectedDataset, setSelectedDataset] = useState<DRCDatasetOptions>(
+    datasetOptions[0]
+  );
   const [selectedDatasetOption, setSelectedDatasetOption] = useState<{
     value: string;
     label: string;
-  } | null>(null);
+  }>({
+    value: datasetOptions[0].viability_dataset_given_id,
+    label: datasetOptions[0].display_name,
+  });
   const [showReplicates, setShowReplicates] = useState<boolean>(true);
   const [showUnselectedLines, setShowUnselectedLines] = useState<boolean>(true);
-
-  useEffect(() => {
-    if (datasetOptions) {
-      setSelectedDataset(datasetOptions[0]);
-    }
-  }, [datasetOptions]);
 
   const handleSelectDataset = useCallback(
     (selection: { value: string; label: string } | null) => {
@@ -65,12 +61,7 @@ function DoseCurvesTab({
           <FiltersPanel
             handleSelectDataset={handleSelectDataset}
             datasetOptions={datasetOptions}
-            selectedDatasetOption={
-              selectedDatasetOption || {
-                value: datasetOptions[0].viability_dataset_given_id,
-                label: datasetOptions[0].display_name,
-              }
-            }
+            selectedDatasetOption={selectedDatasetOption}
             showReplicates={showReplicates}
             showUnselectedLines={showUnselectedLines}
             handleToggleShowReplicates={(nextValue: boolean) =>

--- a/frontend/packages/portal-frontend/src/compound/doseCurvesTab/hooks/useDoseCurvesSelectionHandlers.ts
+++ b/frontend/packages/portal-frontend/src/compound/doseCurvesTab/hooks/useDoseCurvesSelectionHandlers.ts
@@ -117,10 +117,8 @@ function useDoseCurvesSelectionHandlers(
 
   return {
     selectedModelIds,
-    setselectedModelIds: setSelectedModelIds,
     selectedTableRows,
     selectedLabels,
-    setSelectedTableRows,
     handleClickCurve,
     handleChangeSelection,
     handleClickSaveSelectionAsContext,

--- a/frontend/packages/portal-frontend/src/compound/heatmapTab/HeatmapPlotSection.tsx
+++ b/frontend/packages/portal-frontend/src/compound/heatmapTab/HeatmapPlotSection.tsx
@@ -103,8 +103,10 @@ function HeatmapPlotSection({
     stringId?: string;
   }) => {
     if (selection.stringId) {
-      // start and end are equal because we are only selecting a single column in the plot.
-      handleSetSelectedPlotModels(new Set([selection.stringId]), false);
+      // The shiftKey parameter is false because you cannot hold down the shift key and search to add
+      // to your selection.
+      const shiftKey = false;
+      handleSetSelectedPlotModels(new Set([selection.stringId]), shiftKey);
     }
   };
 

--- a/frontend/packages/portal-frontend/src/compound/heatmapTab/HeatmapTab.tsx
+++ b/frontend/packages/portal-frontend/src/compound/heatmapTab/HeatmapTab.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useState } from "react";
+import React, { useCallback, useState } from "react";
 import HeatmapTabMainContent from "./HeatmapTabMainContent";
 import FiltersPanel from "./FiltersPanel";
 import { DRCDatasetOptions } from "@depmap/types";
@@ -20,28 +20,20 @@ function HeatmapTab({
   compoundName,
   compoundId,
 }: HeatmapTabProps) {
-  const [
-    selectedDataset,
-    setSelectedDataset,
-  ] = useState<DRCDatasetOptions | null>(null);
+  const [selectedDataset, setSelectedDataset] = useState<DRCDatasetOptions>(
+    datasetOptions[0]
+  );
   const [selectedDatasetOption, setSelectedDatasetOption] = useState<{
     value: string;
     label: string;
-  } | null>(null);
-
-  // NOTE: temporarily disabling insensitive lines filter until "insensitive" is better defined
-  // const [showInsensitiveLines, setShowInsensitiveLines] =
-  //   useState<boolean>(true);
+  }>({
+    value: datasetOptions[0].viability_dataset_given_id,
+    label: datasetOptions[0].display_name,
+  });
   const [showUnselectedLines, setShowUnselectedLines] = useState<boolean>(true);
   const [selectedDoses, setSelectedDoses] = useState<
     { value: number; label: string }[]
   >([]);
-
-  useEffect(() => {
-    if (datasetOptions) {
-      setSelectedDataset(datasetOptions[0]);
-    }
-  }, [datasetOptions]);
 
   const handleSelectDataset = useCallback(
     (selection: { value: string; label: string } | null) => {
@@ -52,7 +44,6 @@ function HeatmapTab({
             option.viability_dataset_given_id === selection.value
         )[0];
         setSelectedDataset(selectedCompoundDataset);
-        // setShowInsensitiveLines(true);
         setShowUnselectedLines(true);
         setSelectedDoses([]);
       }
@@ -77,12 +68,7 @@ function HeatmapTab({
           <FiltersPanel
             handleSelectDataset={handleSelectDataset}
             datasetOptions={datasetOptions}
-            selectedDatasetOption={
-              selectedDatasetOption || {
-                value: datasetOptions[0].viability_dataset_given_id,
-                label: datasetOptions[0].display_name,
-              }
-            }
+            selectedDatasetOption={selectedDatasetOption}
             handleFilterByDose={handleFilterByDose}
             selectedDose={selectedDoses}
             showUnselectedLines={showUnselectedLines}

--- a/frontend/packages/portal-frontend/src/compound/heatmapTab/HeatmapTabMainContent.tsx
+++ b/frontend/packages/portal-frontend/src/compound/heatmapTab/HeatmapTabMainContent.tsx
@@ -153,8 +153,10 @@ function HeatmapTabMainContent({
         <h3>Viability Heatmap</h3>
         <p>
           Each cell line is organized by column, divided by dose. Hover over
-          plot points for tooltip information. Click on items to select from the
-          plot or table.
+          plot points for tooltip information. Click on columns to select from
+          the plot or table. Shift-click to select multiple columns. To
+          deselect, shift-click on a selected column, or shift-click and drag on
+          a series of selected columns.
         </p>
       </div>
       {error ? (
@@ -173,6 +175,7 @@ function HeatmapTabMainContent({
                 doseUnits={doseUnits}
                 selectedModelIds={selectedModelIds}
                 handleSetSelectedPlotModels={handleSetSelectedPlotModels}
+                handleClearSelection={handleClearSelection}
                 handleSetPlotElement={setPlotElement}
                 displayNameModelIdMap={displayNameModelIdMap}
                 visibleZIndexes={visibleZIndexes}

--- a/frontend/packages/portal-frontend/src/compound/heatmapTab/doseViabilityHeatmap/types.ts
+++ b/frontend/packages/portal-frontend/src/compound/heatmapTab/doseViabilityHeatmap/types.ts
@@ -1,7 +1,7 @@
 type PRCid = string;
 type ModelID = string;
 type CompoundName = string;
-export type Viability = number | null;
+type Viability = number | null;
 type CellLineName = string;
 type DoseWithUnits = `${number} uM`;
 type DoseWithoutUnits = number;

--- a/frontend/packages/portal-frontend/src/compound/heatmapTab/doseViabilityHeatmap/types.ts
+++ b/frontend/packages/portal-frontend/src/compound/heatmapTab/doseViabilityHeatmap/types.ts
@@ -1,7 +1,7 @@
 type PRCid = string;
 type ModelID = string;
 type CompoundName = string;
-type Viability = number | null;
+export type Viability = number | null;
 type CellLineName = string;
 type DoseWithUnits = `${number} uM`;
 type DoseWithoutUnits = number;

--- a/frontend/packages/portal-frontend/src/compound/heatmapTab/hooks/useHeatmapSelectionHandlers.ts
+++ b/frontend/packages/portal-frontend/src/compound/heatmapTab/hooks/useHeatmapSelectionHandlers.ts
@@ -47,18 +47,31 @@ function useHeatmapSelectionHandlers(
     [plotData, selectedModelIds]
   );
 
-  const handleSetSelectedPlotModels = (models: Set<string>) => {
-    setPlotSelectedModelIds((prev) => {
-      const next = new Set(prev);
-      models.forEach((id) => next.add(id));
-      setSelectedTableRows((tablePrev) => {
-        const tableNext = new Set(tablePrev);
-        models.forEach((id) => tableNext.add(id));
-        return tableNext;
+  const handleSetSelectedPlotModels = useCallback(
+    (selections: Set<string>, shiftKey: boolean) => {
+      setPlotSelectedModelIds((prev) => {
+        // NOTE: if people don't like shift click just always set next to new Set(prev)
+        const next: Set<string> = shiftKey ? new Set(prev) : new Set();
+
+        selections.forEach((id) => {
+          if (next.has(id)) {
+            next.delete(id);
+          } else {
+            next.add(id);
+          }
+        });
+
+        setSelectedTableRows(() => {
+          const tableNext = new Set(next);
+          next.forEach((id) => tableNext.add(id));
+          return tableNext;
+        });
+
+        return next;
       });
-      return next;
-    });
-  };
+    },
+    [setPlotSelectedModelIds, setSelectedTableRows]
+  );
 
   const handleClickSaveSelectionAsContext = useCallback(() => {
     const labels = [...selectedModelIds];


### PR DESCRIPTION
These changes include support to:
1. Delete selections from the plot. This has largely already been reviewed in a previous PR.
2. Selection is reset on click or click+drag unless the user is holding down the shift button. To add to your existing selection, or delete from your existing selection, you must be holding down the shift key. Additional explanatory text was also added to the UI.