### PR TITLE
 Change Context Explorer box plots so that y axis urls open in a new tab

### DIFF
--- a/frontend/packages/portal-frontend/src/contextExplorer/components/boxPlots/BoxPlot.tsx
+++ b/frontend/packages/portal-frontend/src/contextExplorer/components/boxPlots/BoxPlot.tsx
@@ -251,7 +251,11 @@ export default function LazyBoxPlot({
                             {code}
                           </span>
                         ) : (
-                          <a href={getNewContextUrl(code, urlPrefix, tab)}>
+                          <a
+                            href={getNewContextUrl(code, urlPrefix, tab)}
+                            rel="noreferrer"
+                            target="_blank"
+                          >
                             {code}
                           </a>
                         )}

--- a/frontend/packages/portal-frontend/src/contextExplorer/components/boxPlots/BoxPlotHeaderTitle.tsx
+++ b/frontend/packages/portal-frontend/src/contextExplorer/components/boxPlots/BoxPlotHeaderTitle.tsx
@@ -15,7 +15,12 @@ export function BoxPlotHeaderTitle({
   return selectedCode === subtypeCode ? (
     <span className={styles.unlinkedBoxPlotTitle}>{subtypeCode}</span>
   ) : (
-    <a className={styles.linkedBoxPlotTitle} href={url}>
+    <a
+      className={styles.linkedBoxPlotTitle}
+      rel="noreferrer"
+      target="_blank"
+      href={url}
+    >
       {subtypeCode}
     </a>
   );


### PR DESCRIPTION
Updated the Context Explorer box plots so that the y-axis urls open in new tabs.

For more info about the reason for this change, see this Asana task: https://app.asana.com/1/9513920295503/project/1200970789253100/task/1210811611676565