### PR TITLE
Gene tea misc bug fixes and small feature additions

### DIFF
--- a/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
+++ b/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
@@ -27,6 +27,7 @@ interface Props {
   columns: UseTableOptions<object>["columns"];
   data: UseTableOptions<object>["data"];
   selectedLabels: Set<string> | null;
+  minimumAllowedSelections?: number;
   idProp?: string;
   onChangeSelections?: (selections: any[]) => void;
   rowHeight?: number;
@@ -57,6 +58,7 @@ const ReactTableV7 = React.forwardRef(
       idProp,
       onChangeSelections,
       selectedLabels,
+      minimumAllowedSelections = undefined,
       rowHeight = 24,
       getTrProps = undefined,
       singleSelectionMode = false,
@@ -304,6 +306,11 @@ const ReactTableV7 = React.forwardRef(
           const nextSelections = new Set(prevSelections);
 
           if (nextSelections.has(idValue)) {
+            if (
+              minimumAllowedSelections &&
+              nextSelections.size === minimumAllowedSelections
+            )
+              return nextSelections;
             nextSelections.delete(idValue);
           } else {
             nextSelections.add(idValue);

--- a/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
+++ b/frontend/packages/@depmap/wide-table/src/ReactTableV7.tsx
@@ -309,8 +309,9 @@ const ReactTableV7 = React.forwardRef(
             if (
               minimumAllowedSelections &&
               nextSelections.size === minimumAllowedSelections
-            )
+            ) {
               return nextSelections;
+            }
             nextSelections.delete(idValue);
           } else {
             nextSelections.add(idValue);
@@ -327,7 +328,7 @@ const ReactTableV7 = React.forwardRef(
           return nextSelections;
         });
       },
-      [rows, idProp, onChangeSelections]
+      [rows, idProp, onChangeSelections, minimumAllowedSelections]
     );
 
     const handleClickSingleSelectCheckbox = useCallback(

--- a/frontend/packages/@depmap/wide-table/src/WideTable.tsx
+++ b/frontend/packages/@depmap/wide-table/src/WideTable.tsx
@@ -135,6 +135,13 @@ export interface WideTableProps {
   onChangeSelections?: (selections: any[]) => void;
 
   /**
+   *  Use this to prevent the user from selecting less than some number of selections. This is useful
+   *  if some number of table rows is selected by default and it does not make sense to allow the user
+   *  to reach 0 rows selected. Used in GeneTEA (frontend/packages/portal-frontend/src/geneTea/components/GeneTeaTable.tsx)
+   */
+  minimumAllowedSelections?: number;
+
+  /**
    *  This determines what property of each row will be used to track
    *  selections. Must be defined to if `onChangeSelections` is.
    */
@@ -1033,6 +1040,7 @@ class WideTable extends React.Component<WideTableProps, WideTableState> {
           hideSelectAllCheckbox={this.props.hideSelectAllCheckbox}
           initialSortBy={this.props.sorted}
           fixedHeight={this.props.fixedHeight}
+          minimumAllowedSelections={this.props.minimumAllowedSelections}
         />
       </div>
     );

--- a/frontend/packages/portal-frontend/src/geneTea/components/GeneTeaMainContent.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/GeneTeaMainContent.tsx
@@ -81,7 +81,7 @@ function GeneTeaMainContent({ tab }: GeneTeaMainContentProps) {
   );
 
   const [plotElement, setPlotElement] = useState<ExtendedPlotType | null>(null);
-
+  console.log("selectedTableRows", selectedTableRows);
   // Get the table data and prefferedTableDataForDownload. Combined in this useMemo so we don't
   // have to iterate through allEnrichedTerms twice. The only difference is that the tableData is
   // rounded, while the prefferedTableDataForDownload is NOT rounded.
@@ -194,9 +194,10 @@ function GeneTeaMainContent({ tab }: GeneTeaMainContentProps) {
               ? selectedTableRows
               : new Set(rawData.enrichedTerms?.term)
           }
-          handleChangeSelection={(selections: string[]) =>
-            handleSetSelectedTableRows(new Set(selections))
-          }
+          handleChangeSelection={(selections: string[]) => {
+            if (selections.length === 0) return;
+            handleSetSelectedTableRows(new Set(selections));
+          }}
         />
       )}
     </div>

--- a/frontend/packages/portal-frontend/src/geneTea/components/GeneTeaMainContent.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/GeneTeaMainContent.tsx
@@ -81,7 +81,7 @@ function GeneTeaMainContent({ tab }: GeneTeaMainContentProps) {
   );
 
   const [plotElement, setPlotElement] = useState<ExtendedPlotType | null>(null);
-  console.log("selectedTableRows", selectedTableRows);
+
   // Get the table data and prefferedTableDataForDownload. Combined in this useMemo so we don't
   // have to iterate through allEnrichedTerms twice. The only difference is that the tableData is
   // rounded, while the prefferedTableDataForDownload is NOT rounded.
@@ -133,6 +133,7 @@ function GeneTeaMainContent({ tab }: GeneTeaMainContentProps) {
       </div>
     );
   }
+
   // Default: Top Tea Terms main content
   return (
     <div className={styles.mainContentContainer}>

--- a/frontend/packages/portal-frontend/src/geneTea/components/GeneTeaTable.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/GeneTeaTable.tsx
@@ -54,6 +54,7 @@ const GeneTeaTable: React.FC<GeneTeaTableProps> = ({
           hideSelectAllCheckbox
           allowDownloadFromTableDataWithMenu
           allowDownloadFromTableDataWithMenuFileName="gene-tea-data.csv"
+          minimumAllowedSelections={1}
         />
       </div>
     );

--- a/frontend/packages/portal-frontend/src/geneTea/components/MultiSelectTextArea.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/MultiSelectTextArea.tsx
@@ -5,13 +5,13 @@ import { useGeneTeaContext } from "../context/GeneTeaContext";
 import { MAX_GENES_ALLOWED } from "../types";
 
 // TODO move to utils
-function removeLineBreaks(text: string): string {
+function replaceLineBreaksWithSingleSpace(text: string): string {
   // The regular expression /(\r\n|\n|\r)/g matches all occurrences of:
   // - \r\n (carriage return followed by newline, common on Windows)
   // - \n (newline, common on Unix/Linux/macOS)
   // - \r (carriage return, less common but still possible)
   // The 'g' flag ensures that all occurrences are replaced, not just the first one.
-  return text.replace(/(\r\n|\n|\r)/g, "");
+  return text.replace(/(\r\n|\n|\r)/g, " ");
 }
 
 const MultiSelectTextarea: React.FC = () => {
@@ -41,7 +41,7 @@ const MultiSelectTextarea: React.FC = () => {
     if (e.key === "Enter" && inputValue.trim() !== "") {
       e.preventDefault(); // Prevent newline in textarea
 
-      const newItems = removeLineBreaks(inputValue)
+      const newItems = replaceLineBreaksWithSingleSpace(inputValue)
         .split(/[, ]+/)
         .filter((item) => item.trim() !== "");
       handleSetGeneSymbolSelections(
@@ -167,7 +167,7 @@ const MultiSelectTextarea: React.FC = () => {
           className={styles.selectGenesButton}
           disabled={inputValue.length === 0}
           onClick={() => {
-            const newItems = removeLineBreaks(inputValue)
+            const newItems = replaceLineBreaksWithSingleSpace(inputValue)
               .split(/[, ]+/)
               .filter((item) => item.trim() !== "");
             handleSetGeneSymbolSelections(

--- a/frontend/packages/portal-frontend/src/geneTea/components/PlotOptionsPanel.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/PlotOptionsPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useRef } from "react";
 import ToggleSwitch from "@depmap/common-components/src/components/ToggleSwitch";
 import { useGeneTeaContext } from "../context/GeneTeaContext";
+import styles from "../styles/GeneTea.scss";
 
 const PlotOptionsPanel: React.FC = () => {
   const ref = useRef<HTMLTableElement>(null);
@@ -20,37 +21,46 @@ const PlotOptionsPanel: React.FC = () => {
         Use toggles to group and cluster.
       </p>
       <div style={{ display: "flex", alignItems: "center", marginBottom: 12 }}>
-        <ToggleSwitch
-          value={doClusterTerms}
-          onChange={handleSetDoClusterTerms}
-          options={[
-            { label: "", value: false },
-            { label: "", value: true },
-          ]}
-        />
-        <span style={{ marginLeft: 12 }}>Use term clustering.</span>
+        <div style={{ alignItems: "center", height: 32, marginBottom: 20 }}>
+          <span>Use term clustering.</span>
+          <ToggleSwitch
+            className={styles.toggleSwitch}
+            value={doClusterTerms}
+            onChange={handleSetDoClusterTerms}
+            options={[
+              { label: "OFF", value: false },
+              { label: "ON", value: true },
+            ]}
+          />
+        </div>
       </div>
       <div style={{ display: "flex", alignItems: "center", marginBottom: 12 }}>
-        <ToggleSwitch
-          value={doClusterGenes}
-          onChange={handleSetDoClusterGenes}
-          options={[
-            { label: "", value: false },
-            { label: "", value: true },
-          ]}
-        />
-        <span style={{ marginLeft: 12 }}>Use gene clustering.</span>
+        <div style={{ alignItems: "center", height: 32, marginBottom: 20 }}>
+          <span>Use gene clustering.</span>
+          <ToggleSwitch
+            className={styles.toggleSwitch}
+            value={doClusterGenes}
+            onChange={handleSetDoClusterGenes}
+            options={[
+              { label: "OFF", value: false },
+              { label: "ON", value: true },
+            ]}
+          />
+        </div>
       </div>
-      <div style={{ display: "flex", alignItems: "center" }}>
-        <ToggleSwitch
-          value={doGroupTerms}
-          onChange={handleSetDoGroupTerms}
-          options={[
-            { label: "", value: false },
-            { label: "", value: true },
-          ]}
-        />
-        <span style={{ marginLeft: 12 }}>Group terms when possible.</span>
+      <div style={{ display: "flex", alignItems: "center", marginBottom: 8 }}>
+        <div style={{ alignItems: "center", height: 32, marginBottom: 20 }}>
+          <span>Group terms when possible.</span>
+          <ToggleSwitch
+            className={styles.toggleSwitch}
+            value={doGroupTerms}
+            onChange={handleSetDoGroupTerms}
+            options={[
+              { label: "OFF", value: false },
+              { label: "ON", value: true },
+            ]}
+          />
+        </div>
       </div>
     </div>
   );

--- a/frontend/packages/portal-frontend/src/geneTea/components/PlotSection.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/PlotSection.tsx
@@ -90,6 +90,7 @@ function PlotSection({
               PlotToolOptions.MakeContext,
               PlotToolOptions.Download,
               PlotToolOptions.Search,
+              PlotToolOptions.ResetSelection,
             ]}
             onSearch={handleSearch}
             searchOptions={
@@ -109,6 +110,9 @@ function PlotSection({
               height: 600,
             }}
             onDownload={() => {}}
+            onClearSelection={
+              selectedPlotGenes.size > 0 ? handleClearPlotSelection : undefined
+            }
             onMakeContext={
               selectedPlotGenes.size > 0
                 ? handleClickSavePlotSelectionAsContext

--- a/frontend/packages/portal-frontend/src/geneTea/components/PlotSection.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/PlotSection.tsx
@@ -105,7 +105,11 @@ function PlotSection({
               height: 600,
             }}
             onDownload={() => {}}
-            onMakeContext={handleClickSavePlotSelectionAsContext}
+            onMakeContext={
+              selectedPlotGenes.size > 0
+                ? handleClickSavePlotSelectionAsContext
+                : undefined
+            }
             zoomToSelectedSelections={selectedColumns}
             altContainerStyle={{ backgroundColor: "#7B8CB2" }}
             hideCSVDownload

--- a/frontend/packages/portal-frontend/src/geneTea/components/PlotSection.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/PlotSection.tsx
@@ -45,7 +45,6 @@ function PlotSection({
     end: number,
     shiftKey: boolean
   ) => {
-    console.log(start);
     const newlySelected = new Set<string>();
     for (let i = start; i <= end; i += 1) {
       if (heatmapFormattedData && heatmapFormattedData.x[i]) {

--- a/frontend/packages/portal-frontend/src/geneTea/components/PlotSection.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/PlotSection.tsx
@@ -138,6 +138,9 @@ function PlotSection({
               onClearSelection={() => handleClearPlotSelection()}
               onSelectColumnRange={handleSelectColumnRange}
               selectedColumns={selectedColumns}
+              zmax={Math.max(...(heatmapFormattedData.z as number[]))}
+              zmin={Math.min(...(heatmapFormattedData.z as number[]))}
+              doGroupTerms={doGroupTerms}
             />
           </div>
         )}

--- a/frontend/packages/portal-frontend/src/geneTea/components/PlotSection.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/PlotSection.tsx
@@ -45,10 +45,15 @@ function PlotSection({
     end: number,
     shiftKey: boolean
   ) => {
+    console.log(start);
     const newlySelected = new Set<string>();
     for (let i = start; i <= end; i += 1) {
       if (heatmapFormattedData && heatmapFormattedData.x[i]) {
-        newlySelected.add(heatmapFormattedData.x[i]!);
+        const selectableColumnLength = [...new Set(heatmapFormattedData.y)]
+          .length;
+        if (i < selectableColumnLength) {
+          newlySelected.add(heatmapFormattedData.x[i]!);
+        }
       }
     }
     handleSetPlotSelectedGenes(newlySelected, shiftKey);

--- a/frontend/packages/portal-frontend/src/geneTea/components/TermOptionsPanel.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/TermOptionsPanel.tsx
@@ -3,17 +3,11 @@ import styles from "../styles/MultiSelectTextArea.scss";
 import { Button } from "react-bootstrap";
 
 import NumberInput from "./NumberInput";
-import { useGeneTeaContext } from "../context/GeneTeaContext";
+import {
+  TERM_OPTIONS_FILTER_DEFAULTS,
+  useGeneTeaContext,
+} from "../context/GeneTeaContext";
 import { SortOption } from "../types";
-
-const DEFAULTS = {
-  sortBy: "Effect Size",
-  maxTopTerms: 10,
-  maxFDR: 0.05,
-  effectSizeThreshold: 0.1,
-  minMatchingQuery: 2,
-  maxMatchingOverall: 5373,
-};
 
 const TermOptionsPanel: React.FC = () => {
   const ref = useRef<HTMLTableElement>(null);
@@ -36,7 +30,7 @@ const TermOptionsPanel: React.FC = () => {
   // Local state for staged changes
   const [localSortBy, setLocalSortBy] = useState<string>(sortBy);
   const [localMaxTopTerms, setLocalMaxTopTerms] = useState<number>(
-    maxTopTerms ?? DEFAULTS.maxTopTerms
+    maxTopTerms ?? TERM_OPTIONS_FILTER_DEFAULTS.maxTopTerms
   );
   const [localMaxFDR, setLocalMaxFDR] = useState<number>(maxFDR);
   const [
@@ -44,12 +38,14 @@ const TermOptionsPanel: React.FC = () => {
     setLocalEffectSizeThreshold,
   ] = useState<number>(effectSizeThreshold);
   const [localMinMatchingQuery, setLocalMinMatchingQuery] = useState<number>(
-    minMatchingQuery || DEFAULTS.minMatchingQuery
+    minMatchingQuery || TERM_OPTIONS_FILTER_DEFAULTS.minMatchingQuery
   );
   const [
     localMaxMatchingOverall,
     setLocalMaxMatchingOverall,
-  ] = useState<number>(maxMatchingOverall || DEFAULTS.maxMatchingOverall);
+  ] = useState<number>(
+    maxMatchingOverall || TERM_OPTIONS_FILTER_DEFAULTS.maxMatchingOverall
+  );
 
   return (
     <div ref={ref} style={{ backgroundColor: "#ffffff" }}>
@@ -85,7 +81,7 @@ const TermOptionsPanel: React.FC = () => {
           step={1}
           value={localMaxTopTerms}
           setValue={setLocalMaxTopTerms}
-          defaultValue={DEFAULTS.maxTopTerms}
+          defaultValue={TERM_OPTIONS_FILTER_DEFAULTS.maxTopTerms}
         />
         <NumberInput
           name="maxFDR"
@@ -93,7 +89,7 @@ const TermOptionsPanel: React.FC = () => {
           min={0}
           value={localMaxFDR}
           setValue={setLocalMaxFDR}
-          defaultValue={DEFAULTS.maxFDR}
+          defaultValue={TERM_OPTIONS_FILTER_DEFAULTS.maxFDR}
           step={0.01}
         />
         {/* TODO: Fix. Temporarily hiding. I don't think the api supports this filter yet.
@@ -112,7 +108,7 @@ const TermOptionsPanel: React.FC = () => {
           min={0}
           value={localMinMatchingQuery}
           setValue={setLocalMinMatchingQuery}
-          defaultValue={DEFAULTS.minMatchingQuery}
+          defaultValue={TERM_OPTIONS_FILTER_DEFAULTS.minMatchingQuery}
           step={1}
         />
         <NumberInput
@@ -121,7 +117,7 @@ const TermOptionsPanel: React.FC = () => {
           min={0}
           value={localMaxMatchingOverall}
           setValue={setLocalMaxMatchingOverall}
-          defaultValue={DEFAULTS.maxMatchingOverall}
+          defaultValue={TERM_OPTIONS_FILTER_DEFAULTS.maxMatchingOverall}
           step={1}
         />
         <div
@@ -150,18 +146,32 @@ const TermOptionsPanel: React.FC = () => {
           <Button
             className={styles.clearInputButton}
             onClick={() => {
-              setLocalSortBy(DEFAULTS.sortBy);
-              setLocalMaxFDR(DEFAULTS.maxFDR);
-              setLocalMaxTopTerms(DEFAULTS.maxTopTerms);
-              setLocalMaxMatchingOverall(DEFAULTS.maxMatchingOverall);
-              setLocalMinMatchingQuery(DEFAULTS.minMatchingQuery);
-              setLocalEffectSizeThreshold(DEFAULTS.effectSizeThreshold);
-              handleSetSortBy(DEFAULTS.sortBy as SortOption);
-              handleSetMaxTopTerms(DEFAULTS.maxTopTerms);
-              handleSetMaxFDR(DEFAULTS.maxFDR);
-              handleSetMaxMatchingOverall(DEFAULTS.maxMatchingOverall);
-              handleSetMinMatchingQuery(DEFAULTS.minMatchingQuery);
-              handleSetEffectSizeThreshold(DEFAULTS.effectSizeThreshold);
+              setLocalSortBy(TERM_OPTIONS_FILTER_DEFAULTS.sortBy);
+              setLocalMaxFDR(TERM_OPTIONS_FILTER_DEFAULTS.maxFDR);
+              setLocalMaxTopTerms(TERM_OPTIONS_FILTER_DEFAULTS.maxTopTerms);
+              setLocalMaxMatchingOverall(
+                TERM_OPTIONS_FILTER_DEFAULTS.maxMatchingOverall
+              );
+              setLocalMinMatchingQuery(
+                TERM_OPTIONS_FILTER_DEFAULTS.minMatchingQuery
+              );
+              setLocalEffectSizeThreshold(
+                TERM_OPTIONS_FILTER_DEFAULTS.effectSizeThreshold
+              );
+              handleSetSortBy(
+                TERM_OPTIONS_FILTER_DEFAULTS.sortBy as SortOption
+              );
+              handleSetMaxTopTerms(TERM_OPTIONS_FILTER_DEFAULTS.maxTopTerms);
+              handleSetMaxFDR(TERM_OPTIONS_FILTER_DEFAULTS.maxFDR);
+              handleSetMaxMatchingOverall(
+                TERM_OPTIONS_FILTER_DEFAULTS.maxMatchingOverall
+              );
+              handleSetMinMatchingQuery(
+                TERM_OPTIONS_FILTER_DEFAULTS.minMatchingQuery
+              );
+              handleSetEffectSizeThreshold(
+                TERM_OPTIONS_FILTER_DEFAULTS.effectSizeThreshold
+              );
             }}
             style={{ marginBottom: 0 }}
           >

--- a/frontend/packages/portal-frontend/src/geneTea/context/GeneTeaContext.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/context/GeneTeaContext.tsx
@@ -251,6 +251,9 @@ export function GeneTeaContextProvider({
   );
   const handleSetMaxFDR = useCallback((v: number) => setMaxFDR(v), []);
 
+  const [selectedPlotGenes, setSelectedPlotGenes] = useState<Set<string>>(
+    new Set([])
+  );
   const handleSetSelectionFromContext = useCallback(async () => {
     const labels = await promptForSelectionFromContext(
       validGeneSymbols,
@@ -261,11 +264,7 @@ export function GeneTeaContextProvider({
     }
 
     setSelectedPlotGenes(labels);
-  }, [allAvailableGenes]);
-
-  const [selectedPlotGenes, setSelectedPlotGenes] = useState<Set<string>>(
-    new Set([])
-  );
+  }, [validGeneSymbols]);
 
   const handleSetPlotSelectedGenes = useCallback(
     (selections: Set<string>, shiftKey: boolean) => {

--- a/frontend/packages/portal-frontend/src/geneTea/context/GeneTeaContext.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/context/GeneTeaContext.tsx
@@ -11,6 +11,16 @@ import { defaultContextName } from "@depmap/data-explorer-2/src/components/DataE
 import { saveNewContext } from "src";
 import { DataExplorerContext } from "@depmap/types";
 
+// TODO organize this file a little better...
+export const TERM_OPTIONS_FILTER_DEFAULTS = {
+  sortBy: "Effect Size",
+  maxTopTerms: 10,
+  maxFDR: 0.05,
+  effectSizeThreshold: 0.1,
+  minMatchingQuery: 2,
+  maxMatchingOverall: 5373,
+};
+
 export interface GeneTeaContextType {
   effectSizeThreshold: number;
   handleSetEffectSizeThreshold: (v: any) => void;
@@ -112,7 +122,9 @@ export function GeneTeaContextProvider({
     []
   );
 
-  const [sortBy, setSortBy] = useState<SortOption>("Effect Size");
+  const [sortBy, setSortBy] = useState<SortOption>(
+    TERM_OPTIONS_FILTER_DEFAULTS.sortBy as SortOption
+  );
   const handleSetSortBy = useCallback((v: SortOption) => setSortBy(v), []);
 
   const [geneSymbolSelections, setGeneSymbolSelections] = useState<Set<string>>(
@@ -158,7 +170,9 @@ export function GeneTeaContextProvider({
     []
   );
 
-  const [effectSizeThreshold, setEffectSizeThreshold] = useState<number>(0.1);
+  const [effectSizeThreshold, setEffectSizeThreshold] = useState<number>(
+    TERM_OPTIONS_FILTER_DEFAULTS.effectSizeThreshold
+  );
   const handleSetEffectSizeThreshold = useCallback(
     (v: any) => {
       setEffectSizeThreshold((prevVal: number) => {
@@ -175,7 +189,9 @@ export function GeneTeaContextProvider({
     [handleClearSelectedTableRows]
   );
 
-  const [minMatchingQuery, setMinMatchingQuery] = useState<number>(2);
+  const [minMatchingQuery, setMinMatchingQuery] = useState<number>(
+    TERM_OPTIONS_FILTER_DEFAULTS.minMatchingQuery
+  );
   const handleSetMinMatchingQuery = useCallback(
     (v: any) => {
       setMinMatchingQuery((prevVal: number) => {
@@ -193,7 +209,7 @@ export function GeneTeaContextProvider({
   );
 
   const [maxMatchingOverall, setMaxMatchingOverall] = useState<number | null>(
-    5357
+    TERM_OPTIONS_FILTER_DEFAULTS.maxMatchingOverall
   );
   const handleSetMaxMatchingOverall = useCallback(
     (v: any) => {
@@ -211,7 +227,9 @@ export function GeneTeaContextProvider({
     [handleClearSelectedTableRows]
   );
 
-  const [maxTopTerms, setMaxTopTerms] = useState<number | null>(10);
+  const [maxTopTerms, setMaxTopTerms] = useState<number | null>(
+    TERM_OPTIONS_FILTER_DEFAULTS.maxTopTerms
+  );
   const handleSetMaxTopTerms = useCallback(
     (v: any) => {
       setMaxTopTerms((prevVal: number | null) => {
@@ -228,7 +246,9 @@ export function GeneTeaContextProvider({
     [handleClearSelectedTableRows]
   );
 
-  const [maxFDR, setMaxFDR] = useState<number>(0.05);
+  const [maxFDR, setMaxFDR] = useState<number>(
+    TERM_OPTIONS_FILTER_DEFAULTS.maxFDR
+  );
   const handleSetMaxFDR = useCallback((v: number) => setMaxFDR(v), []);
 
   const handleSetSelectionFromContext = useCallback(async () => {

--- a/frontend/packages/portal-frontend/src/geneTea/context/GeneTeaContext.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/context/GeneTeaContext.tsx
@@ -253,14 +253,14 @@ export function GeneTeaContextProvider({
 
   const handleSetSelectionFromContext = useCallback(async () => {
     const labels = await promptForSelectionFromContext(
-      allAvailableGenes,
+      validGeneSymbols,
       "gene"
     );
     if (labels === null) {
       return;
     }
 
-    setGeneSymbolSelections(labels);
+    setSelectedPlotGenes(labels);
   }, [allAvailableGenes]);
 
   const [selectedPlotGenes, setSelectedPlotGenes] = useState<Set<string>>(

--- a/frontend/packages/portal-frontend/src/geneTea/hooks/useData.ts
+++ b/frontend/packages/portal-frontend/src/geneTea/hooks/useData.ts
@@ -228,7 +228,11 @@ function useData(
       const customdata = filteredPairs.map(([gene, term]) => {
         const idx = lookup.get(`${gene}|${term}`);
         return idx !== undefined
-          ? `<b>Gene: </b>${gene}<br><b>${data.groupby}: </b>${term}<br><b>Matches: </b>${termToEntity.nTerms[idx]}`
+          ? `<b>Gene: </b>${gene}<br><b>${
+              data.groupby
+            }: </b>${term}<br><b>Matches: </b>${
+              termToEntity.fraction[idx] * termToEntity.nTerms[idx]
+            }`
           : "";
       });
 

--- a/frontend/packages/portal-frontend/src/geneTea/hooks/useData.ts
+++ b/frontend/packages/portal-frontend/src/geneTea/hooks/useData.ts
@@ -356,7 +356,7 @@ function useData(
         sortedTermVals
       );
 
-      const customdata = transformX.orderedTerms.map((currentTerm, i) => {
+      const customdata = transformX.orderedTerms.map((currentTerm) => {
         const enrichedTermsIndex = data.enrichedTerms!.term.indexOf(
           currentTerm
         );

--- a/frontend/packages/portal-frontend/src/geneTea/hooks/useData.ts
+++ b/frontend/packages/portal-frontend/src/geneTea/hooks/useData.ts
@@ -315,12 +315,14 @@ function useData(
           const valuesForY = groupedData[y];
 
           // Sort the x-values for the current y-group from smallest to largest
-          valuesForY.sort((a: any, b: any) => a - b);
+          const sortedValuesForY = [...valuesForY].sort(
+            (a: any, b: any) => a - b
+          );
 
           let previousX = 0;
 
           // 3. Iterate to calculate new values
-          for (const x of valuesForY) {
+          for (const x of sortedValuesForY) {
             // Instead of graphing literal x values, we want the stacked sections to be the difference between its own -log10(FDR)
             // value and the value that was graphed before it such that the total size of the bar is equal to the highest magnitude
             // -log10(FDR) of this particular Term Group.
@@ -333,10 +335,7 @@ function useData(
         return newXValues;
       };
 
-      const sortedXSource =
-        data.groupby === "Term Group"
-          ? sortedCombinedXY.map((val) => val.xVal)
-          : xSource;
+      const sortedXSource = sortedCombinedXY.map((val) => val.xVal);
 
       const customdata = sortedYSource.map((termOrTermGroup, i) => {
         const term =

--- a/frontend/packages/portal-frontend/src/geneTea/hooks/useData.ts
+++ b/frontend/packages/portal-frontend/src/geneTea/hooks/useData.ts
@@ -291,8 +291,9 @@ function useData(
 
       const calculateStackedXValues = (
         xValues: number[],
-        yValues: string[]
-      ): number[] => {
+        yValues: string[],
+        sortedTermVals: string[]
+      ): { x: number[]; orderedTerms: string[] } => {
         if (xValues.length !== yValues.length) {
           throw new Error("xValues and yValues must be of the same length.");
         }
@@ -300,15 +301,20 @@ function useData(
         const combinedData: any = xValues.map((x, index) => ({
           x,
           y: yValues[index],
+          term: sortedTermVals[index],
         }));
 
         // 1. Group data by y-value
         const groupedData = combinedData.reduce((acc: any, current: any) => {
-          (acc[current.y] = acc[current.y] || []).push(current.x);
+          (acc[current.y] = acc[current.y] || []).push({
+            x: current.x,
+            term: current.term,
+          });
           return acc;
-        }, {} as Record<string, number[]>);
+        }, {} as Record<string, { x: number[]; term: string[] }>);
 
         const newXValues: number[] = [];
+        let terms: string[] = [];
 
         // 2. Process each group to sort and calculate new x-values
         Object.keys(groupedData).forEach((y) => {
@@ -316,8 +322,11 @@ function useData(
 
           // Sort the x-values for the current y-group from smallest to largest
           const sortedValuesForY = [...valuesForY].sort(
-            (a: any, b: any) => a - b
+            (a: any, b: any) => a.x - b.x
           );
+
+          const currentTerms = sortedValuesForY.map((v) => v.term);
+          terms = terms.concat(currentTerms);
 
           let previousX = 0;
 
@@ -326,37 +335,44 @@ function useData(
             // Instead of graphing literal x values, we want the stacked sections to be the difference between its own -log10(FDR)
             // value and the value that was graphed before it such that the total size of the bar is equal to the highest magnitude
             // -log10(FDR) of this particular Term Group.
-            const newX = x - previousX;
+            const newX = x.x - previousX;
             newXValues.push(newX);
-            previousX = x; // Store the original x as the 'previously added x' for the next iteration
+            previousX = x.x; // Store the original x as the 'previously added x' for the next iteration
           }
         });
 
-        return newXValues;
+        return { x: newXValues, orderedTerms: terms };
       };
 
       const sortedXSource = sortedCombinedXY.map((val) => val.xVal);
+      const sortedYSourceVals = sortedYSource.map((val) => val.val);
+      const sortedTermVals = sortedYSource.map(
+        (val) => data.enrichedTerms!.term[val.origIndex]
+      );
 
-      const customdata = sortedYSource.map((termOrTermGroup, i) => {
-        const term =
-          data.groupby === "Term Group"
-            ? data.enrichedTerms!.term[termOrTermGroup.origIndex]
-            : termOrTermGroup.val;
-        const termGroup = data.enrichedTerms!.termGroup[
-          termOrTermGroup.origIndex
-        ];
-        const fdr = data.enrichedTerms!.fdr[termOrTermGroup.origIndex];
-        const effectSize = data.enrichedTerms!.effectSize[
-          termOrTermGroup.origIndex
-        ];
+      const transformX = calculateStackedXValues(
+        sortedXSource,
+        sortedYSourceVals,
+        sortedTermVals
+      );
+
+      const customdata = transformX.orderedTerms.map((currentTerm, i) => {
+        const enrichedTermsIndex = data.enrichedTerms!.term.indexOf(
+          currentTerm
+        );
+        const term = currentTerm;
+        const termGroup = data.enrichedTerms!.termGroup[enrichedTermsIndex];
+        const fdr = data.enrichedTerms!.fdr[enrichedTermsIndex];
+        const negLogFDR = data.enrichedTerms!.negLogFDR[enrichedTermsIndex];
+        const effectSize = data.enrichedTerms!.effectSize[enrichedTermsIndex];
         const nMatchingGenesOverall = data.enrichedTerms!.nMatchingGenesOverall[
-          termOrTermGroup.origIndex
+          enrichedTermsIndex
         ];
 
         return term !== undefined
-          ? `<b>${term}</b><br>${termGroup}<br><br>-log10(FDR):  ${sortedXSource[
-              i
-            ].toFixed(4)}  <br>FDR:  ${fdr.toExponential(
+          ? `<b>${term}</b><br>${termGroup}<br><br>-log10(FDR):  ${negLogFDR.toFixed(
+              4
+            )}  <br>FDR:  ${fdr.toExponential(
               5
             )}  <br>Effect Size:  ${effectSize.toFixed(
               4
@@ -364,15 +380,8 @@ function useData(
           : "";
       });
 
-      const sortedYSourceVals = sortedYSource.map((val) => val.val);
-
-      const transformX = calculateStackedXValues(
-        sortedXSource,
-        sortedYSourceVals
-      );
-
       return {
-        x: transformX,
+        x: transformX.x,
         y: sortedYSourceVals,
         customdata,
       };

--- a/frontend/packages/portal-frontend/src/geneTea/plots/HeatmapBarChart.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/plots/HeatmapBarChart.tsx
@@ -374,6 +374,7 @@ function HeatmapBarChart({
     hovertemplate,
     zmin,
     zmax,
+    doGroupTerms,
     xAxisTickLabels,
     barChartData,
     heatmapXAxisTitle,

--- a/frontend/packages/portal-frontend/src/geneTea/plots/HeatmapBarChart.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/plots/HeatmapBarChart.tsx
@@ -25,18 +25,9 @@ import styles from "./HeatmapBarChart.scss";
 import debounce from "lodash.debounce";
 import usePlotResizer from "src/compound/heatmapTab/doseViabilityHeatmap/hooks/usePlotResizer";
 
-const viridisRColorscale = [
-  ["0", "#D3D3D3"],
-  ["0.001", "rgb(253, 231, 37)"],
-  ["0.111", "rgb(180, 222, 44)"],
-  ["0.222", "rgb(109, 205, 89)"],
-  ["0.333", "rgb(53, 183, 121)"],
-  ["0.444", "rgb(31, 158, 137)"],
-  ["0.556", "rgb(38, 130, 142)"],
-  ["0.667", "rgb(49, 104, 142)"],
-  ["0.778", "rgb(62, 74, 137)"],
-  ["0.889", "rgb(72, 40, 120)"],
-  ["1.0", "rgb(68, 1, 84)"],
+const greenScale = [
+  [0, "rgb(232, 232, 232)"],
+  [1, "rgb(0, 110, 87)"],
 ];
 interface Props {
   plotTitle: string;
@@ -167,7 +158,7 @@ function HeatmapBarChart({
     const plotlyHeatmapData: PlotlyData = {
       type: "heatmap",
       ...heatmapData,
-      colorscale: viridisRColorscale as ColorScale,
+      colorscale: greenScale as ColorScale,
       zmin: 0,
       zmax: 1,
       xaxis: "x",

--- a/frontend/packages/portal-frontend/src/geneTea/plots/HeatmapBarChart.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/plots/HeatmapBarChart.tsx
@@ -40,6 +40,7 @@ interface Props {
   onSelectColumnRange: (start: number, end: number, shiftKey: boolean) => void;
   onClearSelection: () => void;
   onLoad: (plot: ExtendedPlotType) => void;
+  doGroupTerms: boolean;
   hovertemplate?: string | string[];
   // Optionally set a min/max for the color scale. If left undefined, these
   // will default to the min and max of values contained in `data.z`
@@ -48,6 +49,7 @@ interface Props {
 }
 
 function HeatmapBarChart({
+  doGroupTerms,
   plotTitle,
   heatmapXAxisTitle,
   heatmapData,
@@ -159,8 +161,8 @@ function HeatmapBarChart({
       type: "heatmap",
       ...heatmapData,
       colorscale: greenScale as ColorScale,
-      zmin: 0,
-      zmax: 1,
+      zmin,
+      zmax,
       xaxis: "x",
       yaxis: "y",
       hovertemplate,
@@ -193,10 +195,12 @@ function HeatmapBarChart({
       hovertemplate,
       orientation: "h",
       marker: {
-        color: "#777b7e",
+        color: doGroupTerms
+          ? barChartData.x.map((_, i) => (i % 2 === 0 ? "#bdbdbd" : "#777b7e"))
+          : "#777b7e",
+
         line: {
-          color: "white",
-          width: 1, // Set the line width for the divider
+          width: 0.2, // Set the line width for the divider
         },
       },
     };

--- a/frontend/packages/portal-frontend/src/geneTea/styles/GeneTea.scss
+++ b/frontend/packages/portal-frontend/src/geneTea/styles/GeneTea.scss
@@ -52,3 +52,22 @@
     }
   }
 }
+
+.toggleSwitch {
+  margin-left: 15px;
+  padding-top: 8px;
+  .label {
+    font-size: 7px;
+  }
+  button {
+    height: 19px;
+    transition: background-color 0.2s;
+  }
+  button[aria-checked="true"],
+  button.active,
+  button:checked {
+    border-width: 2px;
+    border-color: rgba(25, 118, 210, 1);
+    color: #fff;
+  }
+}

--- a/frontend/packages/portal-frontend/src/plot/components/PlotControls.tsx
+++ b/frontend/packages/portal-frontend/src/plot/components/PlotControls.tsx
@@ -30,6 +30,7 @@ export enum PlotToolOptions {
   MakeContext,
   UnselectAnnotatedPoints,
   ZoomToSelection,
+  ResetSelection,
 }
 
 interface Props {
@@ -41,6 +42,7 @@ interface Props {
   downloadImageOptions?: DownloadImageOptions;
   enabledTools?: PlotToolOptions[];
   onMakeContext?: () => void;
+  onClearSelection?: () => void;
   onDeselectPoints?: () => void;
   altContainerStyle?: any;
   hideCSVDownload?: boolean;
@@ -101,6 +103,7 @@ function PlotControls({
   downloadImageOptions = undefined,
   enabledTools = undefined,
   onMakeContext = undefined,
+  onClearSelection = undefined,
   onDeselectPoints = () => {},
   altContainerStyle = undefined,
   hideCSVDownload = false,
@@ -144,7 +147,9 @@ function PlotControls({
   const zoomToSelectionEnabled = enabledTools?.includes(
     PlotToolOptions.ZoomToSelection
   ); // A newer, more experimental tool, so only turn on if explicitly included in the enabledTools list.
-
+  const clearSelectionEnabled = enabledTools?.includes(
+    PlotToolOptions.ResetSelection
+  );
   return (
     <div className={styles.PlotControls}>
       <div style={altContainerStyle} className={styles.container}>
@@ -218,6 +223,7 @@ function PlotControls({
             <Button disabled={!plot} onClick={plot?.zoomOut}>
               <span className="glyphicon glyphicon-minus" />
             </Button>
+
             <Button disabled={!plot} onClick={plot?.resetZoom}>
               reset
             </Button>
@@ -243,6 +249,20 @@ function PlotControls({
               reset
             </Button>
           </div>
+        )}
+        {clearSelectionEnabled && (
+          <Tooltip
+            id="clear-selection-tooltip"
+            content="Clear selection"
+            placement="top"
+          >
+            <Button
+              disabled={!plot || !onClearSelection}
+              onClick={onClearSelection ? () => onClearSelection() : undefined}
+            >
+              Clear Selection
+            </Button>
+          </Tooltip>
         )}
         {(annotateEnabled || onlyUnselectAnnotateEnabled) && (
           <div className={styles.buttonGroup}>

--- a/frontend/packages/portal-frontend/src/plot/components/PlotControls.tsx
+++ b/frontend/packages/portal-frontend/src/plot/components/PlotControls.tsx
@@ -106,7 +106,6 @@ function PlotControls({
   hideCSVDownload = false,
   zoomToSelectedSelections = undefined,
 }: Props) {
-  console.log("onMakeContext", onMakeContext);
   const [dragmode, setDragmode] = useState<Dragmode>("zoom");
 
   useEffect(() => {
@@ -202,6 +201,7 @@ function PlotControls({
               placement="top"
             >
               <Button
+                type="button"
                 disabled={onMakeContext == undefined}
                 onClick={() => (onMakeContext ? onMakeContext() : {})}
               >

--- a/frontend/packages/portal-frontend/src/plot/components/PlotControls.tsx
+++ b/frontend/packages/portal-frontend/src/plot/components/PlotControls.tsx
@@ -100,12 +100,13 @@ function PlotControls({
   searchPlaceholder,
   downloadImageOptions = undefined,
   enabledTools = undefined,
-  onMakeContext = () => {},
+  onMakeContext = undefined,
   onDeselectPoints = () => {},
   altContainerStyle = undefined,
   hideCSVDownload = false,
   zoomToSelectedSelections = undefined,
 }: Props) {
+  console.log("onMakeContext", onMakeContext);
   const [dragmode, setDragmode] = useState<Dragmode>("zoom");
 
   useEffect(() => {
@@ -200,7 +201,10 @@ function PlotControls({
               content="Make a context from the current selection"
               placement="top"
             >
-              <Button disabled={!plot} onClick={() => onMakeContext()}>
+              <Button
+                disabled={onMakeContext == undefined}
+                onClick={() => (onMakeContext ? onMakeContext() : {})}
+              >
                 Make Context
               </Button>
             </Tooltip>

--- a/frontend/packages/portal-frontend/src/plot/components/PlotControls.tsx
+++ b/frontend/packages/portal-frontend/src/plot/components/PlotControls.tsx
@@ -207,7 +207,7 @@ function PlotControls({
             >
               <Button
                 type="button"
-                disabled={onMakeContext == undefined}
+                disabled={onMakeContext === undefined}
                 onClick={() => (onMakeContext ? onMakeContext() : {})}
               >
                 Make Context


### PR DESCRIPTION
Changes:
	•	Fix mismatched default filters causing weird behavior on reset button click
	•	Gray out "Make Context" but if nothing is selected
	•	Bug - Make Context button (Plot Controls) - Save as context in plot selections won’t actually save if I change the name.
	•	Plot Selections Panel - Set Selections from Context does not work
	⁃	It seems to be setting the Gene Symbol list on the left instead of selecting in the plot like it is supposed to
	•	Newline separated genes are not parsed correctly
	•	Incorrect Hover text for "Match"
	•	Don't allow <1 selection in the table
	•	Fix barchart bar order
	•	Somehow, the ~ novo and ~ dihydroorotate bars are inverted here.
	•	When there are many terms, the overlaid bar becomes hard to read because of the white outline
	•	BUG (functional): Click and drag on the bar chart mysteriously selects on the Heatmap
	•	ON/OFF status of Toggle is unclear
	•	Plot Controls - Add "Clear Selection" button
