### PR TITLE
Always load Compound Overview if isMobile

### DIFF
--- a/portal-backend/depmap/templates/compounds/index.html
+++ b/portal-backend/depmap/templates/compounds/index.html
@@ -191,6 +191,11 @@ active_tab_set = False %}
       {% endfor %}
     {% endfor %}
   };
+
+  // There are no tabs in mobile, so we need to just always init the Overview tab tiles.
+  if (isMobile) {
+    DepMap.initOverviewTab();
+  }
 </script>
 <script>
    // This is the only place we still use jquery-stickytabs. It should be


### PR DESCRIPTION
Tab-based lazy loading broken the mobile version of the compound overview page.

When viewing from a device that hides the tab, triggering isMobile to be True, we want to just always init the Overview tab.