### PR TITLE
Fix gene page characterization plots bug

### DIFF
--- a/frontend/packages/portal-frontend/src/genePage/components/GeneCharacterizationPanel.tsx
+++ b/frontend/packages/portal-frontend/src/genePage/components/GeneCharacterizationPanel.tsx
@@ -40,10 +40,7 @@ const GeneCharacterizationPanel = ({
   }, [symbol]);
 
   useEffect(() => {
-    const handler = () =>
-      document.querySelectorAll(".js-plotly-plot").forEach((el) => {
-        window.Plotly?.Plots?.resize(el as HTMLElement);
-      });
+    const handler = () => window.dispatchEvent(new Event("resize"));
     window.addEventListener("changeTab:characterization", handler);
     return () =>
       window.removeEventListener("changeTab:characterization", handler);
@@ -82,11 +79,7 @@ const GeneCharacterizationPanel = ({
       orientation="vertical"
       // HACK: Use the onChange event to resize plots that may have been improperly
       // sized if the window size change while the plots were loaded on a hidden tab.
-      onChange={() => {
-        document.querySelectorAll(".js-plotly-plot").forEach((el) => {
-          window.Plotly?.Plots?.resize(el as HTMLElement);
-        });
-      }}
+      onChange={() => window.dispatchEvent(new Event("resize"))}
     >
       <TabList className={styles.TabList}>
         {characterizations.map((c: any) => (

--- a/frontend/packages/portal-frontend/src/genePage/components/GeneCharacterizationPanel.tsx
+++ b/frontend/packages/portal-frontend/src/genePage/components/GeneCharacterizationPanel.tsx
@@ -80,6 +80,8 @@ const GeneCharacterizationPanel = ({
       lazyBehavior="keepMounted"
       queryParamName="characterization"
       orientation="vertical"
+      // HACK: Use the onChange event to resize plots that may have been improperly
+      // sized if the window size change while the plots were loaded on a hidden tab.
       onChange={() => {
         document.querySelectorAll(".js-plotly-plot").forEach((el) => {
           window.Plotly?.Plots?.resize(el as HTMLElement);

--- a/frontend/packages/portal-frontend/src/genePage/components/GeneCharacterizationPanel.tsx
+++ b/frontend/packages/portal-frontend/src/genePage/components/GeneCharacterizationPanel.tsx
@@ -39,18 +39,29 @@ const GeneCharacterizationPanel = ({
     })();
   }, [symbol]);
 
+  useEffect(() => {
+    const handler = () =>
+      document.querySelectorAll(".js-plotly-plot").forEach((el) => {
+        window.Plotly?.Plots?.resize(el as HTMLElement);
+      });
+    window.addEventListener("changeTab:characterization", handler);
+    return () =>
+      window.removeEventListener("changeTab:characterization", handler);
+  }, []);
+
   if (!characterizations) {
     return <div>Loading...</div>;
   }
 
   // After a tile loads, we run a regex to find all the <script> tags within
   // it and evaluate them.
-  const evaluateAllScripts = (html: string) => {
+  const evaluateAllScripts = async (html: string) => {
     // An `elementId` variable needs to be in scope even though it appears to
     // be unused. It's actually used interally by the scripts when they're
     // eval'd below.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    let elementId;
+    // Inside AsyncTile's data fetching logic
+    await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 second delay
 
     const scriptsRegex = /<script\b[^>]*>([\s\S]*?)<\/script>/gm;
     let match;
@@ -70,6 +81,11 @@ const GeneCharacterizationPanel = ({
       lazyBehavior="keepMounted"
       queryParamName="characterization"
       orientation="vertical"
+      onChange={() => {
+        document.querySelectorAll(".js-plotly-plot").forEach((el) => {
+          window.Plotly?.Plots?.resize(el as HTMLElement);
+        });
+      }}
     >
       <TabList className={styles.TabList}>
         {characterizations.map((c: any) => (

--- a/frontend/packages/portal-frontend/src/genePage/components/GeneCharacterizationPanel.tsx
+++ b/frontend/packages/portal-frontend/src/genePage/components/GeneCharacterizationPanel.tsx
@@ -55,13 +55,12 @@ const GeneCharacterizationPanel = ({
 
   // After a tile loads, we run a regex to find all the <script> tags within
   // it and evaluate them.
-  const evaluateAllScripts = async (html: string) => {
+  const evaluateAllScripts = (html: string) => {
     // An `elementId` variable needs to be in scope even though it appears to
     // be unused. It's actually used interally by the scripts when they're
     // eval'd below.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    // Inside AsyncTile's data fetching logic
-    await new Promise((resolve) => setTimeout(resolve, 2000)); // 2 second delay
+    let elementId;
 
     const scriptsRegex = /<script\b[^>]*>([\s\S]*?)<\/script>/gm;
     let match;


### PR DESCRIPTION
### Bug Report:

In Slack, someone reported the following: a "small bug with the Enriched Lineages tile on skyros (not sure if this applies to other portals). To reproduce it go to any gene page -> immediately go to the predictability tab BEFORE the Enriched Lineages tile fully renders -> wait for predictability tab to fully render -> come back to the overview tab. This seems to happen to the plot sizing on the characterization tab as well "

### Part of the reported bug was already fixed:
The enriched lineages bug had already been fixed. The enriched lineages tile plots were a React component, and so the fix was simpler: https://github.com/broadinstitute/depmap-portal/commit/910cf2447ba037e61e0ada3b884b8845b07c2124 and https://github.com/broadinstitute/depmap-portal/blob/910cf2447ba037e61e0ada3b884b8845b07c2124/frontend/packages/portal-frontend/src/contextExplorer/components/boxPlots/CollapsibleBoxPlots.tsx#L216-L225

### To solve the remaining issue for the characterization tab I had to:
1. Fix the sizing problem on the initial tab change (e.g. from the Overview tab to the Characterization tab) via a `document.querySelectorAll` (instead of using a key change hack to force rerender) fired in response to the `changeTab:{tab} `event that was added as part of the enriched lineages tile sizing bug.
```
useEffect(() => {
    const handler = () =>
      document.querySelectorAll(".js-plotly-plot").forEach((el) => {
        window.Plotly?.Plots?.resize(el as HTMLElement);
      });
    window.addEventListener("changeTab:characterization", handler);
    return () =>
      window.removeEventListener("changeTab:characterization", handler);
  }, []);

```
2. There was an additional sizing issue caused by the Characterization tab's nested TabsWithHistory. To solve this I added the following to the inner TabsWithHistory props: 
```
onChange={() => {
        document.querySelectorAll(".js-plotly-plot").forEach((el) => {
          window.Plotly?.Plots?.resize(el as HTMLElement);
        });
      }}
```