### PR TITLE
make `evaluateLegacyContext` forward compatible 

### DIFF
--- a/frontend/packages/@depmap/data-explorer-2/src/services/deprecatedDataExplorerAPI/portalMethods.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/deprecatedDataExplorerAPI/portalMethods.ts
@@ -1,10 +1,13 @@
 import qs from "qs";
+import { cached, breadboxAPI } from "@depmap/api";
 import { ComputeResponseResult } from "@depmap/compute";
 import { getUrlPrefix } from "@depmap/globals";
 import {
   DataExplorerAnonymousContext,
   DataExplorerContext,
+  DataExplorerContextV2,
 } from "@depmap/types";
+import { isV2Context } from "../../utils/context";
 
 const urlPrefix = `${getUrlPrefix().replace(/^\/$/, "")}/data_explorer_2`;
 const fetchJsonCache: Record<string, Promise<unknown> | null> = {};
@@ -148,6 +151,21 @@ export async function fetchLegacyAssociations(
 export async function evaluateLegacyContext(
   context: DataExplorerContext | DataExplorerAnonymousContext
 ): Promise<string[]> {
+  // It's possible that we've been passed a V2 context
+  // because this hacky wrapper is not properly typed:
+  // https://github.com/broadinstitute/depmap-portal/blob/5b38776/frontend/packages/@depmap/data-explorer-2/src/components/ContextSelector/index.tsx#L6-L15
+  // For now we'll detect when this happens and defer to Breadbox.
+  // This is only temporary code anyway and will be removed
+  // when we sunset all the legacy Portal's DE2 endpoints.
+  if (isV2Context(context as any)) {
+    const v2Context = (context as unknown) as DataExplorerContextV2;
+    const result = await cached(breadboxAPI).evaluateContext(v2Context);
+
+    return v2Context.dimension_type === "depmap_model"
+      ? result.ids
+      : result.labels;
+  }
+
   return postJson<string[]>("/context/labels", { context });
 }
 

--- a/frontend/packages/@depmap/data-explorer-2/src/utils/extend-react-select.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/extend-react-select.tsx
@@ -351,6 +351,7 @@ export default function extendReactSelect(
                   <span className={styles.placeholder}>{placeholder}</span>
                 )
               }
+              menuPosition="fixed"
               menuPortalTarget={menuPortalTarget}
               className={cx(styles.Select, props.className, {
                 [styles.selectError]: hasError,


### PR DESCRIPTION
This is a deprecated function that will be removed soon anyway. There would be no real reason to call it while in "Breadbox mode." But in the off chance that someone tries to do that, it will now detect that and defer the API request to Breadbox.