### PR TITLE
Enriched Lineage Tile and Context Explorer Box Plot performance improvements

### DIFF
--- a/portal-backend/depmap/context/models_new.py
+++ b/portal-backend/depmap/context/models_new.py
@@ -1,5 +1,6 @@
+from dataclasses import dataclass
 from operator import and_
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 from depmap.database import (
     Column,
     ForeignKey,
@@ -16,6 +17,12 @@ from typing import Type
 from sqlalchemy import and_, or_
 from depmap.entity.models import Entity
 from depmap.cell_line.models_new import DepmapModel, depmap_model_context_association
+
+
+@dataclass
+class OtherModelDisplayNames:
+    heme: Dict[str, str]
+    solid: Dict[str, str]
 
 
 class TreeType(enum.Enum):
@@ -300,55 +307,68 @@ class SubtypeContext(Model):
         return node_models, all_model_ids
 
     @staticmethod
-    def get_model_ids_for_other_solid_contexts(
-        subtype_codes_to_filter_out: List[str],
-        tree_type: str,
-        all_sig_models: List[str],
-    ) -> Dict[str, str]:
-        subtype_codes_to_filter_out_set = set(subtype_codes_to_filter_out)
-        all_sig_models_set = set(all_sig_models)
-        depmap_model_contexts = (
+    def get_model_ids_for_other_heme_and_other_solid_contexts(
+        subtype_codes_to_filter_out: Set[str], tree_type: str, all_sig_models: Set[str],
+    ) -> OtherModelDisplayNames:
+        HEME_filter_exp = and_(
+            or_(SubtypeNode.level_0 == "MYELOID", SubtypeNode.level_0 == "LYMPH"),
+            SubtypeNode.tree_type == tree_type,
+        )
+
+        SOLID_filter_exp = and_(
+            SubtypeNode.level_0 != "MYELOID",
+            SubtypeNode.level_0 != "LYMPH",
+            SubtypeNode.tree_type == tree_type,
+        )
+
+        # We are looking for insignificant models only, so filter out significant subtype codes and models
+        depmap_model_context_query = (
             db.session.query(depmap_model_context_association)
             .filter(
                 (
                     depmap_model_context_association.c.subtype_code.notin_(
-                        subtype_codes_to_filter_out_set
+                        subtype_codes_to_filter_out
                     )
                 )
-                & (
-                    depmap_model_context_association.c.model_id.notin_(
-                        all_sig_models_set
-                    )
-                )
+                & (depmap_model_context_association.c.model_id.notin_(all_sig_models))
             )
             .join(
                 SubtypeNode,
                 SubtypeNode.subtype_code
                 == depmap_model_context_association.c.subtype_code,
             )
-            .filter(
-                and_(
-                    SubtypeNode.level_0 != "MYELOID",
-                    SubtypeNode.level_0 != "LYMPH",
-                    SubtypeNode.tree_type == tree_type,
+        )
+
+        other_heme_model_contexts = depmap_model_context_query.filter(
+            HEME_filter_exp
+        ).all()
+        other_solid_model_contexts = depmap_model_context_query.filter(
+            SOLID_filter_exp
+        ).all()
+
+        heme_display_name_series = {}
+        if len(other_heme_model_contexts) != 0:
+            heme_model_ids = [c[0] for c in other_heme_model_contexts]
+
+            if len(heme_model_ids) > 0:
+                heme_display_names = DepmapModel.get_cell_line_display_names(
+                    model_ids=list(set(heme_model_ids))
                 )
-            )
-            .all()
+                heme_display_name_series = heme_display_names.to_dict()
+
+        solid_display_name_series = {}
+        if len(other_solid_model_contexts) != 0:
+            solid_model_ids = [c[0] for c in other_solid_model_contexts]
+
+            if len(solid_model_ids) > 0:
+                solid_display_names = DepmapModel.get_cell_line_display_names(
+                    model_ids=list(set(solid_model_ids))
+                )
+                solid_display_name_series = solid_display_names.to_dict()
+
+        return OtherModelDisplayNames(
+            heme=heme_display_name_series, solid=solid_display_name_series
         )
-
-        if len(depmap_model_contexts) == 0:
-            return {}
-
-        model_ids = [c[0] for c in depmap_model_contexts]
-
-        if len(model_ids) == 0:
-            return {}
-
-        display_name_series = DepmapModel.get_cell_line_display_names(
-            model_ids=list(set(model_ids))
-        )
-
-        return display_name_series.to_dict()
 
     @staticmethod
     def get_model_ids_for_other_heme_contexts(

--- a/portal-backend/depmap/context/models_new.py
+++ b/portal-backend/depmap/context/models_new.py
@@ -13,7 +13,7 @@ from depmap.database import (
 import enum
 import pandas as pd
 from typing import Type
-from sqlalchemy import and_, or_, select
+from sqlalchemy import and_, or_
 from depmap.entity.models import Entity
 from depmap.cell_line.models_new import DepmapModel, depmap_model_context_association
 

--- a/portal-backend/depmap/context_explorer/box_plot_utils.py
+++ b/portal-backend/depmap/context_explorer/box_plot_utils.py
@@ -1,8 +1,7 @@
-import dataclasses
 from functools import partial
 from operator import contains
 import re
-from typing import Any, Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional, Set
 from depmap import data_access
 from depmap.cell_line.models_new import DepmapModel
 from depmap.compound.models import Compound
@@ -10,7 +9,9 @@ from depmap.context_explorer.models import (
     BoxCardData,
     ContextAnalysis,
     EnrichedLineagesTileData,
+    GroupedOtherBoxPlotData,
 )
+import dataclasses
 from depmap.dataset.models import DependencyDataset
 from depmap.gene.models import Gene
 from depmap.tile.views import get_dependency_dataset_for_entity
@@ -42,6 +43,35 @@ def _get_node_entity_data(
         entity_label=entity_label,
         entity_full_row_of_values=entity_full_row_of_values,
         entity_overview_page_label=entity_overview_page_label,
+    )
+
+
+def _get_box_data(
+    entity_full_row_of_values,
+    model_id_display_names: Dict[str, str],
+    category: Literal["heme", "solid"],
+) -> BoxData:
+    if model_id_display_names == {}:
+        return BoxData(
+            label="Other Heme" if category == "heme" else "Other Solid",
+            data=[],
+            cell_line_display_names=[],
+        )
+
+    model_ids = list(model_id_display_names.keys())
+    values = entity_full_row_of_values[entity_full_row_of_values.index.isin(model_ids)]
+
+    values.dropna(inplace=True)
+
+    display_names_series = DepmapModel.get_cell_line_display_names(model_ids=model_ids)
+    display_names_dict = display_names_series.to_dict()
+
+    context_values_index_by_display_name = values.rename(index=display_names_dict)
+
+    return BoxData(
+        label="Other Heme" if category == "heme" else "Other Solid",
+        data=context_values_index_by_display_name.tolist(),
+        cell_line_display_names=context_values_index_by_display_name.index.tolist(),
     )
 
 
@@ -164,52 +194,31 @@ def get_box_plot_card_data(
 
 
 def get_box_plot_data_for_other_category(
-    category: Literal["heme", "solid"],
-    all_sig_context_codes: List[str],
+    all_sig_context_codes: Set[str],
     entity_full_row_of_values,
     tree_type: str,
-    all_sig_models: List[str],
-) -> BoxData:
-    heme_model_id_series = (
-        SubtypeContext.get_model_ids_for_other_heme_contexts(
-            subtype_codes_to_filter_out=all_sig_context_codes,
-            tree_type=tree_type,
-            all_sig_models=all_sig_models,
-        )
-        if category == "heme"
-        else SubtypeContext.get_model_ids_for_other_solid_contexts(
-            subtype_codes_to_filter_out=all_sig_context_codes,
-            tree_type=tree_type,
-            all_sig_models=all_sig_models,
-        )
+    all_sig_models: Set[str],
+) -> GroupedOtherBoxPlotData:
+    heme_solid_model_ids = SubtypeContext.get_model_ids_for_other_heme_and_other_solid_contexts(
+        subtype_codes_to_filter_out=all_sig_context_codes,
+        tree_type=tree_type,
+        all_sig_models=all_sig_models,
     )
 
-    if heme_model_id_series == {}:
-        return BoxData(
-            label="Other Heme" if category == "heme" else "Other Solid",
-            data=[],
-            cell_line_display_names=[],
-        )
-
-    heme_model_ids = list(heme_model_id_series.keys())
-    heme_values = entity_full_row_of_values[
-        entity_full_row_of_values.index.isin(heme_model_ids)
-    ]
-
-    heme_values.dropna(inplace=True)
-
-    display_names_series = DepmapModel.get_cell_line_display_names(
-        model_ids=heme_model_ids
+    heme_model_ids = heme_solid_model_ids.heme
+    solid_model_ids = heme_solid_model_ids.solid
+    heme_box_data = _get_box_data(
+        entity_full_row_of_values=entity_full_row_of_values,
+        model_id_display_names=heme_model_ids,
+        category="heme",
     )
-    display_names_dict = display_names_series.to_dict()
-
-    context_values_index_by_display_name = heme_values.rename(index=display_names_dict)
-
-    return BoxData(
-        label="Other Heme" if category == "heme" else "Other Solid",
-        data=context_values_index_by_display_name.tolist(),
-        cell_line_display_names=context_values_index_by_display_name.index.tolist(),
+    solid_box_data = _get_box_data(
+        entity_full_row_of_values=entity_full_row_of_values,
+        model_id_display_names=solid_model_ids,
+        category="solid",
     )
+
+    return GroupedOtherBoxPlotData(heme=heme_box_data, solid=solid_box_data)
 
 
 def get_box_plot_data_for_context(
@@ -429,20 +438,11 @@ def get_context_plot_box_data(
                 if other_sig_data is not None:
                     other_box_plot_data.append(other_sig_data)
 
-    heme_box_plot_data = get_box_plot_data_for_other_category(
-        category="heme",
-        all_sig_context_codes=ordered_sig_context_codes,
+    solid_and_heme_box_data = get_box_plot_data_for_other_category(
+        all_sig_context_codes=set(ordered_sig_context_codes),
         entity_full_row_of_values=entity_full_row_of_values,
         tree_type=tree_type,
-        all_sig_models=all_sig_models,
-    )
-
-    solid_box_plot_data = get_box_plot_data_for_other_category(
-        category="solid",
-        all_sig_context_codes=ordered_sig_context_codes,
-        entity_full_row_of_values=entity_full_row_of_values,
-        tree_type=tree_type,
-        all_sig_models=all_sig_models,
+        all_sig_models=set(all_sig_models),
     )
 
     significant_selection = (
@@ -463,8 +463,8 @@ def get_context_plot_box_data(
         significant_selection=significant_selection,
         insignificant_selection=insignificant_selection,
         other_cards=other_box_plot_data,
-        insignificant_heme_data=heme_box_plot_data,
-        insignificant_solid_data=solid_box_plot_data,
+        insignificant_heme_data=solid_and_heme_box_data.heme,
+        insignificant_solid_data=solid_and_heme_box_data.solid,
         drug_dotted_line=drug_dotted_line,
         entity_label=node_entity_data.entity_label,
         entity_overview_page_label=node_entity_data.entity_overview_page_label,
@@ -549,9 +549,7 @@ def get_compound_experiment_and_dataset_name_from_compound(compound: Compound):
         compound.entity_id
     )
     compound_experiment_and_datasets = [
-        x
-        for x in compound_experiment_and_datasets
-        if not x[1].is_dose_replicate
+        x for x in compound_experiment_and_datasets if not x[1].is_dose_replicate
     ]  # filter for non dose replicate datasets"
     best_ce_and_d = temp_get_compound_experiment_dataset(
         compound_experiment_and_datasets
@@ -616,21 +614,16 @@ def get_data_to_show_if_no_contexts_significant(
     drug_dotted_line = (
         entity_full_row_of_values.mean() if entity_type == "compound" else None
     )
-    heme_box_plot_data = get_box_plot_data_for_other_category(
-        category="heme",
-        all_sig_context_codes=[],
-        entity_full_row_of_values=entity_full_row_of_values,
-        tree_type=tree_type,
-        all_sig_models=[],
-    )
 
-    solid_box_plot_data = get_box_plot_data_for_other_category(
-        category="solid",
+    grouped_other_box_plot_data = get_box_plot_data_for_other_category(
         all_sig_context_codes=[],
         entity_full_row_of_values=entity_full_row_of_values,
         tree_type=tree_type,
         all_sig_models=[],
     )
+    heme_box_plot_data = grouped_other_box_plot_data.heme
+
+    solid_box_plot_data = grouped_other_box_plot_data.solid
 
     dataset_units = data_access.get_dataset_units(dataset_id=dataset_name)
     assert dataset_units is not None

--- a/portal-backend/depmap/context_explorer/box_plot_utils.py
+++ b/portal-backend/depmap/context_explorer/box_plot_utils.py
@@ -616,10 +616,10 @@ def get_data_to_show_if_no_contexts_significant(
     )
 
     grouped_other_box_plot_data = get_box_plot_data_for_other_category(
-        all_sig_context_codes=[],
+        all_sig_context_codes=set(),
         entity_full_row_of_values=entity_full_row_of_values,
         tree_type=tree_type,
-        all_sig_models=[],
+        all_sig_models=set(),
     )
     heme_box_plot_data = grouped_other_box_plot_data.heme
 

--- a/portal-backend/depmap/context_explorer/models.py
+++ b/portal-backend/depmap/context_explorer/models.py
@@ -38,6 +38,12 @@ class BoxData:
 
 
 @dataclass
+class GroupedOtherBoxPlotData:
+    heme: BoxData
+    solid: BoxData
+
+
+@dataclass
 class BoxCardData:
     significant: List[BoxData]
     insignificant: BoxData


### PR DESCRIPTION
These changes improve the performance of the Enriched Lineages Tile and Context Explorer Box Plots. 

Instead of filtering out insignificant models in a nested list comprehension after the query, these changes use the depmap model context association table to filter within the query and also eliminate unnecessary joins.