### PR TITLE
refactor(breadbox): simplify custom analysis feature loading

### DIFF
--- a/breadbox/breadbox/compute/download_tasks.py
+++ b/breadbox/breadbox/compute/download_tasks.py
@@ -315,7 +315,7 @@ def get_feature_and_sample_indices_per_merged_dataset(
     feature_indices_per_dataset: List[List[int]] = []
     datasets: List[Dataset] = []
     for dataset_id in dataset_ids:
-        features, feature_indices, dataset = get_features_info_and_dataset(
+        _, feature_indices, dataset = get_features_info_and_dataset(
             db, user, dataset_id, feature_labels
         )
 
@@ -446,7 +446,7 @@ def export_dataset(
         settings = get_settings()
 
         # Get feature_indices using feature_labels as a filter
-        features, feature_indices, dataset = get_features_info_and_dataset(
+        _, feature_indices, dataset = get_features_info_and_dataset(
             db, user, dataset_id, feature_labels
         )
 

--- a/breadbox/tests/api/test_downloads.py
+++ b/breadbox/tests/api/test_downloads.py
@@ -58,7 +58,7 @@ def test_get_processed_df(minimal_db, settings):
     # Query as the default user
     user = settings.default_user
     minimal_db.reset_user(user)
-    feature_labels, feature_indices, dataset = get_features_info_and_dataset(
+    _, feature_indices, dataset = get_features_info_and_dataset(
         db=minimal_db,
         user=user,
         dataset_id=created_dataset.id,


### PR DESCRIPTION
Following up on one of @jessica-cheng 's comments on my last PR [here](https://github.com/broadinstitute/depmap-portal/pull/370/files#r2263689493), I had initially been thinking that some of this refactoring would need to wait until after the old implementation of custom analysis was removed from the portal-backend. I created a follow-up task in Asana ([here](https://app.asana.com/1/9513920295503/project/1165651979405609/task/1211008695306454?focus=true)) to work on some of that at a later date. However, as I was writing up that task, I realized that some of the complexity we have in this `get_features_info_and_dataset` function could be easily simplified now (and wanted to do it while it was fresh in my mind)

There is still more to do, but hopefully this is a small step in the right direction. 