### PR TITLE
Gene tea UI stale state fix

### DIFF
--- a/frontend/packages/portal-frontend/src/geneTea/components/MultiSelectTextArea.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/MultiSelectTextArea.tsx
@@ -122,6 +122,7 @@ const MultiSelectTextarea: React.FC = () => {
                 {chip}
                 <button
                   type="button"
+                  disabled={isLoading}
                   className={styles.chipRemoveButton}
                   onClick={() => handleRemoveChip(chip)}
                 >

--- a/frontend/packages/portal-frontend/src/geneTea/components/MultiSelectTextArea.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/MultiSelectTextArea.tsx
@@ -29,6 +29,7 @@ const MultiSelectTextarea: React.FC = () => {
     handleSetError,
     error,
     errorMessage,
+    isLoading,
   } = useGeneTeaFiltersContext();
 
   const [inputValue, setInputValue] = useState("");
@@ -189,7 +190,10 @@ const MultiSelectTextarea: React.FC = () => {
         </Button>
         <Button
           className={styles.clearInputButton}
-          disabled={inputValue.length === 0 && geneSymbolSelections.size === 0}
+          disabled={
+            (inputValue.length === 0 && geneSymbolSelections.size === 0) ||
+            isLoading
+          }
           onClick={() => {
             handleSetGeneSymbolSelections(() => new Set());
             handleSetValidGeneSymbols(new Set());


### PR DESCRIPTION
Deleting gene symbol chips rapidly resulted in a partial update to the graph's state. Solution: Disable the "Clear" button and each individual chip's "X" button if isLoading.