### PR TITLE
update UI to no longer use labels from /datasets/dimension/data/

### DIFF
--- a/frontend/packages/@depmap/api/src/breadboxAPI/resources/datasets.ts
+++ b/frontend/packages/@depmap/api/src/breadboxAPI/resources/datasets.ts
@@ -127,7 +127,6 @@ export function getMatrixDatasetSamples(dataset_id: string) {
 export function getDimensionData(sliceQuery: SliceQuery) {
   return postJson<{
     ids: string[];
-    labels: string[];
     values: string[];
   }>("/datasets/dimension/data/", sliceQuery);
 }


### PR DESCRIPTION
We want to rework this endpoint to only return a set of `ids` and `values`. The responses can be quite large so eliminating `labels` will help shrink them (at least a little bit).

`labels` can be fetched from `/types/dimensions/{name}/identifiers` instead.

This PR updates the UI to do exactly that so it will be safe to make the change on the backend.