### PR TITLE
docs(breadbox): Document custom analysis API

### DIFF
--- a/breadbox/breadbox/api/compute.py
+++ b/breadbox/breadbox/api/compute.py
@@ -64,6 +64,13 @@ def compute_univariate_associations(
     user: str = Depends(get_user),
     settings: Settings = Depends(get_settings),
 ):
+    """
+    Custom analysis offers three different analysis types: "pearson", "association", and "two_class". 
+    In all 3 types, the caller must specify both: a dataset and a vector of data (which we refer to as the "query vector").
+    The query vector can be specified _either_ by providing the data (queryCellLines + queryValues) or by 
+    specifying identifiers for retrieving the data within breadbox (queryFeatureId + queryDatasetId).
+    For two class comparisons, the queryValues are the strings "in" and "out".
+    """
     utils.check_celery()
 
     resultsDirPrefix = settings.compute_results_location

--- a/breadbox/breadbox/api/compute.py
+++ b/breadbox/breadbox/api/compute.py
@@ -32,27 +32,22 @@ def _get_vector_is_dependent(
 
 def _validate_parameters(
     analysis_type: str,
-    query_node_id: Optional[str],
     query_feature_id: Optional[str],
     query_dataset_id: Optional[str],
     query_values: Optional[List[str]],
     depmap_model_ids: Optional[List[str]],
 ):
-    if query_node_id and query_feature_id and query_dataset_id:
-        raise UserError(
-            f"Query feature must be specified through either node id or feature id + dataset id, not both."
-        )
-    has_query_id = query_node_id or (query_feature_id and query_dataset_id)
+    has_query_identifiers = query_feature_id and query_dataset_id
     if (
         analysis_type == models.AnalysisType.pearson
         or analysis_type == models.AnalysisType.association
     ):
         # Values can be specified with either the query_id or query_values
-        assert (has_query_id and not query_values) or (
-            query_values and not has_query_id
+        assert (has_query_identifiers and not query_values) or (
+            query_values and not has_query_identifiers
         )
     elif analysis_type == models.AnalysisType.two_class:
-        assert not has_query_id
+        assert not has_query_identifiers
         assert depmap_model_ids
         assert query_values
     else:
@@ -85,7 +80,6 @@ def compute_univariate_associations(
     assert dataset_id is not None
     _validate_parameters(
         analysis_type=analysis_type,
-        query_node_id=computeParams.queryId,
         query_feature_id=computeParams.queryFeatureId,
         query_dataset_id=computeParams.queryDatasetId,
         query_values=query_values,
@@ -102,7 +96,6 @@ def compute_univariate_associations(
         result = utils.cast_celery_task(analysis_tasks.run_custom_analysis).delay(
             user=user,
             analysis_type=analysis_type,
-            query_node_id=computeParams.queryId,
             query_feature_id=computeParams.queryFeatureId,
             query_dataset_id=computeParams.queryDatasetId,
             filestore_location=settings.filestore_location,

--- a/breadbox/breadbox/compute/analysis_tasks.py
+++ b/breadbox/breadbox/compute/analysis_tasks.py
@@ -337,7 +337,7 @@ def run_custom_analysis(
             or analysis_type == models.AnalysisType.association
         ):
             if query_feature_id and query_dataset_id:
-                # The given query Id should be the id of the feature itself
+                # The query_feature_id is a given ID
                 feature = dataset_crud.get_dataset_feature_by_given_id(
                     db, query_dataset_id, query_feature_id
                 )

--- a/breadbox/breadbox/compute/analysis_tasks.py
+++ b/breadbox/breadbox/compute/analysis_tasks.py
@@ -190,7 +190,7 @@ def get_features_info_and_dataset(
     user: str,
     dataset_id: str,
     feature_filter_labels: Optional[List[str]] = None,
-    use_feature_ids=False,
+    use_feature_ids=False, # As opposed to slice IDs with feature labels
 ) -> Tuple[List[Feature], List[int], Dataset]:
     dataset = dataset_crud.get_dataset(db, user, dataset_id)
     if dataset is None:
@@ -292,7 +292,6 @@ def run_custom_analysis(
     self,
     user: str,
     analysis_type: str,  # pearson, association, or two_class
-    query_node_id: Optional[str],  # Query feature spec used by elara (deprecated)
     query_feature_id: Optional[
         str
     ],  # Query feature spec used by the portal (feature given id)
@@ -317,7 +316,7 @@ def run_custom_analysis(
     with db_context(user) as db:
 
         # All features and feature_indices for the dataset we're searching in
-        use_feature_ids = query_node_id is None
+        use_feature_ids=True
         features, feature_indices, dataset = get_features_info_and_dataset(
             db, user, dataset_id, use_feature_ids=use_feature_ids
         )
@@ -337,16 +336,7 @@ def run_custom_analysis(
             analysis_type == models.AnalysisType.pearson
             or analysis_type == models.AnalysisType.association
         ):
-            if query_node_id:
-                # This is the node for the feature of the vector we're querying
-                dataset_feature_id = query_node_id
-                feature_dataset = dataset_crud.get_dataset(db, user, dataset_feature_id)
-                if feature_dataset is None:
-                    raise ResourceNotFoundError("Query dataset not found")
-                query_series = get_feature_data_slice_values(
-                    db, user, dataset_feature_id, feature_dataset, filestore_location
-                )
-            elif query_feature_id and query_dataset_id:
+            if query_feature_id and query_dataset_id:
                 # The given query Id should be the id of the feature itself
                 feature = dataset_crud.get_dataset_feature_by_given_id(
                     db, query_dataset_id, query_feature_id
@@ -387,7 +377,6 @@ def run_custom_analysis(
             datasetId=dataset_id,
             query=dict(
                 analysisType=analysis_type,
-                queryId=query_node_id,
                 queryFeatureId=query_feature_id,
                 queryDatasetId=query_dataset_id,
                 queryValues=filtered_query_values_list,

--- a/breadbox/breadbox/schemas/compute.py
+++ b/breadbox/breadbox/schemas/compute.py
@@ -4,24 +4,38 @@ from typing import Optional, Annotated, Any, List, Literal, Union
 
 class ComputeParams(BaseModel):
     analysisType: Annotated[
-        Optional[Literal["pearson", "association", "two_class"]],
+        Literal["pearson", "association", "two_class"],
         Field(description="The type of analysis to run")
-    ] = None
+    ]
     datasetId: Annotated[
         str, Field(description="The given ID or UUID of the dataset to search for association")
     ]
 
-    # Specify these two if using a feature defined in breadbox
+    # Option 1 for specifying a "query vector": Provide the dataset ID and feature given ID.
     queryFeatureId: Annotated[
-        Optional[str], Field(description="")
+        Optional[str], 
+        Field(description="The given ID of the feature/slice which is being queried (ex. for genes, this would be an entrez ID). If specified, the caller must also provide the `queryDatasetId`.")
     ] = None
-    queryDatasetId: Optional[str] = None
+    queryDatasetId: Annotated[
+        Optional[str], 
+        Field(description="The UUID or dataset given ID of the dataset in which the query feature/slice is defined. If specified, the caller must also provide the `queryFeatureId`.")
+    ] = None
 
-    # Specify this if using a feature not defined in breadbox
-    queryCellLines: Optional[List[str]] = None # Alternatively, could take slice Query
-    queryValues: Optional[List[Any]] = None
-    # TODO: rename this to "association_var_independence", add better typing
-    vectorVariableType: Optional[str] = None # Either "dependent" or "independent". Only relevant for Association and two-class
+    # Option 2 for specifying a "query vector": Provide the values and IDs of the slice. 
+    # This option is used when calling custom analysis from the breadbox_shim in the portal-backend.
+    queryCellLines: Annotated[
+        Optional[list[str]],
+        Field(description="A list of identifiers for the query vector. At the moment, this is always cell lines. If provided, the caller must also provide the `queryValues`.")
+    ] = None
+    queryValues: Annotated[
+        Optional[list[Any]],
+        Field(description="A list of values for the query vector. If provided, the caller must also provide the `queryCellLines`.")
+    ] = None
+
+    vectorVariableType: Annotated[
+        Optional[Literal["dependent", "independent"]],
+        Field(description="Describes whether the dataset is expected to be independent or dependent from the query vector. Only relevant for `association` and `two_class` analyses")
+    ] = None
 
 
 class ComputeResponse(BaseModel):

--- a/breadbox/breadbox/schemas/compute.py
+++ b/breadbox/breadbox/schemas/compute.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Optional, Annotated, Any, List, Literal, Union
+from typing import Optional, Annotated, Any, Literal
 
 
 class ComputeParams(BaseModel):

--- a/breadbox/breadbox/schemas/compute.py
+++ b/breadbox/breadbox/schemas/compute.py
@@ -11,21 +11,15 @@ class ComputeParams(BaseModel):
         str, Field(description="The given ID or UUID of the dataset to search for association")
     ]
 
-    # Either queryId (node id) or queryFeatureId and queryDatasetId are required
-    # queryId is a deprecated query type which is only used by Elara
-    # TODO: remove this
-    queryId: Optional[str] = None # REMOVE
-
-    # TODO: check if this is used? It's different from the portal backend
+    # Specify these two if using a feature defined in breadbox
     queryFeatureId: Annotated[
         Optional[str], Field(description="")
     ] = None
     queryDatasetId: Optional[str] = None
 
+    # Specify this if using a feature not defined in breadbox
     queryCellLines: Optional[List[str]] = None # Alternatively, could take slice Query
-    queryValues: Optional[List[Any]] = (
-        None  # The query may be specified with either the QueryId or QueryValues
-    )
+    queryValues: Optional[List[Any]] = None
     # TODO: rename this to "association_var_independence", add better typing
     vectorVariableType: Optional[str] = None # Either "dependent" or "independent". Only relevant for Association and two-class
 

--- a/breadbox/breadbox/schemas/compute.py
+++ b/breadbox/breadbox/schemas/compute.py
@@ -1,20 +1,33 @@
 from pydantic import BaseModel, Field
-from typing import Optional, Any, List
+from typing import Optional, Annotated, Any, List, Literal, Union
 
 
 class ComputeParams(BaseModel):
-    analysisType: str
-    datasetId: str
+    analysisType: Annotated[
+        Optional[Literal["pearson", "association", "two_class"]],
+        Field(description="The type of analysis to run")
+    ] = None
+    datasetId: Annotated[
+        str, Field(description="The given ID or UUID of the dataset to search for association")
+    ]
+
     # Either queryId (node id) or queryFeatureId and queryDatasetId are required
     # queryId is a deprecated query type which is only used by Elara
-    queryId: Optional[str] = None
-    queryFeatureId: Optional[str] = None
+    # TODO: remove this
+    queryId: Optional[str] = None # REMOVE
+
+    # TODO: check if this is used? It's different from the portal backend
+    queryFeatureId: Annotated[
+        Optional[str], Field(description="")
+    ] = None
     queryDatasetId: Optional[str] = None
-    vectorVariableType: Optional[str] = None
-    queryCellLines: Optional[List[str]] = None
+
+    queryCellLines: Optional[List[str]] = None # Alternatively, could take slice Query
     queryValues: Optional[List[Any]] = (
         None  # The query may be specified with either the QueryId or QueryValues
     )
+    # TODO: rename this to "association_var_independence", add better typing
+    vectorVariableType: Optional[str] = None # Either "dependent" or "independent". Only relevant for Association and two-class
 
 
 class ComputeResponse(BaseModel):

--- a/breadbox/tests/api/test_celery.py
+++ b/breadbox/tests/api/test_celery.py
@@ -167,7 +167,6 @@ def test_compute_univariate_associations(
         "queryValues": ["in"] * num_in + ["out"] * num_out if useQueryValues else None,
         "analysisType": analysisType,
         "datasetId": dataset_id,
-        "queryId": None,
         "queryFeatureId": query_feature_id if useQueryId else None,
         "queryDatasetId": query_dataset_id if useQueryId else None,
         "vectorVariableType": (
@@ -320,7 +319,6 @@ def test_compute_univariate_associations_intersection_with_minimum_points(
         "queryValues": None,
         "analysisType": "association",
         "datasetId": dataset_id,
-        "queryId": None,
         "queryFeatureId": query_feature_id,
         "queryDatasetId": query_dataset_id,
         "vectorVariableType": "dependent",

--- a/breadbox/tests/api/test_compute.py
+++ b/breadbox/tests/api/test_compute.py
@@ -352,9 +352,14 @@ def test_run_custom_analysis_pearson_with_feature_ids_and_query_values(
     tmpdir, minimal_db: SessionWithUser, settings, monkeypatch
 ):
     """
-    The legacy portal makes custom analysis requests to breadbox with a slightly different format.
-    Instead of using the uery_feature_id + query_dataset_id params, it sometimes passes in 
-    pre-loaded query values. 
+    Not all data exists in breadbox (yet)! And as a result, we sometimes need a subset of the custom 
+    analysis data to be loaded from the portal-backend and the other subset to be loaded in breadbox. 
+    This tests the case where the feature/"query vector" data is loaded in the portal-backend and the 
+    dataset data is loaded from breadbox. Since the "dataset data" is often large, we perform the analysis in 
+    breadbox in this case. 
+
+    Once the Custom Analysis frontend has been updated to read exclusively from breadbox, we could probably
+    drop support for this functionality.  
     """
 
     @contextmanager

--- a/breadbox/tests/api/test_compute.py
+++ b/breadbox/tests/api/test_compute.py
@@ -254,7 +254,6 @@ def _run_custom_analysis_test_wrapper(
 
     compute._validate_parameters(
         analysis_type=analysis_type,
-        query_node_id=None,
         query_feature_id=query_feature_id,
         query_dataset_id=query_dataset_id,
         query_values=query_values,
@@ -266,7 +265,6 @@ def _run_custom_analysis_test_wrapper(
     result = run_custom_analysis(
         user=settings.default_user,
         analysis_type=analysis_type.name,
-        query_node_id=None,
         query_feature_id=query_feature_id,
         query_dataset_id=query_dataset_id,
         filestore_location=settings.filestore_location,
@@ -355,8 +353,8 @@ def test_run_custom_analysis_pearson_with_feature_ids_and_query_values(
 ):
     """
     The legacy portal makes custom analysis requests to breadbox with a slightly different format.
-    1. It uses feature ids instead of node ids (with the flag use_feature_ids=True)
-    2. It sometimes passes in pre-loaded query values instead of using the query_node_id parameter
+    Instead of using the uery_feature_id + query_dataset_id params, it sometimes passes in 
+    pre-loaded query values. 
     """
 
     @contextmanager
@@ -395,7 +393,6 @@ def test_run_custom_analysis_pearson_with_feature_ids_and_query_values(
     result = run_custom_analysis(
         user=settings.default_user,
         analysis_type=AnalysisType.pearson.name,
-        query_node_id=None,
         query_feature_id=None,
         query_dataset_id=None,
         filestore_location=settings.filestore_location,
@@ -748,7 +745,6 @@ def test_no_overlap(
         "queryCellLines": [],
         "analysisType": "association",
         "datasetId": dataset_id,
-        "queryId": None,
         "queryFeatureId": "A",
         "queryDatasetId": dataset2.id,
         "vectorVariableType": "dependent",


### PR DESCRIPTION
**Making a couple of updates, with the goal of making the Custom Analysis API easier to use:**
1. Adding documentation that will appear in the Swagger docs
2. Removing an old parameter (`query_id`) which is no longer being used in breadbox. For context, we used to use this parameter to pass in a "Node ID", which was an identifier that was used in the old `vector_catalog` endpoints. The `queryId` parameter has since been updated to take feature IDs instead of Node IDs, but it's still not being used - and I don't think we don't have any plans to use it in the future.  

After these changes, the swagger page looks like this:
<img width="1402" height="806" alt="image" src="https://github.com/user-attachments/assets/11756bba-9048-456f-a6c7-2edff3758508" />