### PR TITLE
Heatmap and Dose Curves: prioritize datasets in dropdown

### DIFF
--- a/frontend/packages/@depmap/api/src/legacyPortalAPI/resources/compound.ts
+++ b/frontend/packages/@depmap/api/src/legacyPortalAPI/resources/compound.ts
@@ -39,10 +39,12 @@ export function getCompoundDoseCurveData(
 }
 
 export function getPrioritizedDataset(
-  compoundLabel: string
+  compoundLabel: string,
+  compoundId: string
 ): Promise<DRCDatasetOptions> {
   const params = {
     compound_label: compoundLabel,
+    compound_id: compoundId,
   };
 
   return getJson<DRCDatasetOptions>(

--- a/frontend/packages/@depmap/types/src/compounds.ts
+++ b/frontend/packages/@depmap/types/src/compounds.ts
@@ -59,6 +59,9 @@ export type DoseTableRow = {
 
 export interface DRCDatasetOptions {
   display_name: string;
+  priority: number | null;
+  auc_dataset_display_name: string; // for label on heatmap tile
+  viability_dataset_display_name: string; // for label on heatmap tile
   viability_dataset_given_id: string;
   replicate_dataset: string;
   auc_dataset_given_id: string;

--- a/frontend/packages/@depmap/utils/src/sort.ts
+++ b/frontend/packages/@depmap/utils/src/sort.ts
@@ -1,3 +1,5 @@
+type SortOrder = "asc" | "desc";
+
 const collator = new Intl.Collator("en", { sensitivity: "base" });
 
 export const compareCaseInsensitive = collator.compare;
@@ -22,3 +24,32 @@ export const getSortProp = <T>(key: keyof T) => {
     return (a: T, b: T): number => compare(String(a[key]), String(b[key]));
   };
 };
+
+export function sortByNumberOrNull<T>(
+  arr: T[],
+  property: keyof T,
+  order: SortOrder = "asc"
+): T[] {
+  return [...arr].sort((a, b) => {
+    const valA = a[property] as number | null;
+    const valB = b[property] as number | null;
+
+    // Handle null values: nulls always go to the end
+    if (valA === null && valB !== null) {
+      return 1;
+    }
+    if (valA !== null && valB === null) {
+      return -1;
+    }
+    if (valA === null && valB === null) {
+      return 0; // Both are null, maintain relative order
+    }
+
+    // Both are numbers, perform numeric comparison
+    if (order === "asc") {
+      return (valA as number) - (valB as number);
+    } else {
+      return (valB as number) - (valA as number);
+    }
+  });
+}

--- a/frontend/packages/portal-frontend/src/compound/tiles/HeatmapTile/HeatmapTile.tsx
+++ b/frontend/packages/portal-frontend/src/compound/tiles/HeatmapTile/HeatmapTile.tsx
@@ -13,11 +13,13 @@ import { useDoseViabilityDataContext } from "src/compound/hooks/DoseViabilityDat
 
 interface HeatmapTileProps {
   compoundName: string;
+  displayName: string;
   isLoadingDataset: boolean;
 }
 
 export const HeatmapTile: React.FC<HeatmapTileProps> = ({
   compoundName,
+  displayName,
   isLoadingDataset,
 }) => {
   const {
@@ -75,9 +77,11 @@ export const HeatmapTile: React.FC<HeatmapTileProps> = ({
           )}
         </h2>
         <div className="card_padding">
-          <div className={styles.subHeader}>
-            {compoundName} sensitivity distributed per dose
-          </div>
+          {tableFormattedData && (
+            <div className={styles.subHeader}>
+              {compoundName} ({displayName}) sensitivity distributed per dose
+            </div>
+          )}
           {(isLoading || isLoadingDataset) && !error && <PlotSpinner />}
           {!isLoading && !error && sortedHeatmapFormattedData && (
             <div className={styles.heatmapWithTriangle}>

--- a/frontend/packages/portal-frontend/src/compound/tiles/HeatmapTile/HeatmapTileContainer.tsx
+++ b/frontend/packages/portal-frontend/src/compound/tiles/HeatmapTile/HeatmapTileContainer.tsx
@@ -20,7 +20,8 @@ export const HeatmapTileContainer: React.FC<HeatmapTileContainerProps> = ({
     (async () => {
       setIsLoading(true);
       const prioritizedDataset = await legacyPortalAPI.getPrioritizedDataset(
-        compoundName
+        compoundName,
+        compoundId
       );
       setDataset(prioritizedDataset);
       setIsLoading(false);
@@ -29,7 +30,11 @@ export const HeatmapTileContainer: React.FC<HeatmapTileContainerProps> = ({
 
   return (
     <DoseViabilityDataProvider dataset={dataset} compoundId={compoundId}>
-      <HeatmapTile compoundName={compoundName} isLoadingDataset={isLoading} />
+      <HeatmapTile
+        compoundName={compoundName}
+        displayName={dataset?.display_name || ""}
+        isLoadingDataset={isLoading}
+      />
     </DoseViabilityDataProvider>
   );
 };

--- a/frontend/packages/portal-frontend/src/index.tsx
+++ b/frontend/packages/portal-frontend/src/index.tsx
@@ -6,7 +6,7 @@ import { legacyPortalAPI, LegacyPortalApiResponse } from "@depmap/api";
 import { CustomList } from "@depmap/cell-line-selector";
 import { toStaticUrl } from "@depmap/globals";
 
-import { getQueryParams } from "@depmap/utils";
+import { getQueryParams, sortByNumberOrNull } from "@depmap/utils";
 
 import { DatasetOption } from "src/entity/components/EntitySummary";
 
@@ -298,7 +298,7 @@ export function initDoseCurvesTab(
   renderWithErrorBoundary(
     <React.Suspense fallback={<div>Loading...</div>}>
       <DoseCurvesTab
-        datasetOptions={datasetOptions}
+        datasetOptions={sortByNumberOrNull(datasetOptions, "priority", "asc")}
         doseUnits={units}
         compoundName={name}
         compoundId={compoundId}
@@ -318,7 +318,7 @@ export function initHeatmapTab(
   renderWithErrorBoundary(
     <React.Suspense fallback={<div>Loading...</div>}>
       <HeatmapTab
-        datasetOptions={datasetOptions}
+        datasetOptions={sortByNumberOrNull(datasetOptions, "priority", "asc")}
         doseUnits={units}
         compoundName={name}
         compoundId={compoundId}

--- a/portal-backend/depmap/compound/api.py
+++ b/portal-backend/depmap/compound/api.py
@@ -28,16 +28,20 @@ class DoseCurveData(Resource):
 class PrioritizedDataset(Resource):
     def get(self):
         compound_label = request.args.get("compound_label")
+        compound_id = request.args.get("compound_id")
 
         dataset_options = get_heatmap_options_new_tab_if_available(
-            compound_label=compound_label
+            compound_label=compound_label, compound_id=compound_id
         )
 
-        # Expect at least (or only?) 1 dataset to be priority 1
-        prioritized_dataset = [
-            option.priority for option in dataset_options if option.priority == 1
-        ]
+        # Find the dataset with the lowest priority. Priority can be None, and the lowest priority won't necessarily
+        # have a priority of 1, because this compound might not exist in the dataset with priority 1. dataset_options
+        # will only have the options for which this compound exists.
+        sorted_data = sorted(
+            dataset_options,
+            key=lambda dataset: dataset.priority
+            if dataset.priority is not None
+            else float("inf"),
+        )
 
-        assert len(prioritized_dataset) > 0
-
-        return dataclasses.asdict(prioritized_dataset[0])
+        return dataclasses.asdict(sorted_data[0])

--- a/portal-backend/depmap/compound/api.py
+++ b/portal-backend/depmap/compound/api.py
@@ -1,6 +1,7 @@
 import dataclasses
+from depmap import data_access
 from depmap.compound.new_dose_curves_utils import get_dose_response_curves_per_model
-from depmap.compound.views.index import format_heatmap_options_new_tab_if_available
+from depmap.compound.views.index import get_heatmap_options_new_tab_if_available
 from flask_restplus import Namespace, Resource
 from flask import request
 
@@ -28,9 +29,15 @@ class PrioritizedDataset(Resource):
     def get(self):
         compound_label = request.args.get("compound_label")
 
-        dataset_options = format_heatmap_options_new_tab_if_available(
+        dataset_options = get_heatmap_options_new_tab_if_available(
             compound_label=compound_label
         )
-        prioritized_dataset = dataset_options[0]
 
-        return dataclasses.asdict(prioritized_dataset)
+        # Expect at least (or only?) 1 dataset to be priority 1
+        prioritized_dataset = [
+            option.priority for option in dataset_options if option.priority == 1
+        ]
+
+        assert len(prioritized_dataset) > 0
+
+        return dataclasses.asdict(prioritized_dataset[0])

--- a/portal-backend/depmap/compound/models.py
+++ b/portal-backend/depmap/compound/models.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import List, Optional, Union
 import sqlalchemy
 from sqlalchemy import and_, func
 from depmap.database import (
@@ -26,6 +26,13 @@ class DRCCompoundDataset:
     replicate_dataset: str
     auc_dataset_given_id: str
     display_name: str
+
+
+@dataclass
+class DRCCompoundDatasetWithNamesAndPriority(DRCCompoundDataset):
+    priority: Union[int, None]
+    auc_dataset_display_name: str
+    viability_dataset_display_name: str
 
 
 drc_compound_datasets = [

--- a/portal-backend/depmap/compound/new_dose_curves_utils.py
+++ b/portal-backend/depmap/compound/new_dose_curves_utils.py
@@ -143,7 +143,7 @@ def _get_curve_params_for_model_ids(
 # CompoundDoseReplicates. As result, here we:
 # 1. Look at each Compound Experiment, are there valid CompoundDoseReplicates?
 # 2. As soon as we find valid replicates, ignore any subsequent CompoundExperiments.
-def _get_compound_dose_replicates(
+def get_compound_dose_replicates(
     compound_id: str, drc_dataset_label: str, replicate_dataset_name: str
 ):
     ces = CompoundExperiment.get_corresponding_compound_experiment_using_drc_dataset_label(
@@ -184,7 +184,7 @@ def get_dose_response_curves_per_model(
     """
     Setup retrieval of dose response curves and replicate points for a compound and dataset.
     """
-    compound_dose_replicates = _get_compound_dose_replicates(
+    compound_dose_replicates = get_compound_dose_replicates(
         compound_id=compound_id,
         drc_dataset_label=drc_dataset_label,
         replicate_dataset_name=replicate_dataset_name,

--- a/portal-backend/depmap/compound/utils.py
+++ b/portal-backend/depmap/compound/utils.py
@@ -1,9 +1,9 @@
 from depmap import data_access
+from depmap.compound import new_dose_curves_utils
 from depmap.compound.models import (
     DRCCompoundDataset,
     DRCCompoundDatasetWithNamesAndPriority,
 )
-from depmap.compound.new_dose_curves_utils import get_compound_dose_replicates
 
 
 def get_compound_dataset_with_name_and_priority(drc_dataset: DRCCompoundDataset):
@@ -46,7 +46,7 @@ def dataset_exists_with_compound_in_auc_and_rep_datasets(
     # See if we can find any dose replicates for this compound. We cannot simply check is valid_row because the feature labels
     # of the replicate set are not equal to the compound_label. If the compound does not exist in this replicate dataset,
     # get_compound_dose_replicates will return an empty list.
-    valid_compound_dose_replicates = get_compound_dose_replicates(
+    valid_compound_dose_replicates = new_dose_curves_utils.get_compound_dose_replicates(
         compound_id=compound_id,
         drc_dataset_label=drc_dataset.drc_dataset_label,
         replicate_dataset_name=drc_dataset.replicate_dataset,

--- a/portal-backend/depmap/compound/utils.py
+++ b/portal-backend/depmap/compound/utils.py
@@ -1,0 +1,28 @@
+from depmap import data_access
+from depmap.compound.models import (
+    DRCCompoundDataset,
+    DRCCompoundDatasetWithNamesAndPriority,
+)
+
+
+def get_compound_dataset_with_name_and_priority(drc_dataset: DRCCompoundDataset):
+    auc_dataset_display_name = data_access.get_dataset_label(
+        drc_dataset.auc_dataset_given_id
+    )
+    priority = data_access.get_dataset_priority(drc_dataset.auc_dataset_given_id)
+    viability_dataset_display_name = data_access.get_dataset_label(
+        drc_dataset.viability_dataset_given_id
+    )
+
+    with_names_and_priority = DRCCompoundDatasetWithNamesAndPriority(
+        drc_dataset_label=drc_dataset.drc_dataset_label,
+        viability_dataset_given_id=drc_dataset.viability_dataset_given_id,
+        replicate_dataset=drc_dataset.replicate_dataset,
+        auc_dataset_given_id=drc_dataset.auc_dataset_given_id,
+        display_name=drc_dataset.display_name,
+        priority=priority,
+        auc_dataset_display_name=auc_dataset_display_name,
+        viability_dataset_display_name=viability_dataset_display_name,
+    )
+
+    return with_names_and_priority

--- a/portal-backend/depmap/compound/utils.py
+++ b/portal-backend/depmap/compound/utils.py
@@ -3,6 +3,7 @@ from depmap.compound.models import (
     DRCCompoundDataset,
     DRCCompoundDatasetWithNamesAndPriority,
 )
+from depmap.compound.new_dose_curves_utils import get_compound_dose_replicates
 
 
 def get_compound_dataset_with_name_and_priority(drc_dataset: DRCCompoundDataset):
@@ -26,3 +27,33 @@ def get_compound_dataset_with_name_and_priority(drc_dataset: DRCCompoundDataset)
     )
 
     return with_names_and_priority
+
+
+def dataset_exists_with_compound_in_auc_and_rep_datasets(
+    drc_dataset: DRCCompoundDataset, compound_label: str, compound_id: str
+) -> bool:
+    """ 
+    We only want to load the dose curves and heatmap if the auc and replicate datasets all exist with the compound.
+    The Heatmap relies on dose curve data to load the curve params (hidden columns by default) into the table.
+    """
+    does_auc_dataset_exist_with_compound = data_access.dataset_exists(
+        drc_dataset.auc_dataset_given_id
+    ) and data_access.valid_row(drc_dataset.auc_dataset_given_id, compound_label)
+
+    if not does_auc_dataset_exist_with_compound:
+        return False
+
+    # See if we can find any dose replicates for this compound. We cannot simply check is valid_row because the feature labels
+    # of the replicate set are not equal to the compound_label. If the compound does not exist in this replicate dataset,
+    # get_compound_dose_replicates will return an empty list.
+    valid_compound_dose_replicates = get_compound_dose_replicates(
+        compound_id=compound_id,
+        drc_dataset_label=drc_dataset.drc_dataset_label,
+        replicate_dataset_name=drc_dataset.replicate_dataset,
+    )
+    does_replicate_dataset_exist_with_compound = (
+        data_access.dataset_exists(drc_dataset.replicate_dataset)
+        and len(valid_compound_dose_replicates) > 0
+    )
+
+    return does_replicate_dataset_exist_with_compound

--- a/portal-backend/depmap/compound/views/index.py
+++ b/portal-backend/depmap/compound/views/index.py
@@ -5,6 +5,7 @@ import tempfile
 from typing import Any, List, Optional
 import zipfile
 from depmap.compound import legacy_utils
+from depmap.compound.utils import get_compound_dataset_with_name_and_priority
 import requests
 import urllib.parse
 
@@ -28,6 +29,7 @@ from depmap.compound.models import (
     Compound,
     CompoundDoseReplicate,
     CompoundExperiment,
+    DRCCompoundDatasetWithNamesAndPriority,
     DoseResponseCurve,
     drc_compound_datasets,
 )
@@ -97,7 +99,7 @@ def view_compound(name):
     dose_curve_options_new = format_dose_curve_options_new_tab_if_available(
         compound_label=compound.label
     )
-    heatmap_dataset_options = format_heatmap_options_new_tab_if_available(
+    heatmap_dataset_options = get_heatmap_options_new_tab_if_available(
         compound_label=compound.label
     )
 
@@ -246,12 +248,17 @@ def format_dose_curve_options_new_tab_if_available(compound_label: str):
                         "ENABLED_FEATURES"
                     ].show_all_new_dose_curve_and_heatmap_tab_datasets
                 ):
-                    valid_options.append(drc_dataset)
+                    complete_option = get_compound_dataset_with_name_and_priority(
+                        drc_dataset
+                    )
+                    valid_options.append(complete_option)
 
     return valid_options
 
 
-def format_heatmap_options_new_tab_if_available(compound_label: str):
+def get_heatmap_options_new_tab_if_available(
+    compound_label: str,
+) -> List[DRCCompoundDatasetWithNamesAndPriority]:
     show_heatmap_tab = current_app.config["ENABLED_FEATURES"].new_compound_page_tabs
 
     valid_options = []
@@ -269,7 +276,10 @@ def format_heatmap_options_new_tab_if_available(compound_label: str):
                         "ENABLED_FEATURES"
                     ].show_all_new_dose_curve_and_heatmap_tab_datasets
                 ):
-                    valid_options.append(drc_dataset)
+                    complete_option = get_compound_dataset_with_name_and_priority(
+                        drc_dataset
+                    )
+                    valid_options.append(complete_option)
 
     return valid_options
 

--- a/portal-backend/depmap/compound/views/index.py
+++ b/portal-backend/depmap/compound/views/index.py
@@ -5,7 +5,10 @@ import tempfile
 from typing import Any, List, Optional
 import zipfile
 from depmap.compound import legacy_utils
-from depmap.compound.utils import get_compound_dataset_with_name_and_priority
+from depmap.compound.utils import (
+    get_compound_dataset_with_name_and_priority,
+    dataset_exists_with_compound_in_auc_and_rep_datasets,
+)
 import requests
 import urllib.parse
 
@@ -97,10 +100,10 @@ def view_compound(name):
         )
 
     dose_curve_options_new = format_dose_curve_options_new_tab_if_available(
-        compound_label=compound.label
+        compound_label=compound.label, compound_id=compound.compound_id
     )
     heatmap_dataset_options = get_heatmap_options_new_tab_if_available(
-        compound_label=compound.label
+        compound_label=compound.label, compound_id=compound.compound_id
     )
 
     # If there are no no valid dataset options, hide the heatmap tab and tile
@@ -225,7 +228,9 @@ def format_dose_curve_option(dataset, compound_experiment, label):
     return option
 
 
-def format_dose_curve_options_new_tab_if_available(compound_label: str):
+def format_dose_curve_options_new_tab_if_available(
+    compound_label: str, compound_id: str
+):
     """
     Used for jinja rendering of the dose curve tab
     """
@@ -236,10 +241,10 @@ def format_dose_curve_options_new_tab_if_available(compound_label: str):
     valid_options = []
     if show_new_dose_curves_tab:
         for drc_dataset in drc_compound_datasets:
-            if data_access.dataset_exists(
-                drc_dataset.auc_dataset_given_id
-            ) and data_access.valid_row(
-                drc_dataset.auc_dataset_given_id, compound_label
+            if dataset_exists_with_compound_in_auc_and_rep_datasets(
+                drc_dataset=drc_dataset,
+                compound_label=compound_label,
+                compound_id=compound_id,
             ):
                 # TODO: Take this check out once the legacy db old drug datasets are updated to use the processed taiga ids.
                 if (
@@ -257,17 +262,18 @@ def format_dose_curve_options_new_tab_if_available(compound_label: str):
 
 
 def get_heatmap_options_new_tab_if_available(
-    compound_label: str,
+    compound_label: str, compound_id: str
 ) -> List[DRCCompoundDatasetWithNamesAndPriority]:
     show_heatmap_tab = current_app.config["ENABLED_FEATURES"].new_compound_page_tabs
 
     valid_options = []
     if show_heatmap_tab:
         for drc_dataset in drc_compound_datasets:
-            if data_access.dataset_exists(
-                drc_dataset.auc_dataset_given_id
-            ) and data_access.valid_row(
-                drc_dataset.auc_dataset_given_id, compound_label
+            # TODO: Theoretically, we could let the Heatmap load without the dose curve params, but this would involve some frontend changes.
+            if dataset_exists_with_compound_in_auc_and_rep_datasets(
+                drc_dataset=drc_dataset,
+                compound_label=compound_label,
+                compound_id=compound_id,
             ):
                 # TODO: Take this check out once the legacy db old drug datasets are updated to use the processed taiga ids.
                 if (

--- a/portal-backend/tests/depmap/compound/views/test_index.py
+++ b/portal-backend/tests/depmap/compound/views/test_index.py
@@ -1,3 +1,4 @@
+from depmap.compound import new_dose_curves_utils, utils
 from depmap.data_access import breadbox_dao
 from depmap.interactive import interactive_utils
 from depmap.settings.settings import TestConfig
@@ -8,7 +9,12 @@ from json import loads as json_loads
 
 from depmap import data_access
 from depmap.dataset.models import DependencyDataset
-from depmap.compound.models import Compound, DRCCompoundDataset, drc_compound_datasets
+from depmap.compound.models import (
+    Compound,
+    DRCCompoundDataset,
+    DRCCompoundDatasetWithNamesAndPriority,
+    drc_compound_datasets,
+)
 from depmap.compound.views.index import (
     format_dose_curve_options_new_tab_if_available,
     get_heatmap_options_new_tab_if_available,
@@ -34,6 +40,17 @@ from tests.factories import (
 from tests.utilities import interactive_test_utils
 from tests.utilities.override_fixture import override
 
+expected_oncref_dataset_w_priority = DRCCompoundDatasetWithNamesAndPriority(
+    drc_dataset_label="Prism_oncology_per_curve",
+    viability_dataset_given_id="Prism_oncology_viability",
+    replicate_dataset="Prism_oncology_dose_replicate",
+    auc_dataset_given_id="Prism_oncology_AUC_collapsed",
+    display_name="PRISM OncRef",
+    priority=1,
+    auc_dataset_display_name="PRISM OncRef",
+    viability_dataset_display_name="PRISM OncRef",
+)
+
 
 def test_render_view_compound(populated_db, monkeypatch):
     with populated_db.app.test_client() as c:
@@ -47,9 +64,29 @@ def test_render_view_compound(populated_db, monkeypatch):
         def mock_is_breadbox_id(dataset_id):
             return True
 
+        def mock_get_compound_dose_replicates(
+            compound_id, drc_dataset_label, replicate_dataset_name
+        ):
+            return ["mock_replicate_1"]
+
+        def mock_get_dataset_label(dataset):
+            return "PRISM OncRef"
+
+        def mock_get_dataset_priority(dataset):
+            return 1
+
         monkeypatch.setattr(breadbox_dao, "valid_row", mock_valid_row)
         monkeypatch.setattr(breadbox_dao, "is_breadbox_id", mock_is_breadbox_id)
         monkeypatch.setattr(interactive_utils, "has_config", mock_has_config)
+        monkeypatch.setattr(
+            new_dose_curves_utils,
+            "get_compound_dose_replicates",
+            mock_get_compound_dose_replicates,
+        )
+        monkeypatch.setattr(data_access, "get_dataset_label", mock_get_dataset_label)
+        monkeypatch.setattr(
+            data_access, "get_dataset_priority", mock_get_dataset_priority
+        )
 
         for compound in Compound.query.all():
             r = c.get(url_for("compound.view_compound", name=compound.label))
@@ -459,7 +496,7 @@ def test_get_predictive_table(app, empty_db_mock_downloads):
 
 
 def test_format_dose_curve_and_heatmap_options_new_tab_if_available_true(
-    app, monkeypatch
+    app, monkeypatch, empty_db_mock_downloads
 ):
     with app.app_context():
 
@@ -472,23 +509,40 @@ def test_format_dose_curve_and_heatmap_options_new_tab_if_available_true(
         def mock_is_breadbox_id(dataset_id):
             return True
 
+        def mock_get_compound_dose_replicates(
+            compound_id, drc_dataset_label, replicate_dataset_name
+        ):
+            return ["mock_replicate_1"]
+
+        def mock_get_dataset_label(dataset):
+            return "PRISM OncRef"
+
+        def mock_get_dataset_priority(dataset):
+            return 1
+
         monkeypatch.setattr(breadbox_dao, "valid_row", mock_valid_row)
         monkeypatch.setattr(breadbox_dao, "is_breadbox_id", mock_is_breadbox_id)
         monkeypatch.setattr(interactive_utils, "has_config", mock_has_config)
+        monkeypatch.setattr(
+            new_dose_curves_utils,
+            "get_compound_dose_replicates",
+            mock_get_compound_dose_replicates,
+        )
+        monkeypatch.setattr(data_access, "get_dataset_label", mock_get_dataset_label)
+        monkeypatch.setattr(
+            data_access, "get_dataset_priority", mock_get_dataset_priority
+        )
 
-        result = format_dose_curve_options_new_tab_if_available(CompoundFactory().label)
+        compound = CompoundFactory()
+        result = format_dose_curve_options_new_tab_if_available(
+            compound.label, compound.compound_id
+        )
         assert isinstance(result, list)
 
         # TODO: Update when more datasets are available and the legacy db has been
         # updated with the processed versions of older drug datasets.
         assert len(result) == 1
-        assert result[0] == DRCCompoundDataset(
-            display_name="PRISM OncRef",
-            viability_dataset_given_id="Prism_oncology_viability",
-            replicate_dataset="Prism_oncology_dose_replicate",
-            auc_dataset_given_id="Prism_oncology_AUC_collapsed",
-            drc_dataset_label="Prism_oncology_per_curve",
-        )
+        assert result[0] == expected_oncref_dataset_w_priority
 
 
 def test_format_heatmap_options_new_tab_if_available_true(app, monkeypatch):
@@ -503,21 +557,38 @@ def test_format_heatmap_options_new_tab_if_available_true(app, monkeypatch):
         def mock_is_breadbox_id(dataset_id):
             return True
 
+        def mock_get_compound_dose_replicates(
+            compound_id, drc_dataset_label, replicate_dataset_name
+        ):
+            return ["mock_replicate_1"]
+
+        def mock_get_dataset_label(dataset):
+            return "PRISM OncRef"
+
+        def mock_get_dataset_priority(dataset):
+            return 1
+
         monkeypatch.setattr(breadbox_dao, "valid_row", mock_valid_row)
         monkeypatch.setattr(breadbox_dao, "is_breadbox_id", mock_is_breadbox_id)
         monkeypatch.setattr(interactive_utils, "has_config", mock_has_config)
+        monkeypatch.setattr(
+            new_dose_curves_utils,
+            "get_compound_dose_replicates",
+            mock_get_compound_dose_replicates,
+        )
+        monkeypatch.setattr(data_access, "get_dataset_label", mock_get_dataset_label)
+        monkeypatch.setattr(
+            data_access, "get_dataset_priority", mock_get_dataset_priority
+        )
 
         # TODO: Update when more datasets are available and the legacy db has been
         # updated with the processed versions of older drug datasets.
-        result = get_heatmap_options_new_tab_if_available(CompoundFactory().label)
-        assert len(result) == 1
-        assert result[0] == DRCCompoundDataset(
-            display_name="PRISM OncRef",
-            viability_dataset_given_id="Prism_oncology_viability",
-            replicate_dataset="Prism_oncology_dose_replicate",
-            auc_dataset_given_id="Prism_oncology_AUC_collapsed",
-            drc_dataset_label="Prism_oncology_per_curve",
+        compound = CompoundFactory()
+        result = get_heatmap_options_new_tab_if_available(
+            compound.label, compound.compound_id
         )
+        assert len(result) == 1
+        assert result[0] == expected_oncref_dataset_w_priority
 
 
 def config(request):
@@ -547,13 +618,48 @@ def test_dose_curve_options_all_datasets_available(app, monkeypatch):
         def mock_is_breadbox_id(dataset_id):
             return True
 
+        def mock_get_compound_dose_replicates(
+            compound_id, drc_dataset_label, replicate_dataset_name
+        ):
+            return ["mock_replicate_1"]
+
+        def mock_get_dataset_label(dataset):
+            return "dataset_label"
+
+        def mock_get_dataset_priority(dataset):
+            return 1
+
         monkeypatch.setattr(breadbox_dao, "valid_row", mock_valid_row)
         monkeypatch.setattr(breadbox_dao, "is_breadbox_id", mock_is_breadbox_id)
         monkeypatch.setattr(interactive_utils, "has_config", mock_has_config)
+        monkeypatch.setattr(
+            new_dose_curves_utils,
+            "get_compound_dose_replicates",
+            mock_get_compound_dose_replicates,
+        )
+        monkeypatch.setattr(data_access, "get_dataset_label", mock_get_dataset_label)
+        monkeypatch.setattr(
+            data_access, "get_dataset_priority", mock_get_dataset_priority
+        )
 
-        result = format_dose_curve_options_new_tab_if_available(CompoundFactory().label)
+        compound = CompoundFactory()
+        result = format_dose_curve_options_new_tab_if_available(
+            compound.label, compound.compound_id
+        )
         assert isinstance(result, list)
-        assert result == drc_compound_datasets
+        assert result == [
+            DRCCompoundDatasetWithNamesAndPriority(
+                drc_dataset_label=dataset.drc_dataset_label,
+                viability_dataset_given_id=dataset.viability_dataset_given_id,
+                replicate_dataset=dataset.replicate_dataset,
+                auc_dataset_given_id=dataset.auc_dataset_given_id,
+                display_name=dataset.display_name,
+                priority=1,
+                auc_dataset_display_name="dataset_label",
+                viability_dataset_display_name="dataset_label",
+            )
+            for dataset in drc_compound_datasets
+        ]
 
 
 def test_format_dose_curve_options_new_tab_if_available_false(app):

--- a/portal-backend/tests/depmap/compound/views/test_index.py
+++ b/portal-backend/tests/depmap/compound/views/test_index.py
@@ -11,7 +11,7 @@ from depmap.dataset.models import DependencyDataset
 from depmap.compound.models import Compound, DRCCompoundDataset, drc_compound_datasets
 from depmap.compound.views.index import (
     format_dose_curve_options_new_tab_if_available,
-    format_heatmap_options_new_tab_if_available,
+    get_heatmap_options_new_tab_if_available,
     get_sensitivity_tab_info,
     format_summary_option,
     format_dose_curve_options,
@@ -509,7 +509,7 @@ def test_format_heatmap_options_new_tab_if_available_true(app, monkeypatch):
 
         # TODO: Update when more datasets are available and the legacy db has been
         # updated with the processed versions of older drug datasets.
-        result = format_heatmap_options_new_tab_if_available(CompoundFactory().label)
+        result = get_heatmap_options_new_tab_if_available(CompoundFactory().label)
         assert len(result) == 1
         assert result[0] == DRCCompoundDataset(
             display_name="PRISM OncRef",
@@ -566,5 +566,5 @@ def test_format_dose_curve_options_new_tab_if_available_false(app):
 def test_format_heatmap_options_new_tab_if_available_false(app):
     with app.app_context():
         app.config["ENV_TYPE"] = "public"
-        result = format_heatmap_options_new_tab_if_available(CompoundFactory().label)
+        result = get_heatmap_options_new_tab_if_available(CompoundFactory().label)
         assert result == []

--- a/portal-backend/tests/depmap/compound/views/test_index.py
+++ b/portal-backend/tests/depmap/compound/views/test_index.py
@@ -665,12 +665,18 @@ def test_dose_curve_options_all_datasets_available(app, monkeypatch):
 def test_format_dose_curve_options_new_tab_if_available_false(app):
     with app.app_context():
         app.config["ENV_TYPE"] = "public"
-        result = format_dose_curve_options_new_tab_if_available(CompoundFactory().label)
+        compound = CompoundFactory()
+        result = format_dose_curve_options_new_tab_if_available(
+            compound.label, compound.compound_id
+        )
         assert result == []
 
 
 def test_format_heatmap_options_new_tab_if_available_false(app):
     with app.app_context():
         app.config["ENV_TYPE"] = "public"
-        result = get_heatmap_options_new_tab_if_available(CompoundFactory().label)
+        compound = CompoundFactory()
+        result = get_heatmap_options_new_tab_if_available(
+            compound.label, compound.compound_id
+        )
         assert result == []

--- a/portal-backend/tests/factories.py
+++ b/portal-backend/tests/factories.py
@@ -234,8 +234,8 @@ class CompoundFactory(SQLAlchemyModelFactory):
         sqlalchemy_session = _db.session
 
     type = "compound"
-    compound_id = factory.Sequence(
-        lambda n: f"DPC-{n:06d}"
+    compound_id = typing.cast(
+        str, factory.Sequence(lambda n: f"DPC-{n:06d}")
     )  # Generates IDs like DPC-000001, DPC-000002, etc.
     label = typing.cast(
         str, factory.Sequence(lambda number: "compound_{}".format(number))


### PR DESCRIPTION
These changes support sorting the Heatmap and Dose Curves dataset options by the dataset priority field. The heatmap tile will also always now load the highest priority dataset that is available for that particular compound. Previously, the tile always loaded the first dataset available in the hard coded drc_compound_datasets list, but this didn't always match the correct highest priority dataset.

These changes also add the dataset display name to the Heatmap Tile.