### PR TITLE
fix(breadbox): support dataset given IDs containing slashes

### DIFF
--- a/breadbox/breadbox/api/datasets.py
+++ b/breadbox/breadbox/api/datasets.py
@@ -99,7 +99,7 @@ def get_datasets(
 
 
 @router.get(
-    "/features/{dataset_id}", operation_id="get_dataset_features",
+    "/features/{dataset_id:path}", operation_id="get_dataset_features",
 )
 def get_dataset_features(
     db: Annotated[SessionWithUser, Depends(get_db_with_user)],
@@ -117,7 +117,7 @@ def get_dataset_features(
 
 
 @router.get(
-    "/samples/{dataset_id}", operation_id="get_dataset_samples",
+    "/samples/{dataset_id:path}", operation_id="get_dataset_samples",
 )
 def get_dataset_samples(
     db: Annotated[SessionWithUser, Depends(get_db_with_user)],
@@ -289,7 +289,7 @@ def add_dataset(
 
 
 @router.get(
-    "/{dataset_id}",
+    "/{dataset_id:path}",
     operation_id="get_dataset",
     response_model=DatasetResponse,
     response_model_by_alias=False,
@@ -300,7 +300,7 @@ def get_dataset(dataset: DatasetModel = Depends(get_dataset_dep)):
 
 
 @router.post(
-    "/matrix/{dataset_id}", operation_id="get_matrix_dataset_data",
+    "/matrix/{dataset_id:path}", operation_id="get_matrix_dataset_data",
 )
 def get_matrix_dataset_data(
     db: Annotated[SessionWithUser, Depends(get_db_with_user)],
@@ -330,7 +330,7 @@ def get_matrix_dataset_data(
 
 
 @router.post(
-    "/tabular/{dataset_id}", operation_id="get_tabular_dataset_data",
+    "/tabular/{dataset_id:path}", operation_id="get_tabular_dataset_data",
 )
 def get_tabular_dataset_data(
     db: Annotated[SessionWithUser, Depends(get_db_with_user)],
@@ -359,7 +359,9 @@ def get_tabular_dataset_data(
     return Response(df.to_json(), media_type="application/json")
 
 
-@router.post("/data/{dataset_id}", operation_id="get_dataset_data", deprecated=True)
+@router.post(
+    "/data/{dataset_id:path}", operation_id="get_dataset_data", deprecated=True
+)
 def get_dataset_data(
     db: Annotated[SessionWithUser, Depends(get_db_with_user)],
     user: Annotated[str, Depends(get_user)],
@@ -514,7 +516,7 @@ def get_dimension_data(
 
 
 @router.patch(
-    "/{dataset_id}",
+    "/{dataset_id:path}",
     operation_id="update_dataset",
     response_model=DatasetResponse,
     response_model_by_alias=False,
@@ -570,7 +572,7 @@ def update_dataset(
 
 
 @router.delete(
-    "/{dataset_id}", operation_id="remove_dataset",
+    "/{dataset_id:path}", operation_id="remove_dataset",
 )
 def delete_dataset(
     dataset_id: UUID,


### PR DESCRIPTION
For the most part part a `given_id` can be used wherever a regular ID would appear. However, this doesn't work quite right in URLs. `given_id` values are arbitrary strings, not simple IDs, and may include slashes. Even if you take care to URL-encode the given ID, it still breaks FastAPI/Starlette routing, since URLs are decoded before route matching. A slash inside an ID is treated as a path delimiter even if the value was URL-encoded 🫤. This is a known issue:
https://github.com/fastapi/fastapi/issues/791
https://github.com/fastapi/fastapi/discussions/7328

For example, this given_id works just fine:
https://cds.team/depmap/breadbox/datasets/ssgsea

While this one doesn't (without this fix):
https://cds.team/depmap/breadbox/datasets/mirna-573f.3%2FCCLE_miRNA_MIMAT

Workaround: declare the route parameter with `:path` like this:
```py
@router.get("/{dataset_id:path}")
```

That allows the route to match properly and the URL-encoded ID to be processed.

One caveat: `:path` consumes the remainder of the URL. Trying to use it in a nested route like `"/types/dimensions/{name:path}/identifiers"` will not work. Fortunately, all our other routes have the variable portion at the end so this workaround is acceptable.