### PR TITLE
prefer other endpoints over /datasets/dimension/data/ in DE2 UI

### DIFF
--- a/frontend/packages/@depmap/api/src/breadboxAPI/resources/datasets.ts
+++ b/frontend/packages/@depmap/api/src/breadboxAPI/resources/datasets.ts
@@ -127,6 +127,7 @@ export function getMatrixDatasetSamples(dataset_id: string) {
 export function getDimensionData(sliceQuery: SliceQuery) {
   return postJson<{
     ids: string[];
+    labels: string[];
     values: string[];
   }>("/datasets/dimension/data/", sliceQuery);
 }

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/helpers.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/helpers.ts
@@ -1,0 +1,82 @@
+import { breadboxAPI, cached } from "@depmap/api";
+import { SliceQuery } from "@depmap/types";
+
+// WORKAROUND: This works much like the Breadbox API function
+// `getDimensionData` but leverages a few different endpoints, which have
+// mostly overlapping functionality but don't include labels in the response.
+// THe idea is to limit the size of the response as much as possible. Dimension
+// types with 100K+ features, such as transcripts, present a particular
+// challenge. The responses are sometimes so large that nginx refuses to serve
+// them.
+export async function getDimensionDataWithoutLabels(slice: SliceQuery) {
+  if (slice.identifier_type === "column") {
+    const wrapper = await cached(breadboxAPI).getTabularDatasetData(
+      slice.dataset_id,
+      {
+        columns: [slice.identifier],
+      }
+    );
+
+    const indexedData = wrapper[slice.identifier];
+
+    return {
+      ids: Object.keys(indexedData),
+      values: Object.values(indexedData),
+    };
+  }
+
+  if (["feature_id", "feature_label"].includes(slice.identifier_type)) {
+    const features = await cached(breadboxAPI).getMatrixDatasetData(
+      slice.dataset_id,
+      {
+        feature_identifier:
+          slice.identifier_type === "feature_id" ? "id" : "label",
+        features: [slice.identifier],
+      }
+    );
+
+    if (Object.keys(features).length === 0) {
+      return { ids: [] as string[], values: [] as any[] };
+    }
+
+    // The response is always an object keyed with feature IDs.
+    // In this case, we've only requested one feature.
+    const onlyFeatureId = Object.keys(features)[0];
+    const valuesBySampleId = features[onlyFeatureId];
+
+    return {
+      ids: Object.keys(valuesBySampleId),
+      values: Object.values(valuesBySampleId),
+    };
+  }
+
+  if (["sample_id", "sample_label"].includes(slice.identifier_type)) {
+    const features = await cached(breadboxAPI).getMatrixDatasetData(
+      slice.dataset_id,
+      {
+        sample_identifier:
+          slice.identifier_type === "sample_id" ? "id" : "label",
+        samples: [slice.identifier],
+      }
+    );
+
+    if (Object.keys(features).length === 0) {
+      return { ids: [] as string[], values: [] as any[] };
+    }
+
+    // The response is always an object keyed with feature IDs.
+    const ids = Object.keys(features);
+    // Each value of `features` is itself an object with
+    // only one key (the single sample we requested).
+    const onlySampleId = Object.keys(features[ids[0]])[0];
+
+    return {
+      ids,
+      values: Object.values(features).map(
+        (valueForSampleId) => valueForSampleId[onlySampleId]
+      ),
+    };
+  }
+
+  throw new Error(`Bad slice query ${JSON.stringify(slice)}`);
+}


### PR DESCRIPTION
That endpoint's response format includes not just ids and values but also the labels for each feature/sample. In the case of the dimension type "transcript" (which has around 160K features), that can cause the request to fail.

More context:
https://app.asana.com/1/9513920295503/project/1165651979405609/task/1211048526298770

These two endpoints can be used to achieve similar results: 
`/datasets/matrix/{dataset_id}`
`/datasets/tabular/{dataset_id}`

The idea is to replace any request that uses a slice query with an equivalent subset operation (i.e. a slice can be thought of as subset based on exactly one sample id, feature id, or column name).

While being less ergonomic, those endpoints respond with only values indexed by ids, omitting labels completely, so they're preferable for requesting large slices.

This commit reworks a few operations in the Data Explorer UI to work that way.