### PR TITLE
add support for new Breadbox mutation matrices

### DIFF
--- a/frontend/packages/@depmap/cell-line-selector/src/components/DataColumnSelect.tsx
+++ b/frontend/packages/@depmap/cell-line-selector/src/components/DataColumnSelect.tsx
@@ -42,7 +42,6 @@ function DataColumnSelect({ onChange }: Props) {
           className={styles.DimensionSelect}
           mode="entity-only"
           index_type="depmap_model"
-          valueTypes={DimensionSelect.CONTINUOUS_ONLY}
           value={null}
           onChange={(dimension) => {
             const sliceId = convertDimensionToSliceId(dimension);

--- a/frontend/packages/@depmap/compute/src/components/CustomOrCatalogVectorSelect.tsx
+++ b/frontend/packages/@depmap/compute/src/components/CustomOrCatalogVectorSelect.tsx
@@ -91,7 +91,6 @@ export class CustomOrCatalogVectorSelect extends React.Component<
         <DimensionSelectV2
           mode="entity-only"
           index_type="depmap_model"
-          valueTypes={DimensionSelectV2.CONTINUOUS_ONLY}
           value={
             this.state.selectedDimension as DataExplorerPlotConfigDimensionV2
           }
@@ -108,7 +107,6 @@ export class CustomOrCatalogVectorSelect extends React.Component<
       <DimensionSelect
         mode="entity-only"
         index_type="depmap_model"
-        valueTypes={DimensionSelect.CONTINUOUS_ONLY}
         value={this.state.selectedDimension as DataExplorerPlotConfigDimension}
         onChange={
           onChangeDimension as (

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/Variable/DataSourceSelect.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/Variable/DataSourceSelect.tsx
@@ -58,12 +58,19 @@ function DataSourceSelect({ expr, path }: Props) {
         // Create a var reference if one doesn't exist.
         if (!nextVarName) {
           nextVarName = crypto.randomUUID();
-
-          dispatch({
-            type: "update-value",
-            payload: { path, value: { var: nextVarName } },
-          });
         }
+
+        // Also reset the operator to a neutral value.
+        const nextOp = "==";
+        const outerExpr = { [nextOp]: [{ var: nextVarName }, null] };
+
+        dispatch({
+          type: "update-value",
+          payload: {
+            path: path.slice(0, -2),
+            value: outerExpr,
+          },
+        });
 
         // Update the var reference.
         setVar(nextVarName, {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/Variable/MatrixDataSelect.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/Variable/MatrixDataSelect.tsx
@@ -45,6 +45,9 @@ function MatrixDataSelect({ varName }: Props) {
       mode="entity-only"
       removeWrapperDiv
       allowNullFeatureType
+      allowTextValueType
+      allowCategoricalValueType
+      allowListStringsValueType
       index_type={dimension_type}
       value={dimension}
       onChange={async (nextDimension) => {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/index.tsx
@@ -30,7 +30,7 @@ function RelationalExpression({ expr, path, isLastOfList }: Props) {
   const prevDomain = useRef<typeof domain | null>(null);
 
   useEffect(() => {
-    if (prevDomain.current) {
+    if (prevDomain.current || !right) {
       const nextExpr = makeCompatibleExpression(expr, domain);
 
       if (expr !== nextExpr) {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/hooks/useMatches.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/hooks/useMatches.ts
@@ -56,6 +56,7 @@ function useMatches(expr: Expr) {
       })();
     } else {
       setNumMatches(null);
+      setHasError(false);
     }
   }, [expr, dimension_type, fullySpecifiedVars, vars]);
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/ColorByViewOptions.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/ColorByViewOptions.tsx
@@ -3,20 +3,18 @@ import { ContextPath, DataExplorerContext, FilterKey } from "@depmap/types";
 import { isBreadboxOnlyMode } from "../../../../isBreadboxOnlyMode";
 import ContextSelector from "../../../ContextSelector";
 import DatasetMetadataSelector from "../../../DatasetMetadataSelector";
-import DimensionSelectV1 from "../../../DimensionSelect";
-import DimensionSelectV2 from "../../../DimensionSelectV2";
 import SliceLabelSelectV1 from "../../../DimensionSelect/SliceLabelSelect";
 import SliceLabelSelectV2 from "../../../DimensionSelectV2/SliceSelect";
 import { useDataExplorerSettings } from "../../../../contexts/DataExplorerSettingsContext";
 import { PlotConfigReducerAction } from "../../reducers/plotConfigReducer";
-import { ColorByTypeSelector, SortBySelector } from "./selectors";
+import {
+  ColorByTypeSelector,
+  ColorByDimensionSelect,
+  SortBySelector,
+} from "./selectors";
 import MetadataColumnSelect from "./MetadataColumnSelect";
 import TabularDatasetSelect from "./TabularDatasetSelect";
 import styles from "../../styles/ConfigurationPanel.scss";
-
-const DimensionSelect = isBreadboxOnlyMode
-  ? ((DimensionSelectV2 as unknown) as typeof DimensionSelectV1)
-  : DimensionSelectV1;
 
 const SliceLabelSelect = isBreadboxOnlyMode
   ? ((SliceLabelSelectV2 as unknown) as typeof SliceLabelSelectV1)
@@ -170,13 +168,9 @@ function ColorByViewOptions({
         />
       </div>
       {color_by === "custom" && (
-        <DimensionSelect
-          // HACK: Only support by DimensionSelectV2
-          {...{ allowNullFeatureType: true }}
-          mode="entity-or-context"
-          className={styles.customColorDimension}
+        <ColorByDimensionSelect
+          plot_type={plot_type}
           index_type={plot.index_type || null}
-          includeAllInContextOptions={false}
           value={dimensions.color || null}
           onChange={(dimension) => {
             dispatch({
@@ -193,10 +187,13 @@ function ColorByViewOptions({
             const context = plot.dimensions.color.context;
             onClickSaveAsContext(context, path);
           }}
-          onHeightChange={(el) => {
-            el.scrollIntoView({
-              behavior: "smooth",
-              block: "nearest",
+          // A secondary SortBySelector appears only when the selected matrix
+          // has categorical values (only supported in "Breadbox mode").
+          sortByValue={sort_by}
+          onChangeSortBy={(next_sort_by) => {
+            dispatch({
+              type: "select_sort_by",
+              payload: next_sort_by,
             });
           }}
         />

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerDensity1DPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerDensity1DPlot.tsx
@@ -204,17 +204,12 @@ function DataExplorerDensity1DPlot({
     }
 
     (Reflect.ownKeys(colorMap || {}) as LegendKey[]).forEach((key) => {
-      const name = categoryToDisplayName(
-        key,
-        data,
-        continuousBins,
-        plotConfig.color_by || null
-      );
+      const name = categoryToDisplayName(key, data, continuousBins);
       out[key] = typeof name === "string" ? name : `${name[0]} – ${name[1]}`;
     });
 
     return out;
-  }, [colorMap, data, continuousBins, plotConfig.color_by]);
+  }, [colorMap, data, continuousBins]);
 
   let legendTitle = "";
 
@@ -293,7 +288,6 @@ function DataExplorerDensity1DPlot({
               data={data}
               colorMap={colorMap}
               continuousBins={continuousBins}
-              color_by={plotConfig.color_by}
               hiddenLegendValues={hiddenLegendValues}
               legendKeysWithNoData={legendKeysWithNoData}
               onClickLegendItem={onClickLegendItem}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerScatterPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerScatterPlot.tsx
@@ -243,8 +243,7 @@ function DataExplorerScatterPlot({
         const name = categoryToDisplayName(
           key as LegendKey,
           data as DataExplorerPlotResponse,
-          continuousBins,
-          plotConfig.color_by || null
+          continuousBins
         );
         const formattedName =
           typeof name === "string" ? name : `${name[0]} – ${name[1]}`;
@@ -260,7 +259,7 @@ function DataExplorerScatterPlot({
       title,
       items,
     };
-  }, [colorMap, data, continuousBins, hiddenLegendValues, plotConfig.color_by]);
+  }, [colorMap, data, continuousBins, hiddenLegendValues]);
 
   const pointVisibility = useMemo(
     () => calcVisibility(data, hiddenLegendValues, continuousBins),
@@ -301,7 +300,7 @@ function DataExplorerScatterPlot({
         hidden = true;
       }
 
-      if (plotConfig.color_by === "custom" && plotConfig.show_regression_line) {
+      if (data?.dimensions?.color && plotConfig.show_regression_line) {
         hidden = false;
       }
 
@@ -316,7 +315,14 @@ function DataExplorerScatterPlot({
         b: Number(linreg.intercept),
       };
     });
-  }, [linreg_by_group, plotConfig, colorMap, hiddenLegendValues, palette]);
+  }, [
+    colorMap,
+    data?.dimensions?.color,
+    hiddenLegendValues,
+    linreg_by_group,
+    palette,
+    plotConfig.show_regression_line,
+  ]);
 
   const showIdentityLine = Boolean(
     data?.dimensions?.x &&
@@ -381,7 +387,6 @@ function DataExplorerScatterPlot({
             <PlotLegend
               data={data}
               colorMap={colorMap}
-              color_by={plotConfig.color_by}
               continuousBins={continuousBins}
               hiddenLegendValues={hiddenLegendValues}
               legendKeysWithNoData={legendKeysWithNoData}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerWaterfallPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerWaterfallPlot.tsx
@@ -15,6 +15,7 @@ import {
   calcVisibility,
   categoryToDisplayName,
   continuousValuesToLegendKeySeries,
+  findCategoricalSlice,
   formatDataForWaterfall,
   getColorMap,
   getLegendKeysWithNoData,
@@ -170,14 +171,14 @@ function DataExplorerWaterfallPlot({
   );
 
   const sortedLegendKeys = useMemo(() => {
-    const catData = data?.metadata?.color_property;
+    const catData = findCategoricalSlice(data);
 
     if (!catData || !data?.dimensions?.y) {
       return undefined;
     }
 
     return sortLegendKeysWaterfall(data, catData, plotConfig.sort_by);
-  }, [data, plotConfig]);
+  }, [data, plotConfig.sort_by]);
 
   const formattedData: {
     annotationText: string[];
@@ -248,8 +249,7 @@ function DataExplorerWaterfallPlot({
         const name = categoryToDisplayName(
           key as LegendKey,
           data as DataExplorerPlotResponse,
-          continuousBins,
-          plotConfig.color_by || null
+          continuousBins
         );
         const formattedName =
           typeof name === "string" ? name : `${name[0]} – ${name[1]}`;
@@ -265,7 +265,7 @@ function DataExplorerWaterfallPlot({
       title,
       items,
     };
-  }, [colorMap, data, continuousBins, hiddenLegendValues, plotConfig.color_by]);
+  }, [colorMap, data, continuousBins, hiddenLegendValues]);
 
   const pointVisibility = useMemo(
     () => calcVisibility(data, hiddenLegendValues, continuousBins),
@@ -331,7 +331,6 @@ function DataExplorerWaterfallPlot({
               data={data}
               colorMap={colorMap}
               sortedLegendKeys={sortedLegendKeys}
-              color_by={plotConfig.color_by}
               continuousBins={continuousBins}
               hiddenLegendValues={hiddenLegendValues}
               legendKeysWithNoData={legendKeysWithNoData}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DummyPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DummyPlot.tsx
@@ -112,7 +112,6 @@ function DummyPlot({
           <PlotLegend
             data={null}
             continuousBins={null}
-            color_by={undefined}
             hiddenLegendValues={hiddenLegendValues}
             onClickLegendItem={onClickLegendItem}
             colorMap={{}}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/LegendLabel.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/LegendLabel.tsx
@@ -1,6 +1,5 @@
 import React, { useLayoutEffect, useRef, useState } from "react";
 import { Tooltip, WordBreaker } from "@depmap/common-components";
-import { DataExplorerPlotConfig } from "@depmap/types";
 import {
   calcBins,
   categoryToDisplayName,
@@ -17,10 +16,9 @@ interface Props {
   };
   continuousBins: ReturnType<typeof calcBins>;
   category: LegendKey;
-  color_by: DataExplorerPlotConfig["color_by"];
 }
 
-function LegendLabel({ data, continuousBins, category, color_by }: Props) {
+function LegendLabel({ data, continuousBins, category }: Props) {
   const ref = useRef<HTMLElement | null>(null);
   const [showTooltip, setShowTooltip] = useState(false);
 
@@ -31,12 +29,7 @@ function LegendLabel({ data, continuousBins, category, color_by }: Props) {
     }
   }, []);
 
-  const name = categoryToDisplayName(
-    category,
-    data,
-    continuousBins,
-    color_by || null
-  );
+  const name = categoryToDisplayName(category, data, continuousBins);
   const nameElement =
     typeof name === "string" ? (
       <span>{name}</span>

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/PlotLegend.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/PlotLegend.tsx
@@ -1,8 +1,5 @@
 import React, { useContext } from "react";
-import {
-  DataExplorerPlotConfig,
-  DataExplorerPlotResponse,
-} from "@depmap/types";
+import { DataExplorerPlotResponse } from "@depmap/types";
 import { SectionStackContext } from "../SectionStack";
 import HelpTip from "../HelpTip";
 import LegendLabel from "./LegendLabel";
@@ -19,7 +16,6 @@ function LegendLabels({
   hiddenLegendValues,
   legendKeysWithNoData,
   onClickLegendItem,
-  color_by,
   handleClickShowAll,
   handleClickHideAll,
 }: any) {
@@ -29,7 +25,7 @@ function LegendLabels({
     sortedLegendKeys || Reflect.ownKeys(colorMap || {})
   ).filter(
     (category: any) =>
-      color_by === "custom" ||
+      data?.dimensions?.color ||
       !legendKeysWithNoData ||
       !legendKeysWithNoData.has(category)
   );
@@ -68,7 +64,6 @@ function LegendLabels({
               data={data}
               continuousBins={continuousBins}
               category={category}
-              color_by={color_by}
             />
           </button>
         </div>
@@ -112,7 +107,6 @@ interface Props {
     item: string | symbol,
     catColorMap: Record<string, string>
   ) => void;
-  color_by: DataExplorerPlotConfig["color_by"];
   handleClickShowAll: () => void;
   handleClickHideAll: (catColorMap: Record<string, string>) => void;
 }
@@ -125,7 +119,6 @@ function PlotLegend({
   hiddenLegendValues,
   legendKeysWithNoData,
   onClickLegendItem,
-  color_by,
   handleClickShowAll,
   handleClickHideAll,
 }: Props) {
@@ -144,7 +137,6 @@ function PlotLegend({
         hiddenLegendValues={hiddenLegendValues}
         legendKeysWithNoData={legendKeysWithNoData}
         onClickLegendItem={onClickLegendItem}
-        color_by={color_by}
         handleClickShowAll={handleClickShowAll}
         handleClickHideAll={handleClickHideAll}
       />

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/plotUtils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/plotUtils.ts
@@ -6,6 +6,7 @@ import {
   DataExplorerPlotResponse,
   SliceQuery,
 } from "@depmap/types";
+import wellKnownDatasets from "../../../../../constants/wellKnownDatasets";
 
 // HACK: Copied from the "depmap-shared" directory.
 const colorPalette = {
@@ -181,6 +182,41 @@ function nullifyUnplottableValues(
   return out;
 }
 
+export function findCategoricalSlice(data: DataExplorerPlotResponse | null) {
+  if (!data) {
+    return null;
+  }
+
+  const colorDim = data.dimensions?.color;
+
+  if (colorDim && colorDim.value_type === "categorical") {
+    return {
+      label: colorDim.axis_label,
+      dataset_id: colorDim.dataset_id,
+      values: colorDim.values,
+      value_type: colorDim.value_type,
+    };
+  }
+
+  return data?.metadata?.color_property || null;
+}
+
+export function findContinuousColorSlice(
+  data: DataExplorerPlotResponse | null
+) {
+  const colorDim = data?.dimensions?.color;
+
+  if (colorDim?.value_type === "continuous") {
+    return {
+      label: colorDim.axis_label,
+      values: colorDim.values,
+      value_type: colorDim.value_type,
+    };
+  }
+
+  return null;
+}
+
 export function formatDataForScatterPlot(
   data: DataExplorerPlotResponse | null,
   color_by: DataExplorerPlotConfig["color_by"]
@@ -194,9 +230,10 @@ export function formatDataForScatterPlot(
 
   const c1Values = data.filters?.color1?.values;
   const c2Values = data.filters?.color2?.values;
-  const catValues = data.metadata?.color_property?.values;
+  const catValues = findCategoricalSlice(data)?.values;
+  const contSlice = findContinuousColorSlice(data);
   const contValues = nullifyUnplottableValues(
-    data.dimensions.color?.values,
+    contSlice?.values,
     data.filters?.visible?.values,
     [data.dimensions.x, data.dimensions.y!]
   );
@@ -582,7 +619,7 @@ export function calcVisibility(
   }
 
   const contKeys = Reflect.ownKeys(continuousBins || {});
-  const contValues = data.dimensions.color?.values;
+  const contValues = findContinuousColorSlice(data)?.values;
 
   if (contValues) {
     return contValues.map((value: number) => {
@@ -610,7 +647,7 @@ export function calcVisibility(
     });
   }
 
-  const catValues = data.metadata?.color_property?.values;
+  const catValues = findCategoricalSlice(data)?.values;
 
   if (catValues) {
     const hideOthers = hiddenLegendValues.has(LEGEND_OTHER);
@@ -671,7 +708,7 @@ export function calcVisibility(
 }
 
 export function getLegendKeysWithNoData(data: any, continuousBins: any) {
-  const catData = data?.metadata?.color_property;
+  const catData = findCategoricalSlice(data);
   const visible = data?.filters?.visible;
 
   if (catData && visible) {
@@ -887,9 +924,9 @@ const hasPlottableNulls = (
 
 function makeCategoricalColorMap(
   values: string[] | null,
-  slice_id: string,
-  dimensions: Record<string, { values: unknown[] }> | null,
+  dimensions: Record<string, { dataset_id: string; values: unknown[] }> | null,
   filters: Record<string, { values: boolean[] }> | null,
+  metadata: DataExplorerMetadata | null,
   palette: DataExplorerColorPalette
 ) {
   if (!values) {
@@ -910,16 +947,26 @@ function makeCategoricalColorMap(
     .filter((key) => counts.get(key)! > 0 && plottableCategories.has(key))
     .sort(collator.compare);
 
-  if (slice_id.startsWith("slice/mutations_prioritized/")) {
+  const legacySliceId = (metadata?.color_property as { slice_id?: string })
+    ?.slice_id;
+
+  if (
+    legacySliceId?.startsWith("slice/mutations_prioritized/") ||
+    dimensions?.color?.dataset_id === wellKnownDatasets.mutations_prioritized
+  ) {
     const fixedColors = {
       "Other conserving": colorPalette.other_conserving_color,
       "Other non-conserving": colorPalette.other_non_conserving_color,
       Damaging: colorPalette.damaging_color,
       Hotspot: colorPalette.hotspot_color,
+      Other: colorPalette.other_conserving_color,
     };
 
     keys.forEach((key) => {
-      out[key] = fixedColors[key as keyof typeof fixedColors];
+      out[key] =
+        key in fixedColors
+          ? fixedColors[key as keyof typeof fixedColors]
+          : palette.other;
     });
   } else {
     const colors =
@@ -959,17 +1006,20 @@ export function getColorMap(
 
   let colorMap: Partial<Record<LegendKey, string>> = {};
 
-  if (data.metadata?.color_property) {
+  const catSlice = findCategoricalSlice(data);
+  const contSlice = findContinuousColorSlice(data);
+
+  if (catSlice) {
     colorMap = makeCategoricalColorMap(
-      data.metadata.color_property.values,
-      data.metadata.color_property.slice_id,
+      catSlice.values as string[],
       data.dimensions,
       data.filters,
+      data.metadata,
       palette
     ) as any;
   }
 
-  if (data.dimensions.color) {
+  if (contSlice) {
     colorMap = {
       [LEGEND_RANGE_1]: palette.sequentialScale[0][1],
       [LEGEND_RANGE_2]: palette.sequentialScale[1][1],
@@ -1032,7 +1082,7 @@ export function getColorMap(
   }
 
   if (
-    data.dimensions?.color &&
+    contSlice &&
     hasSomeNullValuesUniqueToDimension(data.dimensions, "color")
   ) {
     colorMap[LEGEND_OTHER] = palette.other;
@@ -1119,13 +1169,15 @@ export type ContinuousBins = ReturnType<typeof calcBins>;
 export function categoryToDisplayName(
   category: LegendKey,
   data: {
+    dimensions?: {
+      color?: object;
+    };
     filters: {
       color1?: { name: string };
       color2?: { name: string };
     };
   },
-  continuousBins: ContinuousBins,
-  color_by: string | null
+  continuousBins: ContinuousBins
 ) {
   if (category === LEGEND_BOTH) {
     return `Both (${[data.filters.color1!.name, data.filters.color2!.name].join(
@@ -1138,7 +1190,12 @@ export function categoryToDisplayName(
   }
 
   if (category === LEGEND_OTHER) {
-    return color_by === "custom" ? "N/A" : "Other";
+    const catSlice = findCategoricalSlice(data as DataExplorerPlotResponse);
+    const hasOther = catSlice?.values.some(
+      (val) => val === "other" || val === "Other"
+    );
+
+    return catSlice && !hasOther ? "Other" : "N/A";
   }
 
   if (typeof category === "symbol") {
@@ -1358,8 +1415,8 @@ export function calcDensityStats(
 ) {
   const color1 = data?.filters?.color1;
   const color2 = data?.filters?.color2;
-  const catData = data?.metadata?.color_property;
-  const contData = data?.dimensions?.color;
+  const catData = findCategoricalSlice(data);
+  const contData = findContinuousColorSlice(data);
   const visible = data?.filters?.visible;
 
   if (color1 || color2) {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/styles/ConfigurationPanel.scss
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/styles/ConfigurationPanel.scss
@@ -118,6 +118,11 @@
   margin-top: -60px;
 }
 
+.customColorSortBy {
+  margin-top: -229px;
+  padding-bottom: 168px;
+}
+
 .checkbox {
   margin-top: 0;
   margin-bottom: 14px;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelect/index.tsx
@@ -21,14 +21,6 @@ export interface Props {
    */
   mode?: "entity-only" | "context-only" | "entity-or-context";
 
-  /**
-   * If defined, filters the available dataset options to only ones that match
-   * the specified value types.
-   *
-   * @default undefined (included all value types)
-   */
-  valueTypes?: Set<"continuous" | "text" | "categorical" | "list_strings">;
-
   /** Called when the height of the container <div> changes. Useful for modals
    * where the available height might be confined. */
   onHeightChange?: (el: HTMLDivElement, prevHeight: number) => void;
@@ -54,7 +46,6 @@ function DimensionSelect({
   onChange,
   className = undefined,
   mode = "entity-or-context",
-  valueTypes = undefined,
   onHeightChange = undefined,
   removeWrapperDiv = false,
   onClickCreateContext = () => {},
@@ -76,12 +67,6 @@ function DimensionSelect({
     onChange,
   });
 
-  if (valueTypes && valueTypes !== DimensionSelect.CONTINUOUS_ONLY) {
-    window.console.warn(
-      "The `valueTypes` prop is not yet implemented and wil be ignored."
-    );
-  }
-
   return (
     <AllSelects
       mode={mode}
@@ -99,9 +84,4 @@ function DimensionSelect({
   );
 }
 
-// Common sets of value types.
-DimensionSelect.CONTINUOUS_ONLY = new Set(["continuous"]);
-
-export default wrapWithErrorBoundary(
-  DimensionSelect
-) as typeof DimensionSelect & { CONTINUOUS_ONLY: Props["valueTypes"] };
+export default wrapWithErrorBoundary(DimensionSelect);

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/AllSelects.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/AllSelects.tsx
@@ -92,9 +92,9 @@ function AllSelects({
           mode === "entity-or-context" &&
           Boolean(slice_type || axis_type === "aggregated_slice")
         }
-        disabled={dataType === "custom"}
         value={axis_type as "raw_slice" | "aggregated_slice"}
         onChange={onChangeAxisType}
+        dataset_id={dataset_id}
       />
       <SliceSelect
         show={axis_type === "raw_slice"}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/AxisTypeToggle.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/AxisTypeToggle.tsx
@@ -1,12 +1,13 @@
-import React from "react";
-import renderConditionally from "../../utils/render-conditionally";
+import React, { useEffect, useState } from "react";
+import { breadboxAPI, cached } from "@depmap/api";
 import { ToggleSwitch } from "@depmap/common-components";
+import renderConditionally from "../../utils/render-conditionally";
 import styles from "../../styles/DimensionSelect.scss";
 
 interface Props {
   value: "raw_slice" | "aggregated_slice";
   onChange: (nextValue: "raw_slice" | "aggregated_slice") => void;
-  disabled?: boolean;
+  dataset_id: string | undefined;
 }
 
 type ToggleOption = { label: string; value: "raw_slice" | "aggregated_slice" };
@@ -16,18 +17,33 @@ const toggleOptions = [
   { label: "Multiple", value: "aggregated_slice" },
 ] as [ToggleOption, ToggleOption];
 
-const AxisTypeToggle = renderConditionally(
-  ({ value, onChange, disabled = false }: Props) => {
-    return (
-      <ToggleSwitch
-        className={styles.AxisTypeToggle}
-        value={value}
-        onChange={onChange}
-        disabled={disabled}
-        options={toggleOptions}
-      />
-    );
-  }
-);
+function AxisTypeToggle({ value, onChange, dataset_id }: Props) {
+  const [disabled, setDisabled] = useState(false);
 
-export default AxisTypeToggle;
+  useEffect(() => {
+    if (dataset_id) {
+      cached(breadboxAPI)
+        .getDataset(dataset_id)
+        .then((dataset) => {
+          setDisabled(
+            dataset.format === "matrix_dataset" &&
+              dataset.value_type !== "continuous"
+          );
+        });
+    } else {
+      setDisabled(false);
+    }
+  }, [dataset_id]);
+
+  return (
+    <ToggleSwitch
+      className={styles.AxisTypeToggle}
+      value={value}
+      onChange={onChange}
+      disabled={disabled}
+      options={toggleOptions}
+    />
+  );
+}
+
+export default renderConditionally(AxisTypeToggle);

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { DataExplorerPlotConfigDimensionV2 } from "@depmap/types";
 import AllSelects from "./AllSelects";
 import useDimensionStateManager from "./useDimensionStateManager";
@@ -22,12 +22,28 @@ export interface Props {
   mode?: "entity-only" | "context-only" | "entity-or-context";
 
   /**
-   * If defined, filters the available dataset options to only ones that match
-   * the specified value types.
+   * Controls whether datasets whose value_type is "text" are displayed
+   * as options.
    *
-   * @default undefined (included all value types)
+   * @default false
    */
-  valueTypes?: Set<"continuous" | "text" | "categorical" | "list_strings">;
+  allowTextValueType?: boolean;
+
+  /**
+   * Controls whether datasets whose value_type is "categorical" are displayed
+   * as options.
+   *
+   * @default false
+   */
+  allowCategoricalValueType?: boolean;
+
+  /**
+   * Controls whether datasets whose value_type is "list_strings" are displayed
+   * as options.
+   *
+   * @default false
+   */
+  allowListStringsValueType?: boolean;
 
   /**
    * Controls whether datasets that have no feature type will appear as
@@ -62,7 +78,9 @@ function DimensionSelectV2({
   onChange,
   className = undefined,
   mode = "entity-or-context",
-  valueTypes = undefined,
+  allowTextValueType = false,
+  allowCategoricalValueType = false,
+  allowListStringsValueType = false,
   allowNullFeatureType = false,
   onHeightChange = undefined,
   removeWrapperDiv = false,
@@ -74,11 +92,36 @@ function DimensionSelectV2({
     throw new Error("Unexpected null index_type");
   }
 
+  const valueTypes = useMemo(() => {
+    const allowedValueTypes = new Set<
+      "continuous" | "text" | "categorical" | "list_strings"
+    >(["continuous"]);
+
+    if (allowTextValueType) {
+      allowedValueTypes.add("text");
+    }
+
+    if (allowCategoricalValueType) {
+      allowedValueTypes.add("categorical");
+    }
+
+    if (allowListStringsValueType) {
+      allowedValueTypes.add("list_strings");
+    }
+
+    return allowedValueTypes;
+  }, [
+    allowTextValueType,
+    allowCategoricalValueType,
+    allowListStringsValueType,
+  ]);
+
   const state = useDimensionStateManager({
     index_type,
     mode,
     value,
     onChange,
+    valueTypes,
     allowNullFeatureType,
   });
 
@@ -90,12 +133,6 @@ function DimensionSelectV2({
   //   state,
   //   onChange,
   // });
-
-  if (valueTypes && valueTypes !== DimensionSelectV2.CONTINUOUS_ONLY) {
-    window.console.warn(
-      "The `valueTypes` prop is not yet implemented and wil be ignored."
-    );
-  }
 
   return (
     <AllSelects
@@ -114,9 +151,6 @@ function DimensionSelectV2({
   );
 }
 
-// Common sets of value types.
-DimensionSelectV2.CONTINUOUS_ONLY = new Set(["continuous"]);
-
 export default wrapWithErrorBoundary(
   DimensionSelectV2
-) as typeof DimensionSelectV2 & { CONTINUOUS_ONLY: Props["valueTypes"] };
+) as typeof DimensionSelectV2;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/index.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/index.ts
@@ -12,6 +12,7 @@ interface Props {
   value: Partial<DataExplorerPlotConfigDimensionV2> | null;
   onChange: (nextValue: Partial<DataExplorerPlotConfigDimensionV2>) => void;
   allowNullFeatureType: boolean;
+  valueTypes: Set<"continuous" | "text" | "categorical" | "list_strings">;
   initialDataType?: string;
 }
 
@@ -21,6 +22,7 @@ export default function useDimensionStateManager({
   value,
   onChange,
   allowNullFeatureType,
+  valueTypes,
   initialDataType = "",
 }: Props) {
   const isInitialized = useRef(false);
@@ -33,6 +35,7 @@ export default function useDimensionStateManager({
     ...DEFAULT_STATE,
     dataType: initialDataType || null,
     allowNullFeatureType,
+    valueTypes,
     dimension: {
       ...value,
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/resolveNextState.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/resolveNextState.ts
@@ -152,14 +152,20 @@ async function resolveNextState(
   }
 
   const options = shouldCalcOptions
-    ? await computeOptions(index_type, dataType, prev.allowNullFeatureType, {
-        ...prev.dimension,
-        axis_type,
-        context,
-        dataset_id,
-        slice_type,
-        aggregation,
-      })
+    ? await computeOptions(
+        index_type,
+        dataType,
+        prev.allowNullFeatureType,
+        prev.valueTypes,
+        {
+          ...prev.dimension,
+          axis_type,
+          context,
+          dataset_id,
+          slice_type,
+          aggregation,
+        }
+      )
     : {
         dataVersionOptions: [],
         dataTypeOptions: [],

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/types.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/types.ts
@@ -54,6 +54,7 @@ export interface State {
   isUnknownDataset: boolean;
   dimension: PartialDimension;
   allowNullFeatureType: boolean;
+  valueTypes: Set<"continuous" | "text" | "categorical" | "list_strings">;
 }
 
 export const DEFAULT_STATE: State = {
@@ -68,6 +69,7 @@ export const DEFAULT_STATE: State = {
   isUnknownDataset: false,
   dimension: {},
   allowNullFeatureType: false,
+  valueTypes: new Set(),
 };
 
 export type Changes = Partial<{

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/utils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/utils.ts
@@ -12,6 +12,7 @@ interface DataExplorerDatasetDescriptor {
   slice_type: string | SliceTypeNull;
   slice_type_display_name: string;
   units: string;
+  value_type: string;
 }
 
 const privateDatasets: Map<string, Dataset> = new Map();
@@ -60,11 +61,6 @@ export async function fetchDatasetsByIndexType(
       return;
     }
 
-    // TODO: add support for other value types
-    if (dataset.value_type !== "continuous") {
-      return;
-    }
-
     const {
       data_type,
       id,
@@ -74,6 +70,7 @@ export async function fetchDatasetsByIndexType(
       units,
       sample_type_name,
       feature_type_name,
+      value_type,
     } =
       // FIXME: The MatrixDataset definition has yet to be updated (because
       // that will have many knock-on effects) but Breadbox allows datasets
@@ -89,6 +86,7 @@ export async function fetchDatasetsByIndexType(
       name,
       priority,
       units,
+      value_type: value_type as string,
     };
 
     if (index_type === sample_type_name) {

--- a/frontend/packages/@depmap/data-explorer-2/src/constants/wellKnownDatasets.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/constants/wellKnownDatasets.ts
@@ -1,0 +1,7 @@
+const mutations_prioritized = "prioritized-mutations-test";
+const mutation_protein_change = "protein-changes-test";
+
+export default {
+  mutations_prioritized,
+  mutation_protein_change,
+};

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/breadboxMethods.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/breadboxMethods.ts
@@ -14,6 +14,7 @@ import {
   DataExplorerMetadata,
   DataExplorerPlotConfigDimension,
   DataExplorerPlotResponse,
+  DataExplorerPlotResponseDimension,
   FilterKey,
   MatrixDataset,
   SliceQuery,
@@ -72,6 +73,30 @@ async function fetchAxisLabel(dimension?: DataExplorerPlotConfigDimension) {
   }
 
   return `${aggregation} ${units} of ${contextCount} ${context.name} ${entities}`;
+}
+
+async function fetchValueType(dimension?: DataExplorerPlotConfigDimension) {
+  if (!dimension || !isCompleteDimension(dimension)) {
+    return "continuous";
+  }
+
+  const datasets = await cached(breadboxAPI).getDatasets();
+
+  const dataset = datasets.find((d) => {
+    return d.id === dimension.dataset_id || d.given_id === dimension.dataset_id;
+  });
+
+  if (!dataset) {
+    throw new Error(`Uknown dataset "${dimension.dataset_id}"`);
+  }
+
+  if (dataset.format !== "matrix_dataset") {
+    throw new Error(
+      "Dataset is not a matrix! This is not supported for plot dimensions."
+    );
+  }
+
+  return dataset.value_type;
 }
 
 async function fetchDatasetLabel(dataset_id?: string) {
@@ -324,7 +349,7 @@ export async function fetchPlotDimensions(
       index_labels,
       index_display_labels,
       linreg_by_group: [],
-      dimensions: {} as Record<string, unknown>,
+      dimensions: {} as DataExplorerPlotResponse["dimensions"],
       filters: {} as Record<string, unknown>,
       metadata: {} as Record<string, unknown>,
     };
@@ -334,6 +359,12 @@ export async function fetchPlotDimensions(
       y: await fetchAxisLabel(dimensions?.y),
       color: await fetchAxisLabel(dimensions?.color),
     } as Record<string, string>;
+
+    const valueTypes = {
+      x: await fetchValueType(dimensions?.x),
+      y: await fetchValueType(dimensions?.y),
+      color: await fetchValueType(dimensions?.color),
+    } as Record<string, DataExplorerPlotResponseDimension["value_type"]>;
 
     const datasetLabels = {
       x: dimensions.x ? await fetchDatasetLabel(dimensions.x.dataset_id) : null,
@@ -353,14 +384,15 @@ export async function fetchPlotDimensions(
       };
 
       if (property === "dimensions") {
-        out.dimensions[key] = {
+        out.dimensions[key as keyof DataExplorerPlotResponse["dimensions"]] = {
           slice_type: dimensions[key].slice_type,
           dataset_id: dimensions[key].dataset_id,
           axis_label: axisLabels[key],
-          dataset_label: datasetLabels[key],
+          dataset_label: datasetLabels[key] as string,
+          value_type: valueTypes[key],
           values: out.index_labels.map((label) => {
             return indexed_values[label] ?? null;
-          }),
+          }) as number[],
         };
       }
 
@@ -494,6 +526,14 @@ export const fetchLinearRegression = memoize(
       categories = data.metadata.color_property.values;
     }
 
+    if (
+      ["categorical", "text"].includes(
+        data.dimensions?.color?.value_type as string
+      )
+    ) {
+      categories = data.dimensions.color!.values;
+    }
+
     if (data.filters?.color1 || data.filters?.color2) {
       const name1 = data.filters?.color1?.name || null;
       const name2 = data.filters?.color2?.name || null;
@@ -594,6 +634,7 @@ const correlateDimension = memoize(
         ({
           slice_type,
           values: [],
+          value_type: "continuous",
           dataset_label,
           context_size: labels.length,
           axis_label:
@@ -667,6 +708,10 @@ const correlateDimension = memoize(
       slice_type,
       axis_label,
       dataset_label,
+      // We assume `value_type` is "continuous" because it wouldn't make sense
+      // to compute a correlation otherwise.
+      // TODO: Add validation for this.
+      value_type: "continuous" as const,
       // HACK: The correlation heatmap is a special case and breaks the
       // standard dimension type. `matrix` is of type number[][] but we'll
       // cast it to number[] just to keep the types simple. Caution must be
@@ -727,7 +772,12 @@ export async function fetchWaterfall(
     metadata
   );
 
-  const categoricalValues = unsortedData.metadata?.color_property?.values;
+  let categoricalValues = unsortedData.metadata?.color_property?.values;
+
+  // FIXME: Should we make this easier to work with?
+  if (unsortedData.dimensions.color?.value_type === "categorical") {
+    categoricalValues = unsortedData.dimensions.color.values;
+  }
 
   const sortedLabels = unsortedData.index_labels
     .map(
@@ -772,14 +822,20 @@ export async function fetchWaterfall(
   };
 
   const sortedDimensions: DataExplorerPlotResponse["dimensions"] = {
+    // HACK: This ouput "x" dimension does not match the input "x" dimension.
+    // Rather, it is a special "rank" dimension that's derived from it.
     x: {
       axis_label: categoricalValues ? "" : "Rank",
       dataset_label: "",
       dataset_id: dimensions.x.dataset_id,
       slice_type: dimensions.x.slice_type,
+      value_type: "continuous",
       values: Array.from({ length: sortedLabels.length }, (_, i) => i),
     },
 
+    // HACK: We remap the "x" dimension from the plot config onto the y axis.
+    // This is for consistency with the density plot, which has a single "x"
+    // dimension.
     y: {
       ...unsortedData.dimensions.x,
       values: sortByReindexedLabels(unsortedData.dimensions.x.values),

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/variables.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/variables.ts
@@ -44,6 +44,11 @@ export async function fetchVariableDomain(
 
   try {
     data = await getDimensionDataWithoutLabels(sliceQuery);
+
+    if (data.values.length === 0) {
+      window.console.error({ sliceQuery });
+      throw new Error("Slice query returned empty data!");
+    }
   } catch {
     window.console.error({ sliceQuery });
     throw new Error("Error fetching data from slice query");
@@ -79,6 +84,23 @@ export async function fetchVariableDomain(
     }
 
     return Promise.resolve({ min, max, value_type });
+  }
+
+  if (value_type === "list_strings") {
+    const stringValues = new Set<string>();
+
+    for (let i = 0; i < data.values.length; i += 1) {
+      const value = data.values[i];
+
+      if (Array.isArray(value)) {
+        value.forEach((s) => stringValues.add(s));
+      }
+    }
+
+    return Promise.resolve({
+      unique_values: [...stringValues].sort(compareCaseInsensitive),
+      value_type,
+    });
   }
 
   throw new Error(`Unsupported value_type "${value_type}".`);

--- a/frontend/packages/@depmap/data-explorer-2/src/utils/context-converter.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/context-converter.tsx
@@ -6,7 +6,13 @@ import {
   DataExplorerContextV2,
   DataExplorerContextVariable,
 } from "@depmap/types";
+import wellKnownDatasets from "../constants/wellKnownDatasets";
 import { sliceIdToSliceQuery } from "./slice-id";
+
+const CATEGORICAL_MATRICES = new Set([
+  wellKnownDatasets.mutations_prioritized,
+  wellKnownDatasets.mutation_protein_change,
+]);
 
 // Returns a Promise of { success, convertedContext }.
 //
@@ -64,7 +70,10 @@ export async function convertContextV1toV2(
   }
 
   // Extract the variables from the expression.
-  const varTypes: Record<string, "continuous" | "categorical"> = {};
+  const varTypes: Record<
+    string,
+    "continuous" | "categorical" | "list_strings"
+  > = {};
 
   JSON.parse(JSON.stringify(context.expr), (_, value) => {
     if (Array.isArray(value)) {
@@ -72,8 +81,15 @@ export async function convertContextV1toV2(
       const varValue = value[1];
 
       if (varName) {
-        varTypes[varName] =
-          typeof varValue === "number" ? "continuous" : "categorical";
+        varTypes[varName] = (() => {
+          // Assume all arrays are lists of strings (we don't support other
+          // list types).
+          if (Array.isArray(varValue)) {
+            return "list_strings";
+          }
+
+          return typeof varValue === "number" ? "continuous" : "categorical";
+        })();
       }
     }
 
@@ -101,7 +117,10 @@ export async function convertContextV1toV2(
 
       let source: DataExplorerContextVariable["source"] = "matrix_dataset";
 
-      if (varTypes[varName] === "categorical") {
+      if (
+        varTypes[varName] === "categorical" &&
+        !CATEGORICAL_MATRICES.has(sliceQuery.dataset_id)
+      ) {
         source = sliceQuery.dataset_id.endsWith("_metadata")
           ? "metadata_column"
           : "tabular_dataset";
@@ -109,7 +128,10 @@ export async function convertContextV1toV2(
 
       vars[varName] = { ...sliceQuery, source };
 
-      if (varTypes[varName] === "continuous") {
+      if (
+        varTypes[varName] === "continuous" ||
+        varTypes[varName] === "list_strings"
+      ) {
         vars[varName].label = sliceQuery.identifier;
       }
     }

--- a/frontend/packages/@depmap/data-explorer-2/src/utils/slice-id.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/slice-id.ts
@@ -1,8 +1,9 @@
 import { SliceQuery } from "@depmap/types";
+import wellKnownDatasets from "../constants/wellKnownDatasets";
 
 export function sliceIdToSliceQuery(
   slice_id: string,
-  value_type: "categorical" | "continuous",
+  value_type: "categorical" | "continuous" | "list_strings",
   dimension_type: string
 ): SliceQuery {
   const [prefix, dataset_id, identifier, labelType] = slice_id
@@ -103,11 +104,23 @@ export function sliceIdToSliceQuery(
         identifier: "GrowthPattern",
       };
 
+    case "mutations_prioritized":
+      return {
+        dataset_id: wellKnownDatasets.mutations_prioritized,
+        identifier,
+        identifier_type: "feature_label",
+      };
+
+    case "mutation_protein_change_by_gene":
+      return {
+        dataset_id: wellKnownDatasets.mutation_protein_change,
+        identifier,
+        identifier_type: "feature_label",
+      };
+
     // TODO: Spport these special cases
-    // case "mutations_prioritized":
     // case "msi-0584.6/msi":
     // case "prism-pools-4441.2/coded_prism_pools":
-    // case "mutation_protein_change_by_gene":
     // case "gene_essentiality":
     // case "gene_selectivity":
     // case "compound_experiment":

--- a/frontend/packages/@depmap/types/src/data-explorer-2.ts
+++ b/frontend/packages/@depmap/types/src/data-explorer-2.ts
@@ -81,6 +81,7 @@ export interface DataExplorerPlotResponseDimension {
   dataset_label: string;
   slice_type: string;
   values: number[];
+  value_type: "continuous" | "text" | "categorical" | "list_strings";
 }
 
 export type ColorByValue =

--- a/portal-backend/depmap/data_explorer_2/plot.py
+++ b/portal-backend/depmap/data_explorer_2/plot.py
@@ -100,6 +100,7 @@ def compute_dimension(
         "dataset_label": dataset.label,
         "axis_label": axis_label,
         "slice_type": dimension["slice_type"],
+        "value_type": "continuous",
         "indexed_values": indexed_values,
     }
 
@@ -203,6 +204,7 @@ def compute_waterfall(index_type, dimensions, filters, metadata):
         "dataset_label": "",
         "axis_label": "Rank" if categorical_colors is None else "",
         "slice_type": primary_dimension["slice_type"],
+        "value_type": "continuous",
         "values": list(range(0, len(index_labels))),
     }
 
@@ -211,6 +213,7 @@ def compute_waterfall(index_type, dimensions, filters, metadata):
         "dataset_label": primary_dimension["dataset_label"],
         "axis_label": primary_dimension["axis_label"],
         "slice_type": primary_dimension["slice_type"],
+        "value_type": "continuous",
         "values": [indexed_values.get(label, None) for label in index_labels],
     }
 
@@ -221,6 +224,7 @@ def compute_waterfall(index_type, dimensions, filters, metadata):
             "dataset_label": color_dimension["dataset_label"],
             "axis_label": color_dimension["axis_label"],
             "slice_type": color_dimension["slice_type"],
+            "value_type": "continuous",
             "values": [
                 color_dimension["indexed_values"].get(label, None)
                 for label in index_labels

--- a/portal-backend/depmap/data_explorer_2/views.py
+++ b/portal-backend/depmap/data_explorer_2/views.py
@@ -173,6 +173,7 @@ def get_correlation():
             "dataset_id": dataset_id,
             "dataset_label": dataset_label,
             "axis_label": "cannot plot",
+            "value_type": "continuous",
             "values": [],
             "context_size": len(row_labels),
             "slice_type": slice_type,
@@ -192,6 +193,7 @@ def get_correlation():
             "dataset_id": dataset_id,
             "dataset_label": dataset_label,
             "axis_label": "context produced no matches",
+            "value_type": "continuous",
             "values": [],
             "context_size": 0,
             "slice_type": slice_type,
@@ -285,6 +287,7 @@ def get_correlation():
             "dataset_id": dataset_id,
             "dataset_label": dataset_label,
             "axis_label": axis_label,
+            "value_type": "continuous",
             "values": values,
             "slice_type": slice_type,
         }


### PR DESCRIPTION
This updates Data Explorer and Context Manager to be able to use the Breadbox versions of the Mutation Prioritzed and Mutation Protein Change datasets.