### PR TITLE
Genetea null terms worflow

### DIFF
--- a/frontend/packages/@depmap/api/src/legacyPortalAPI/resources/experimental_genetea.ts
+++ b/frontend/packages/@depmap/api/src/legacyPortalAPI/resources/experimental_genetea.ts
@@ -170,11 +170,14 @@ export async function fetchGeneTeaEnrichmentExperimental(
         }
       : null;
 
+  // TODO reorganize so this disabling is not necessary!!!
+  /* eslint-disable no-nested-ternary */
   const termClusterTermOrGroup = !plottingPayload.term_cluster
     ? null
     : doGroupTerms
     ? plottingPayload.term_cluster["Term Group"]
     : plottingPayload.term_cluster.Term;
+  /* eslint-enable no-nested-ternary */
 
   const termCluster = !plottingPayload.term_cluster
     ? null

--- a/frontend/packages/@depmap/api/src/legacyPortalAPI/resources/experimental_genetea.ts
+++ b/frontend/packages/@depmap/api/src/legacyPortalAPI/resources/experimental_genetea.ts
@@ -123,88 +123,86 @@ export async function fetchGeneTeaEnrichmentExperimental(
         )
       : await getJson<RawResponse>(`/../../${geneTeaUrl}/`, params);
 
-  // `enriched_terms` can be null when there are no relevant terms. We'll
-  // return a wrapper object to distinguish this from some kind of error.
-  if (body.enriched_terms === null) {
-    return {
-      groupby: "Term",
-      validGenes: [],
-      invalidGenes: [],
-      enrichedTerms: null,
-      totalNEnrichedTerms: 0,
-      totalNTermGroups: 0,
-      termCluster: null,
-      geneCluster: null,
-      termToEntity: null,
-      frequentTerms: null,
-      allEnrichedTerms: null,
-    };
-  }
-
   const plottingPayload = body.plotting_payload;
   const allEt = plottingPayload.all_enriched_terms;
   const et = body.enriched_terms;
-  const enrichedTerms = {
-    term: et.Term,
-    fdr: et.FDR,
-    totalEnrichedTerms: body.total_n_enriched_terms,
-    totalTermGroups: body.total_n_term_groups,
-    synonyms: et.Synonyms.map((list) => list?.split(";") || []),
-    matchingGenesInList: et["Matching Genes in List"],
-    nMatchingGenesInList: et["n Matching Genes in List"],
-    nMatchingGenesOverall: et["n Matching Genes Overall"],
-    termGroup: et["Term Group"],
-    effectSize: et["Effect Size"],
-    pVal: et["p-val"],
-    stopword: et.Stopword,
-    totalInfo: et["Total Info"],
-    negLogFDR: et["-log10 FDR"],
-    clippedTerm: et["Clipped Term"],
-    clippedSynonyms: et["Clipped Synonyms"].map(
-      (list) => list?.split(";") || []
-    ),
-    clippedMatchingGenesInList: et["Clipped Matching Genes in List"],
-  };
-  const allEnrichedTerms = {
-    term: allEt.Term,
-    fdr: allEt.FDR,
-    synonyms: allEt.Synonyms.map((list) => list?.split(";") || []),
-    matchingGenesInList: allEt["Matching Genes in List"],
-    nMatchingGenesInList: allEt["n Matching Genes in List"],
-    nMatchingGenesOverall: allEt["n Matching Genes Overall"],
-    termGroup: allEt["Term Group"],
-    effectSize: allEt["Effect Size"],
-    pVal: allEt["p-val"],
-    stopword: allEt.Stopword,
-    totalInfo: allEt["Total Info"],
-    negLogFDR: allEt["-log10 FDR"],
-  };
 
-  const termClusterTermOrGroup = doGroupTerms
+  const enrichedTerms =
+    et !== null
+      ? {
+          term: et.Term,
+          fdr: et.FDR,
+          totalEnrichedTerms: body.total_n_enriched_terms,
+          totalTermGroups: body.total_n_term_groups,
+          synonyms: et.Synonyms.map((list) => list?.split(";") || []),
+          matchingGenesInList: et["Matching Genes in List"],
+          nMatchingGenesInList: et["n Matching Genes in List"],
+          nMatchingGenesOverall: et["n Matching Genes Overall"],
+          termGroup: et["Term Group"],
+          effectSize: et["Effect Size"],
+          pVal: et["p-val"],
+          stopword: et.Stopword,
+          totalInfo: et["Total Info"],
+          negLogFDR: et["-log10 FDR"],
+          clippedTerm: et["Clipped Term"],
+          clippedSynonyms: et["Clipped Synonyms"].map(
+            (list) => list?.split(";") || []
+          ),
+          clippedMatchingGenesInList: et["Clipped Matching Genes in List"],
+        }
+      : null;
+
+  const allEnrichedTerms =
+    allEt !== null
+      ? {
+          term: allEt.Term,
+          fdr: allEt.FDR,
+          synonyms: allEt.Synonyms.map((list) => list?.split(";") || []),
+          matchingGenesInList: allEt["Matching Genes in List"],
+          nMatchingGenesInList: allEt["n Matching Genes in List"],
+          nMatchingGenesOverall: allEt["n Matching Genes Overall"],
+          termGroup: allEt["Term Group"],
+          effectSize: allEt["Effect Size"],
+          pVal: allEt["p-val"],
+          stopword: allEt.Stopword,
+          totalInfo: allEt["Total Info"],
+          negLogFDR: allEt["-log10 FDR"],
+        }
+      : null;
+
+  const termClusterTermOrGroup = !plottingPayload.term_cluster
+    ? null
+    : doGroupTerms
     ? plottingPayload.term_cluster["Term Group"]
     : plottingPayload.term_cluster.Term;
 
-  const termCluster = {
-    termOrTermGroup: termClusterTermOrGroup as string[],
-    cluster: plottingPayload.term_cluster.Cluster,
-    order: plottingPayload.term_cluster.Order,
-  };
+  const termCluster = !plottingPayload.term_cluster
+    ? null
+    : {
+        termOrTermGroup: termClusterTermOrGroup as string[],
+        cluster: plottingPayload.term_cluster.Cluster,
+        order: plottingPayload.term_cluster.Order,
+      };
 
-  const geneCluster = {
-    gene: plottingPayload.gene_cluster.Gene,
-    cluster: plottingPayload.gene_cluster.Cluster,
-    order: plottingPayload.gene_cluster.Order,
-  };
+  const geneCluster = !plottingPayload.gene_cluster
+    ? null
+    : {
+        gene: plottingPayload.gene_cluster.Gene,
+        cluster: plottingPayload.gene_cluster.Cluster,
+        order: plottingPayload.gene_cluster.Order,
+      };
 
-  const termToEntity = {
-    termOrTermGroup: doGroupTerms
-      ? (plottingPayload.term_to_entity["Term Group"] as string[])
-      : (plottingPayload.term_to_entity.Term as string[]),
-    gene: plottingPayload.term_to_entity.Gene,
-    count: plottingPayload.term_to_entity.Count,
-    nTerms: plottingPayload.term_to_entity["n Terms"],
-    fraction: plottingPayload.term_to_entity.Fraction,
-  };
+  const termToEntity = !plottingPayload.term_to_entity
+    ? null
+    : {
+        termOrTermGroup: doGroupTerms
+          ? (plottingPayload.term_to_entity["Term Group"] as string[])
+          : (plottingPayload.term_to_entity.Term as string[]),
+        gene: plottingPayload.term_to_entity.Gene,
+        count: plottingPayload.term_to_entity.Count,
+        nTerms: plottingPayload.term_to_entity["n Terms"],
+        fraction: plottingPayload.term_to_entity.Fraction,
+      };
 
   const frequentTerms = {
     term: plottingPayload.frequent_terms.Term,

--- a/frontend/packages/@depmap/types/src/experimental_genetea.ts
+++ b/frontend/packages/@depmap/types/src/experimental_genetea.ts
@@ -90,7 +90,7 @@ export interface GeneTeaScatterPlotData {
   allEnriched: {
     data: FrequentTerms;
     customdata: string[];
-  };
+  } | null;
   stopwords: {
     data: FrequentTerms;
     customdata: string[];

--- a/frontend/packages/portal-frontend/src/geneTea/components/AllMatchingTermsTab/AllTermsScatterPlot.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/AllMatchingTermsTab/AllTermsScatterPlot.tsx
@@ -74,63 +74,92 @@ function AllTermsScatterPlot({
           customdata: data.otherTerms.customdata,
         },
         selectedTerms: {
-          indexLabels: data.allEnriched.data.term.filter((term) =>
-            enrichedTermsForInitialSelection.includes(term)
-          ),
-          x: data.allEnriched.data.effectSize.filter((_, index) =>
-            enrichedTermsForInitialSelection.includes(
-              data.allEnriched.data.term[index]
-            )
-          ),
-          y: data.allEnriched.data.negLogFDR.filter((_, index) =>
-            enrichedTermsForInitialSelection.includes(
-              data.allEnriched.data.term[index]
-            )
-          ),
-          matchingGenes: data.allEnriched.data.matchingGenesInList.filter(
-            (_, index) =>
-              enrichedTermsForInitialSelection.includes(
-                data.allEnriched.data.term[index]
-              )
-          ),
-          customdata: data.allEnriched.customdata.filter((_, index) =>
-            enrichedTermsForInitialSelection.includes(
-              data.allEnriched.data.term[index]
-            )
-          ),
+          indexLabels:
+            data.allEnriched === null
+              ? []
+              : data.allEnriched.data.term.filter((term) =>
+                  enrichedTermsForInitialSelection.includes(term)
+                ),
+          x:
+            data.allEnriched === null
+              ? []
+              : data.allEnriched.data.effectSize.filter((_, index) =>
+                  enrichedTermsForInitialSelection.includes(
+                    data.allEnriched!.data.term[index]
+                  )
+                ),
+          y:
+            data.allEnriched === null
+              ? []
+              : data.allEnriched.data.negLogFDR.filter((_, index) =>
+                  enrichedTermsForInitialSelection.includes(
+                    data.allEnriched!.data.term[index]
+                  )
+                ),
+          matchingGenes:
+            data.allEnriched === null
+              ? []
+              : data.allEnriched.data.matchingGenesInList.filter((_, index) =>
+                  enrichedTermsForInitialSelection.includes(
+                    data.allEnriched!.data.term[index]
+                  )
+                ),
+          customdata:
+            data.allEnriched === null
+              ? []
+              : data.allEnriched.customdata.filter((_, index) =>
+                  enrichedTermsForInitialSelection.includes(
+                    data.allEnriched!.data.term[index]
+                  )
+                ),
         },
 
         enrichedTerms: {
-          indexLabels: data.allEnriched.data.term.filter(
-            (_, index) =>
-              !enrichedTermsForInitialSelection.includes(
-                data.allEnriched.data.term[index]
-              )
-          ),
-          x: data.allEnriched.data.effectSize.filter(
-            (_, index) =>
-              !enrichedTermsForInitialSelection.includes(
-                data.allEnriched.data.term[index]
-              )
-          ),
-          y: data.allEnriched.data.negLogFDR.filter(
-            (_, index) =>
-              !enrichedTermsForInitialSelection.includes(
-                data.allEnriched.data.term[index]
-              )
-          ),
-          matchingGenes: data.allEnriched.data.matchingGenesInList.filter(
-            (_, index) =>
-              !enrichedTermsForInitialSelection.includes(
-                data.allEnriched.data.term[index]
-              )
-          ),
-          customdata: data.allEnriched.customdata.filter(
-            (_, index) =>
-              !enrichedTermsForInitialSelection.includes(
-                data.allEnriched.data.term[index]
-              )
-          ),
+          indexLabels:
+            data.allEnriched === null
+              ? []
+              : data.allEnriched.data.term.filter(
+                  (_, index) =>
+                    !enrichedTermsForInitialSelection.includes(
+                      data.allEnriched!.data.term[index]
+                    )
+                ),
+          x:
+            data.allEnriched === null
+              ? []
+              : data.allEnriched.data.effectSize.filter(
+                  (_, index) =>
+                    !enrichedTermsForInitialSelection.includes(
+                      data.allEnriched!.data.term[index]
+                    )
+                ),
+          y:
+            data.allEnriched === null
+              ? []
+              : data.allEnriched.data.negLogFDR.filter(
+                  (_, index) =>
+                    !enrichedTermsForInitialSelection.includes(
+                      data.allEnriched!.data.term[index]
+                    )
+                ),
+          matchingGenes:
+            data.allEnriched === null
+              ? []
+              : data.allEnriched.data.matchingGenesInList.filter(
+                  (_, index) =>
+                    !enrichedTermsForInitialSelection.includes(
+                      data.allEnriched!.data.term[index]
+                    )
+                ),
+          customdata:
+            data.allEnriched === null
+              ? []
+              : data.allEnriched.customdata.filter(
+                  (_, index) =>
+                    !enrichedTermsForInitialSelection.includes(
+                      data.allEnriched!.data.term[index]
+                    )
+                ),
         },
       };
     }
@@ -179,17 +208,19 @@ function AllTermsScatterPlot({
     );
 
     const allEnrichedLookup = buildLookup(
-      data.allEnriched.data.term,
-      data.allEnriched.data.effectSize,
-      data.allEnriched.data.negLogFDR,
-      data.allEnriched.customdata,
-      data.allEnriched.data.matchingGenesInList
+      data.allEnriched === null ? [] : data.allEnriched.data.term,
+      data.allEnriched === null ? [] : data.allEnriched.data.effectSize,
+      data.allEnriched === null ? [] : data.allEnriched.data.negLogFDR,
+      data.allEnriched === null ? [] : data.allEnriched.customdata,
+      data.allEnriched === null ? [] : data.allEnriched.data.matchingGenesInList
     );
 
     // Partition logic: track original group for each term
     const stopwordsSet = new Set(data.stopwords.data.term);
     const otherTermsSet = new Set(data.otherTerms.data.term);
-    const allEnrichedSet = new Set(data.allEnriched.data.term);
+    const allEnrichedSet = new Set(
+      data.allEnriched === null ? [] : data.allEnriched.data.term
+    );
 
     // Helper to build group data
     function buildGroup(
@@ -233,7 +264,7 @@ function AllTermsScatterPlot({
 
     // enrichedTerms: unselected terms that are in allEnriched
     const enrichedTerms = buildGroup(
-      data.allEnriched.data.term,
+      data.allEnriched === null ? [] : data.allEnriched.data.term,
       allEnrichedLookup,
       (t) => !selectedPlotOrTableTerms.has(t)
     );

--- a/frontend/packages/portal-frontend/src/geneTea/components/AllMatchingTermsTab/ScatterPlot.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/AllMatchingTermsTab/ScatterPlot.tsx
@@ -142,23 +142,26 @@ function ScatterPlot({
       },
     };
 
-    const enrichedTermsData: PlotlyData = {
-      type,
-      name: `Enriched Terms n=(${data.enrichedTerms.x.length})`,
-      mode: "markers",
-      x: data.enrichedTerms.x,
-      y: data.enrichedTerms.y as any,
-      customdata: data.enrichedTerms.customdata,
-      hovertemplate: "%{customdata}<extra></extra>",
-      marker: {
-        color: "#00ff2ffc",
-        size: 10,
-        line: {
-          color: "rgba(77, 72, 72, 1)", // Black color for the outline
-          width: 1, // 1px width for the outline
-        },
-      },
-    };
+    const enrichedTermsData: PlotlyData | undefined =
+      data.enrichedTerms === null
+        ? undefined
+        : {
+            type,
+            name: `Enriched Terms n=(${data.enrichedTerms.x.length})`,
+            mode: "markers",
+            x: data.enrichedTerms.x,
+            y: data.enrichedTerms.y as any,
+            customdata: data.enrichedTerms.customdata,
+            hovertemplate: "%{customdata}<extra></extra>",
+            marker: {
+              color: "#00ff2ffc",
+              size: 10,
+              line: {
+                color: "rgba(77, 72, 72, 1)", // Black color for the outline
+                width: 1, // 1px width for the outline
+              },
+            },
+          };
 
     const selectedTermsData: PlotlyData = {
       type,
@@ -182,8 +185,11 @@ function ScatterPlot({
       stopwordsData,
       otherTermsData,
       selectedTermsData,
-      enrichedTermsData,
     ];
+
+    if (enrichedTermsData) {
+      plotlyData.push(enrichedTermsData);
+    }
 
     const layout: Partial<Layout> = {
       height: height === "auto" ? calcPlotHeight(plot) : height,

--- a/frontend/packages/portal-frontend/src/geneTea/components/GeneTea.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/GeneTea.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import GeneTeaMainContent from "./GeneTeaMainContent";
 import { TabsWithHistory } from "src/common/components/tabs/TabsWithHistory";
 import { Tab, TabList, TabPanel, TabPanels } from "src/common/components/tabs";
@@ -12,7 +12,6 @@ import { fetchMetadata } from "../utils";
 import glossary from "src/geneTea/json/glossary.json";
 import Glossary from "src/common/components/Glossary";
 import { GlossaryItem } from "src/common/components/Glossary/types";
-import { useCallback } from "react";
 
 function GeneTea() {
   const [enabledTopTermsTab, setEnableTopTermsTab] = useState<boolean>(true);
@@ -70,7 +69,11 @@ function GeneTea() {
               isLazy
             >
               <TabList className={styles.TabList}>
-                <Tab id="top-tea-terms" className={styles.Tab}>
+                <Tab
+                  id="top-tea-terms"
+                  className={styles.Tab}
+                  disabled={!enabledTopTermsTab}
+                >
                   Top Tea Terms
                 </Tab>
                 <Tab id="all-matching-terms" className={styles.Tab}>

--- a/frontend/packages/portal-frontend/src/geneTea/components/GeneTea.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/GeneTea.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import GeneTeaMainContent from "./GeneTeaMainContent";
 import { TabsWithHistory } from "src/common/components/tabs/TabsWithHistory";
 import { Tab, TabList, TabPanel, TabPanels } from "src/common/components/tabs";
@@ -12,8 +12,11 @@ import { fetchMetadata } from "../utils";
 import glossary from "src/geneTea/json/glossary.json";
 import Glossary from "src/common/components/Glossary";
 import { GlossaryItem } from "src/common/components/Glossary/types";
+import { useCallback } from "react";
 
 function GeneTea() {
+  const [enabledTopTermsTab, setEnableTopTermsTab] = useState<boolean>(true);
+
   const { handleSetAllAvailableGenes } = useGeneTeaFiltersContext();
   useEffect(() => {
     (async () => {
@@ -28,6 +31,10 @@ function GeneTea() {
       handleSetAllAvailableGenes(new Set(Object.values(geneMetadata.label)));
     })();
   }, [handleSetAllAvailableGenes]);
+
+  const handleDisableOrEnableTopTermsTab = useCallback((doEnable: boolean) => {
+    setEnableTopTermsTab(doEnable);
+  }, []);
 
   return (
     <div className={styles.page}>
@@ -72,10 +79,16 @@ function GeneTea() {
               </TabList>
               <TabPanels className={styles.TabPanels}>
                 <TabPanel className={styles.TabPanel}>
-                  <GeneTeaMainContent tab="top-tea-terms" />
+                  <GeneTeaMainContent
+                    tab="top-tea-terms"
+                    handleEnableTopTermsTab={handleDisableOrEnableTopTermsTab}
+                  />
                 </TabPanel>
                 <TabPanel className={styles.TabPanel}>
-                  <GeneTeaMainContent tab="all-matching-terms" />
+                  <GeneTeaMainContent
+                    tab="all-matching-terms"
+                    handleEnableTopTermsTab={handleDisableOrEnableTopTermsTab}
+                  />
                 </TabPanel>
               </TabPanels>
             </TabsWithHistory>

--- a/frontend/packages/portal-frontend/src/geneTea/components/GeneTea.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/GeneTea.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect } from "react";
 import GeneTeaMainContent from "./GeneTeaMainContent";
 import { TabsWithHistory } from "src/common/components/tabs/TabsWithHistory";
 import { Tab, TabList, TabPanel, TabPanels } from "src/common/components/tabs";
@@ -14,8 +14,6 @@ import Glossary from "src/common/components/Glossary";
 import { GlossaryItem } from "src/common/components/Glossary/types";
 
 function GeneTea() {
-  const [enabledTopTermsTab, setEnableTopTermsTab] = useState<boolean>(true);
-
   const { handleSetAllAvailableGenes } = useGeneTeaFiltersContext();
   useEffect(() => {
     (async () => {
@@ -30,10 +28,6 @@ function GeneTea() {
       handleSetAllAvailableGenes(new Set(Object.values(geneMetadata.label)));
     })();
   }, [handleSetAllAvailableGenes]);
-
-  const handleDisableOrEnableTopTermsTab = useCallback((doEnable: boolean) => {
-    setEnableTopTermsTab(doEnable);
-  }, []);
 
   return (
     <div className={styles.page}>
@@ -57,23 +51,9 @@ function GeneTea() {
             <SearchOptionsContainer />
           </div>
           <div className={styles.geneTeaTabsWrapper}>
-            <TabsWithHistory
-              className={styles.Tabs}
-              onChange={() => {
-                /* add something later */
-              }}
-              onSetInitialIndex={() => {
-                /* add something later */
-              }}
-              isManual
-              isLazy
-            >
+            <TabsWithHistory className={styles.Tabs} isManual isLazy>
               <TabList className={styles.TabList}>
-                <Tab
-                  id="top-tea-terms"
-                  className={styles.Tab}
-                  disabled={!enabledTopTermsTab}
-                >
+                <Tab id="top-tea-terms" className={styles.Tab}>
                   Top Tea Terms
                 </Tab>
                 <Tab id="all-matching-terms" className={styles.Tab}>
@@ -82,16 +62,10 @@ function GeneTea() {
               </TabList>
               <TabPanels className={styles.TabPanels}>
                 <TabPanel className={styles.TabPanel}>
-                  <GeneTeaMainContent
-                    tab="top-tea-terms"
-                    handleEnableTopTermsTab={handleDisableOrEnableTopTermsTab}
-                  />
+                  <GeneTeaMainContent tab="top-tea-terms" />
                 </TabPanel>
                 <TabPanel className={styles.TabPanel}>
-                  <GeneTeaMainContent
-                    tab="all-matching-terms"
-                    handleEnableTopTermsTab={handleDisableOrEnableTopTermsTab}
-                  />
+                  <GeneTeaMainContent tab="all-matching-terms" />
                 </TabPanel>
               </TabPanels>
             </TabsWithHistory>

--- a/frontend/packages/portal-frontend/src/geneTea/components/GeneTeaMainContent.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/GeneTeaMainContent.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useCallback } from "react";
+import React, { useMemo, useState, useCallback, useEffect } from "react";
 import { groupStringsByCondition } from "../utils";
 import useData from "../hooks/useData";
 import { useGeneTeaFiltersContext } from "../context/GeneTeaFiltersContext";
@@ -86,15 +86,24 @@ function GeneTeaMainContent({
     handleSetErrorMessage
   );
 
-  const [showNoTermsFoundModal, setShowNoTermsFound] = useState<boolean>(
-    rawData?.enrichedTerms === null
-  );
+  const [showNoTermsFoundModal, setShowNoTermsFound] = useState<boolean>(false);
 
   const handleDisableTopTermsTabAndSelectAllTerms = useCallback(() => {
-    setShowNoTermsFound(false); // Close modal
     setQueryStringWithoutPageReload("tab", "all-matching-terms"); // Force selection of All Terms tab
     handleEnableTopTermsTab(false);
-  }, []);
+  }, [handleEnableTopTermsTab]);
+
+  useEffect(() => {
+    if (rawData?.enrichedTerms === null) {
+      setShowNoTermsFound(true);
+    } else {
+      handleEnableTopTermsTab(true);
+    }
+  }, [
+    rawData?.enrichedTerms,
+    handleEnableTopTermsTab,
+    handleDisableTopTermsTabAndSelectAllTerms,
+  ]);
 
   return (
     <>
@@ -108,13 +117,16 @@ function GeneTeaMainContent({
             heatmapXAxisLabel={heatmapXAxisLabel}
             rawData={rawData}
           />
-          <NullTermsModal
-            geneSymbolList={Array.from(geneSymbolSelections)}
-            show={showNoTermsFoundModal}
-            onClose={handleDisableTopTermsTabAndSelectAllTerms}
-          />
         </>
       )}
+      <NullTermsModal
+        geneSymbolList={Array.from(geneSymbolSelections)}
+        show={showNoTermsFoundModal}
+        onClose={() => {
+          handleDisableTopTermsTabAndSelectAllTerms();
+          setShowNoTermsFound(false);
+        }}
+      />
     </>
   );
 }

--- a/frontend/packages/portal-frontend/src/geneTea/components/GeneTeaMainContent.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/GeneTeaMainContent.tsx
@@ -1,21 +1,15 @@
-import React, { useMemo, useState, useCallback, useEffect } from "react";
+import React, { useMemo } from "react";
 import { groupStringsByCondition } from "../utils";
 import useData from "../hooks/useData";
 import { useGeneTeaFiltersContext } from "../context/GeneTeaFiltersContext";
 import AllMatchingTermsTab from "./AllMatchingTermsTab/AllMatchingTermsTab";
 import TopTermsTab from "./TopTermsTab/TopTermsTab";
-import NullTermsModal from "./NullTermsModal";
-import { setQueryStringWithoutPageReload } from "@depmap/utils";
 
 interface GeneTeaMainContentProps {
   tab: "top-tea-terms" | "all-matching-terms";
-  handleEnableTopTermsTab: (doEnable: boolean) => void;
 }
 
-function GeneTeaMainContent({
-  tab,
-  handleEnableTopTermsTab,
-}: GeneTeaMainContentProps) {
+function GeneTeaMainContent({ tab }: GeneTeaMainContentProps) {
   const {
     geneSymbolSelections,
     doGroupTerms,
@@ -86,47 +80,32 @@ function GeneTeaMainContent({
     handleSetErrorMessage
   );
 
-  const [showNoTermsFoundModal, setShowNoTermsFound] = useState<boolean>(false);
-
-  const handleDisableTopTermsTabAndSelectAllTerms = useCallback(() => {
-    setQueryStringWithoutPageReload("tab", "all-matching-terms"); // Force selection of All Terms tab
-    handleEnableTopTermsTab(false);
-  }, [handleEnableTopTermsTab]);
-
-  useEffect(() => {
-    if (rawData?.enrichedTerms === null) {
-      setShowNoTermsFound(true);
-    } else {
-      handleEnableTopTermsTab(true);
-    }
-  }, [
-    rawData?.enrichedTerms,
-    handleEnableTopTermsTab,
-    handleDisableTopTermsTabAndSelectAllTerms,
-  ]);
-
   return (
     <>
       {tab === "all-matching-terms" ? (
         <AllMatchingTermsTab data={allTermsScatterPlotData} rawData={rawData} />
       ) : (
         <>
-          <TopTermsTab
-            heatmapData={heatmapData}
-            barChartData={barChartData}
-            heatmapXAxisLabel={heatmapXAxisLabel}
-            rawData={rawData}
-          />
+          {rawData?.enrichedTerms === null ? (
+            <div>
+              <h2>No Enriched Terms Found</h2>
+              <h4>
+                {" "}
+                There were no enriched terms found for this gene list:{" "}
+                {Array.from(geneSymbolSelections).join(", ")}. Explore All
+                Matching Terms, or try a new gene list.
+              </h4>
+            </div>
+          ) : (
+            <TopTermsTab
+              heatmapData={heatmapData}
+              barChartData={barChartData}
+              heatmapXAxisLabel={heatmapXAxisLabel}
+              rawData={rawData}
+            />
+          )}
         </>
       )}
-      <NullTermsModal
-        geneSymbolList={Array.from(geneSymbolSelections)}
-        show={showNoTermsFoundModal}
-        onClose={() => {
-          handleDisableTopTermsTabAndSelectAllTerms();
-          setShowNoTermsFound(false);
-        }}
-      />
     </>
   );
 }

--- a/frontend/packages/portal-frontend/src/geneTea/components/NullTermsModal.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/NullTermsModal.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { Button, Modal } from "react-bootstrap";
+import styles from "../styles/GeneTea.scss";
+import renderConditionally from "@depmap/data-explorer-2/src/utils/render-conditionally";
+
+interface Props {
+  geneSymbolList: string[];
+  show: boolean;
+  onClose: () => void;
+}
+
+function NullTermsModal({ onClose, show, geneSymbolList }: Props) {
+  console.log(geneSymbolList);
+  return (
+    <Modal show={show} bsSize="large" onHide={onClose}>
+      <Modal.Header closeButton>
+        <Modal.Title>No Enriched Terms Found</Modal.Title>
+      </Modal.Header>
+      <Modal.Body className={styles.GeneTeaModal} />
+      <Modal.Footer>
+        <Button onClick={onClose}>Close</Button>
+      </Modal.Footer>
+    </Modal>
+  );
+}
+
+export default renderConditionally(NullTermsModal);

--- a/frontend/packages/portal-frontend/src/geneTea/components/NullTermsModal.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/NullTermsModal.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Button, Modal } from "react-bootstrap";
 import styles from "../styles/GeneTea.scss";
-import renderConditionally from "@depmap/data-explorer-2/src/utils/render-conditionally";
 
 interface Props {
   geneSymbolList: string[];
@@ -10,13 +9,16 @@ interface Props {
 }
 
 function NullTermsModal({ onClose, show, geneSymbolList }: Props) {
-  console.log(geneSymbolList);
   return (
-    <Modal show={show} bsSize="large" onHide={onClose}>
+    <Modal show={show} bsSize="small" onHide={onClose}>
       <Modal.Header closeButton>
         <Modal.Title>No Enriched Terms Found</Modal.Title>
       </Modal.Header>
-      <Modal.Body className={styles.GeneTeaModal} />
+      <Modal.Body className={styles.GeneTeaModal} height={"50px"}>
+        There were no enriched terms found for this gene list:{" "}
+        {geneSymbolList.join(", ")}. Explore All Matching Terms, or try a new
+        gene list.
+      </Modal.Body>
       <Modal.Footer>
         <Button onClick={onClose}>Close</Button>
       </Modal.Footer>
@@ -24,4 +26,4 @@ function NullTermsModal({ onClose, show, geneSymbolList }: Props) {
   );
 }
 
-export default renderConditionally(NullTermsModal);
+export default NullTermsModal;

--- a/frontend/packages/portal-frontend/src/geneTea/hooks/useData.ts
+++ b/frontend/packages/portal-frontend/src/geneTea/hooks/useData.ts
@@ -425,9 +425,9 @@ function useData(
   }, [data]);
 
   const allTermsScatterPlotData = useMemo(() => {
-    if (data?.frequentTerms && data?.allEnrichedTerms) {
+    if (data?.frequentTerms) {
       const freqTerms = data.frequentTerms;
-      const allTerms = data.allEnrichedTerms;
+      const allTerms = data.allEnrichedTerms || null;
 
       const allEnriched = filterFrequentTerms(
         freqTerms,
@@ -448,7 +448,7 @@ function useData(
           const freqTermsIndex = freqTerms.term.indexOf(currentTerm);
           const term = currentTerm;
           const termGroup =
-            freqTermsIndex < allTerms.termGroup.length
+            allTerms !== null && freqTermsIndex < allTerms.termGroup.length
               ? allTerms.termGroup[freqTermsIndex]
               : null;
 

--- a/frontend/packages/portal-frontend/src/geneTea/styles/GeneTea.scss
+++ b/frontend/packages/portal-frontend/src/geneTea/styles/GeneTea.scss
@@ -71,3 +71,9 @@
     color: #fff;
   }
 }
+
+.GeneTeaModal {
+  @media screen and (min-height: 510px) {
+    height: 100px;
+  }
+}


### PR DESCRIPTION
Allow "All Matching Terms" to load if enriched_terms is null. Display a message on the Top Terms Tab directing the user to the All Matching Terms tab.

Eventually, per the spec, this will be updated to display a message in a modal, followed by forcibly switching the selected tab to "All Matching Terms".

Due to time constraints, and TabsWithHistory's design as an uncontrolled component, I implemented this simpler alternative.