### PR TITLE
Fix correlation analysis plot bounds

### DIFF
--- a/frontend/packages/portal-frontend/src/correlationAnalysis/components/CorrelationsPlots.tsx
+++ b/frontend/packages/portal-frontend/src/correlationAnalysis/components/CorrelationsPlots.tsx
@@ -30,6 +30,17 @@ export default function CorrelationsPlots(props: CorrelationsPlotsProps) {
     forwardSelectedLabels,
   } = props;
 
+  // HACK: so that Plotly will resize the plot when the user switches to this tab.
+  // Without this hack, if the plot loads while this tab is inactive, Plotly does not
+  // properly calculate plot size, and this can cause the plot to drastically overflow its bounds.
+  const [key, setKey] = React.useState(0);
+
+  React.useEffect(() => {
+    const handler = () => setKey((k) => k + 1);
+    window.addEventListener("changeTab:corr_analysis", handler);
+    return () => window.removeEventListener("changeTab:corr_analysis", handler);
+  }, []);
+
   const filteredDosesForCorrelatedDatasetVolcanoData = React.useCallback(
     (correlatedDatasetVolcanoData: DoseCategoryVolcanoData) => {
       if (dosesToFilter.length) {
@@ -55,7 +66,7 @@ export default function CorrelationsPlots(props: CorrelationsPlotsProps) {
   };
 
   return (
-    <div className={styles.plotContent}>
+    <div className={styles.plotContent} key={key}>
       <div className={styles.plotContainer}>
         {correlatedDatasetsToShow.map((correlatedDataset) => {
           return (

--- a/portal-backend/depmap/templates/compounds/index.html
+++ b/portal-backend/depmap/templates/compounds/index.html
@@ -190,14 +190,6 @@ active_tab_set = False %}
     id="corr_analysis"
   >
     <div id="correlations-analysis-tab-content"></div>
-    <script>
-      $(function () { // document ready for middle-of-html js
-          DepMap.initCorrelationAnalysisTab(
-              "correlations-analysis-tab-content",
-          {{name | tojson}},
-      );
-      });
-    </script>
     {% set active_tab_set = True %}
   </div>
 </div>
@@ -269,6 +261,12 @@ active_tab_set = False %}
           "compound",
           {{ predictability_custom_downloads_link | tojson }},
           {{ predictability_methodology_link | tojson }}
+        );
+      }
+      else if (target === "#corr_analysis") {
+        DepMap.initCorrelationAnalysisTab(
+          "correlations-analysis-tab-content",
+          {{name | tojson}},
         );
       }
       loadedTabs[target] = true;


### PR DESCRIPTION
Add fix where switching tabs before the correlation analysis page is fully loaded causes the correlation plots width to be out of bounds