### PR TITLE
Add custom error for reading large datasets

### DIFF
--- a/breadbox/breadbox/celery_task/utils.py
+++ b/breadbox/breadbox/celery_task/utils.py
@@ -6,7 +6,10 @@ from typing import Any, Dict, Optional
 from celery import current_app as current_celery_app
 import celery
 from celery.result import AsyncResult
-from breadbox.schemas.custom_http_exception import FileValidationError
+from breadbox.schemas.custom_http_exception import (
+    FileValidationError,
+    LargeDatasetReadError,
+)
 from ..compute.celery import app
 from fastapi import HTTPException
 from typing import Any, Optional
@@ -116,16 +119,18 @@ def format_task_status(task):
             # this is a specific, expected error that we check for
             # return error message for the front to display
             message = str(task.result.detail)
+        elif isinstance(task.result, FileValidationError):
+            message = str(task.result)
+        elif isinstance(task.result, LargeDatasetReadError):
+            message = str(task.result.detail)
         elif isinstance(task.result, HTTPException):
             message = {
                 "status_code": str(task.result.status_code),
                 "detail": str(task.result.status_code),
             }
-        elif isinstance(task.result, FileValidationError):
-            message = str(task.result)
         else:
-            # This is an unexpected error thrown while the task was running. 
-            # At this point, the error has already been logged in the celery error reporter 
+            # This is an unexpected error thrown while the task was running.
+            # At this point, the error has already been logged in the celery error reporter
             # and should be visible in the GCS Error Groups.
             message = "Encountered an unexpected error. Please try again later."
     elif task.state == TaskState.PENDING.name:

--- a/breadbox/breadbox/io/hdf5_utils.py
+++ b/breadbox/breadbox/io/hdf5_utils.py
@@ -1,6 +1,9 @@
 from typing import List, Optional, Literal
 
-from breadbox.schemas.custom_http_exception import FileValidationError
+from breadbox.schemas.custom_http_exception import (
+    FileValidationError,
+    LargeDatasetReadError,
+)
 from breadbox.schemas.dataframe_wrapper import ParquetDataFrameWrapper
 import h5py
 import numpy as np
@@ -169,4 +172,4 @@ def _validate_read_size(features_length: int, samples_length: int):
     TODO: We will need to handle reading large data
     """
     if features_length * samples_length * 8 > MAX_HDF5_READ_IN_BYTES:
-        raise Exception("Reading too many columns and rows into memory at once!")
+        raise LargeDatasetReadError(features_length, samples_length)

--- a/breadbox/breadbox/schemas/custom_http_exception.py
+++ b/breadbox/breadbox/schemas/custom_http_exception.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+from typing_extensions import Annotated, Doc
 from fastapi import HTTPException, status
 from pydantic import BaseModel
 from pydantic_settings import SettingsConfigDict
@@ -69,3 +71,11 @@ class ComputeLinearFitError(UserError):
 class CeleryConnectionError(HTTPException):
     def __init__(self, msg, error_code=503):
         super().__init__(error_code, msg)
+
+
+class LargeDatasetReadError(HTTPException):
+    def __init__(self, features_length, samples_length):
+        super().__init__(
+            status_code=507,
+            detail=f"This requires fetching data for {samples_length} samples and {features_length} features which is too large to be processed at once. This is not supported at this time.",
+        )


### PR DESCRIPTION
Adding error to give users more information for why large dataset reads failed. Note this error message should show in custom analyses ([see example here](https://app.asana.com/1/9513920295503/task/1210989013481144/comment/1211000799928061?focus=true))

