### PR TITLE
Fix enriched lineages plot overflows bounds on gene page

### DIFF
--- a/frontend/packages/portal-frontend/src/common/components/tabs/TabsWithHistory.tsx
+++ b/frontend/packages/portal-frontend/src/common/components/tabs/TabsWithHistory.tsx
@@ -145,6 +145,15 @@ export const TabsWithHistory = ({
       });
 
       window.history.pushState({}, "", `?${queryString}`);
+
+      // Only dispatch the event for the tab being shown. Plotly improperly
+      // sized the Enriched Lineages Tile box plots if the plots attempted to load
+      // while the overview tab was hidden. This dispatches an event so that the box
+      // plots will resize on selection of the tab via incrementing the state of the components key.
+      // Note: A similar technique is used for the Compound Page tabs here: portal-backend/depmap/static/js/sticky/stickyTabs.js
+      window.dispatchEvent(
+        new CustomEvent(`changeTab:${tabIndexMap.current[nextIndex]}`)
+      );
     },
     [setIndex, onChange, queryParamName]
   );


### PR DESCRIPTION
This change fixes an issue that causes the Enriched Lineages Tile box plots to overflow their bounds on the Gene Page.

A similar bug was already fixed for the Compound Page. The Compound Page uses stickyTabs instead of React, so the Compound Page fix did not also apply for the Gene Page. However, as part of the Compound Page fix, The Collapsible Box Plot component that is used on the Enriched Lineages Tile listens for the event `changeTab:overview`.

To fix the Gene Page bug, I dispatched an event of the same name in the TabsWithHistory component.