### PR TITLE
Enriched Lineages Tile url bug fix

### DIFF
--- a/frontend/packages/portal-frontend/src/contextExplorer/components/EnrichmentTile.tsx
+++ b/frontend/packages/portal-frontend/src/contextExplorer/components/EnrichmentTile.tsx
@@ -20,7 +20,7 @@ export const EnrichmentTile: React.FC<EnrichmentTileProps> = ({
   entityType,
 }) => {
   const contextExplorerHref = window.location.href
-    .split(entityLabel)[0]
+    .split(encodeURIComponent(entityLabel))[0]
     .replace(entityType, "context_explorer");
 
   const [tileData, setTileData] = useState<EnrichedLineagesTileData | null>(


### PR DESCRIPTION
If compound names had spaces, the url for the Enriched Lineages Tile y-axis was not being encoded properly. As a result, clicking on this url led to a 404 "Sorry, this page doesn't exist" page.

The fix was to wrap the entityLabel in encodeURIComponent.

Asana task: https://app.asana.com/0/1165651979405609/1211385439035513

