### PR TITLE
Remove Context Explorer alpha tag and fix indexing of tabs

### DIFF
--- a/frontend/packages/portal-frontend/src/contextExplorer/components/ContextExplorerTabs.tsx
+++ b/frontend/packages/portal-frontend/src/contextExplorer/components/ContextExplorerTabs.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import {
   TabsWithHistory,
   TabList,
@@ -91,11 +91,29 @@ const ContextExplorerTabs = ({
     };
   });
 
+  // Creat a tabIndexToIdMap to properly index tabs with history
+  const tabIndexToIdMap = useMemo(() => {
+    const map = new Map<number, TabTypes>();
+    const allowedTabTypes = Object.values(TabTypes).filter(
+      (tabTypeStr) =>
+        tabTypeStr !== String(TabTypes.DrugSensitivityOncRef) ||
+        enabledFeatures.context_explorer_prerelease_datasets
+    );
+
+    allowedTabTypes.forEach((tabType, index) => {
+      map.set(index, tabType);
+    });
+
+    return map;
+  }, []);
+
   return (
     <TabsWithHistory
       className={styles.Tabs}
-      onChange={(index) => handleSetSelectedTab(index)}
-      onSetInitialIndex={(index) => handleSetSelectedTab(index)}
+      onChange={(index) => handleSetSelectedTab(tabIndexToIdMap.get(index)!)}
+      onSetInitialIndex={(index) =>
+        handleSetSelectedTab(tabIndexToIdMap.get(index)!)
+      }
       isManual
       isLazy
     >

--- a/frontend/packages/portal-frontend/src/contextExplorer/models/types.ts
+++ b/frontend/packages/portal-frontend/src/contextExplorer/models/types.ts
@@ -157,10 +157,10 @@ export interface OtherSignificantBoxCardData {
 }
 
 export enum TabTypes {
-  Overview = 0,
-  GeneDependency = 1,
-  DrugSensitivityOncRef = 2,
-  DrugSensitivityRepurposing = 3,
+  Overview = "Overview",
+  GeneDependency = "GeneDependency",
+  DrugSensitivityOncRef = "DrugSensitivityOncRef",
+  DrugSensitivityRepurposing = "DrugSensitivityRepurposing",
 }
 
 export enum TreeType {

--- a/portal-backend/depmap/templates/nav_footer/common_nav_elements.html
+++ b/portal-backend/depmap/templates/nav_footer/common_nav_elements.html
@@ -40,7 +40,7 @@
               <li><a href="{{ url_for('tda.view_tda_summary') }}">Target Discovery</a></li>
             {% endif %}
             {% if config.ENABLED_FEATURES.context_explorer %}
-            <li><a href="{{ url_for('context_explorer.view_context_explorer') }}">Context Explorer <i class="alpha-tag"><b>Alpha</b></i></a></li>
+            <li><a href="{{ url_for('context_explorer.view_context_explorer') }}">Context Explorer</a></li>
           {% endif %}
             {% if config.ENABLED_FEATURES.compound_dashboard_app %}
               <li><a href="{{ url_for('compound_dashboard.view_compound_dashboard') }}">Compound Dashboard <i class="alpha-tag"><b>Alpha</b></i></a></li>


### PR DESCRIPTION
In preparation for Context Explorer going public, this PR (1) removes the ALPHA tag from the Context Explorer label in the tools menu, and (2) creates a map of tab types and indexes so that the explanatory text on the left side of the page will properly update even if OncRef is available. Previously, for the tab text to update properly, there had to always be 3 tabs in a precise order as defined by the TabTypes enum, but this no longer an accurate assumption.