### PR TITLE
feat(breadbox)!: Added support for hdf5 uploads to breadbox

### DIFF
--- a/breadbox-client/breadbox_facade/client.py
+++ b/breadbox-client/breadbox_facade/client.py
@@ -367,20 +367,17 @@ class BBClient:
         if data_file_name is not None:
             assert data_file_format is not None, "If data_filename is specified, then also specify data_file_format"
             assert data_df is None, "Cannot have both data_filename and data_df not None"
-        else:
-            assert data_df is not None, "If data_filename is not specified, data_df must be"
-            assert data_file_format is None, "if data_filename is not specified, data_file_format must also be provided"
-
-        if data_file_name is not None:
             # okay, we're uploading a file
             with open(data_file_name, "rb") as f:
                 uploaded_file = self.upload_file(f)
         else:
+            assert data_df is not None, "If data_filename is not specified, data_df must be"
+            assert data_file_format is None, "if data_filename is not specified, data_file_format must also be provided"
             log_status("Writing CSV")
             buffer = io.BytesIO(data_df.to_csv(index=False).encode("utf8"))
             log_status(f"Uploading CSV")
             uploaded_file = self.upload_file(file_handle=buffer)
-            data_file_format=MatrixDatasetParamsDataFileFormat.CSV
+            data_file_format="csv"
 
         params = MatrixDatasetParams(
             name=name,
@@ -399,7 +396,9 @@ class BBClient:
             priority=priority if priority else UNSET,
             taiga_id=taiga_id if taiga_id else UNSET,
             given_id=given_id if given_id else UNSET,
-            data_file_format={"csv": MatrixDatasetParamsDataFileFormat.CSV, "parquet": MatrixDatasetParamsDataFileFormat.PARQUET, "hdf5": MatrixDatasetParamsDataFileFormat.HDF5}[data_file_format],
+            data_file_format=({"csv": MatrixDatasetParamsDataFileFormat.CSV, 
+            "parquet": MatrixDatasetParamsDataFileFormat.PARQUET, 
+            "hdf5": MatrixDatasetParamsDataFileFormat.HDF5}[str(data_file_format)]),
             description=description
         )
         log_status(f"calling add_dataset_uploads_client.sync_detailed")

--- a/breadbox-client/breadbox_facade/client.py
+++ b/breadbox-client/breadbox_facade/client.py
@@ -343,9 +343,12 @@ class BBClient:
         name: str,
         units: str,
         data_type: str,
-        data_df: Optional[pd.DataFrame],
         feature_type: Optional[str],
         sample_type: str,
+        *,
+        data_df: Optional[pd.DataFrame] = None,
+        data_file_name : Optional[str] = None,
+        data_file_format: Optional[Literal["parquet", "csv", "hdf5"]]=None,
         is_transient: bool = False,
         group_id: str = PUBLIC_GROUP_ID,
         value_type: str = ValueType.CONTINUOUS.value,
@@ -354,35 +357,25 @@ class BBClient:
         taiga_id: Optional[str] = None,
         given_id: Optional[str] = None,
         dataset_metadata: Optional[dict] = None,
-        upload_parquet=False,
         timeout=None,
         log_status=lambda msg: None,
-            description:Optional[str] = None,
-            data_parquet : Optional[str] = None,
-    ) -> dict[str, Any]:
+        description:Optional[str] = None,
+    ) -> AddDatasetResponse:
         log_status(f"add_matrix_dataset start")
         metadata = MatrixDatasetParamsDatasetMetadataType0.from_dict(dataset_metadata) if dataset_metadata else None
 
-        if data_parquet is not None:
-            assert data_df is None, "Cannot have both data_parquet and data_df not None"
-            upload_parquet = True
-
-        if upload_parquet:
-            if data_parquet is None:
-                assert data_df is not None
-                with tempfile.NamedTemporaryFile() as tmp:
-                    log_status(f"writing parquet")
-                    data_df.to_parquet(tmp.name, index=False)
-                    log_status(f"uploading parquet")
-                    uploaded_file = self.upload_file(tmp)
-            else:
-                log_status(f"uploading parquet")
-                with open(data_parquet, "rb") as f:
-                    uploaded_file = self.upload_file(f)
-
-            data_file_format=MatrixDatasetParamsDataFileFormat.PARQUET
+        if data_file_name is not None:
+            assert data_file_format is not None, "If data_filename is specified, then also specify data_file_format"
+            assert data_df is None, "Cannot have both data_filename and data_df not None"
         else:
-            assert data_df is not None, "If not using parquet, you must provide a dataframe"
+            assert data_df is not None, "If data_filename is not specified, data_df must be"
+            assert data_file_format is None, "if data_filename is not specified, data_file_format must also be provided"
+
+        if data_file_name is not None:
+            # okay, we're uploading a file
+            with open(data_file_name, "rb") as f:
+                uploaded_file = self.upload_file(f)
+        else:
             log_status("Writing CSV")
             buffer = io.BytesIO(data_df.to_csv(index=False).encode("utf8"))
             log_status(f"Uploading CSV")
@@ -406,7 +399,7 @@ class BBClient:
             priority=priority if priority else UNSET,
             taiga_id=taiga_id if taiga_id else UNSET,
             given_id=given_id if given_id else UNSET,
-            data_file_format=data_file_format,
+            data_file_format={"csv": MatrixDatasetParamsDataFileFormat.CSV, "parquet": MatrixDatasetParamsDataFileFormat.PARQUET, "hdf5": MatrixDatasetParamsDataFileFormat.HDF5}[data_file_format],
             description=description
         )
         log_status(f"calling add_dataset_uploads_client.sync_detailed")
@@ -419,6 +412,7 @@ class BBClient:
         result = self.await_task_result(breadbox_response_.id, timeout=timeout)
         log_status(f"task completed")
         return result
+
 
     def update_dataset(
         self,

--- a/breadbox-client/tests/breadbox_facade/test_client.py
+++ b/breadbox-client/tests/breadbox_facade/test_client.py
@@ -111,4 +111,5 @@ def test_add_dataset_with_dataset_metadata():
 
     response = client.get_dataset(dataset_id)
     assert response.id == dataset_id
+    assert response.dataset_metadata is not None
     assert response.dataset_metadata.to_dict() == {"some": "value"}

--- a/breadbox/breadbox/compute/celery.py
+++ b/breadbox/breadbox/compute/celery.py
@@ -1,4 +1,5 @@
-from celery import Celery, Task
+import psutil
+from celery import Celery, Task, signals
 import os
 from logging import getLogger
 from fastapi import HTTPException
@@ -49,6 +50,37 @@ app = Celery(
 # Add prefix to celery so Breadbox celery tasks triggered by the portal use the correct celery
 # worker. Solution found at https://stackoverflow.com/a/71704583
 app.conf.broker_transport_options = {"global_keyprefix": "breadbox"}
+
+
+def _get_rss():
+    process = psutil.Process(os.getpid())
+    return process.memory_info().rss
+
+
+@signals.task_prerun.connect
+def task_prerun_handler(
+    sender=None, task_id=None, task=None, args=None, kwargs=None, **extras
+):
+    print(
+        f"[BEFORE] Running task {sender.name} rss:{_get_rss()} ({task_id}) with args={args}, kwargs={kwargs}"
+    )
+
+
+@signals.task_postrun.connect
+def task_postrun_handler(
+    sender=None,
+    task_id=None,
+    task=None,
+    args=None,
+    kwargs=None,
+    retval=None,
+    state=None,
+    **extras,
+):
+    print(
+        f"[AFTER] Finished task {sender.name} rss:{_get_rss()} ({task_id}) with result={retval}, state={state}"
+    )
+
 
 if __name__ == "__main__":
     app.start()

--- a/breadbox/breadbox/compute/celery.py
+++ b/breadbox/breadbox/compute/celery.py
@@ -57,29 +57,31 @@ def _get_rss():
     return process.memory_info().rss
 
 
-@signals.task_prerun.connect
-def task_prerun_handler(
-    sender=None, task_id=None, task=None, args=None, kwargs=None, **extras
-):
-    print(
-        f"[BEFORE] Running task {sender.name} rss:{_get_rss()} ({task_id}) with args={args}, kwargs={kwargs}"
-    )
-
-
-@signals.task_postrun.connect
-def task_postrun_handler(
-    sender=None,
-    task_id=None,
-    task=None,
-    args=None,
-    kwargs=None,
-    retval=None,
-    state=None,
-    **extras,
-):
-    print(
-        f"[AFTER] Finished task {sender.name} rss:{_get_rss()} ({task_id}) with result={retval}, state={state}"
-    )
+# from typing import Optional, Any, Dict
+#
+# @signals.task_prerun.connect
+# def task_prerun_handler(
+#    sender:Optional[Any] =None, task_id : Optional[str] =None, task : Optional[Task]=None, args:Optional[Any]=None, kwargs:Optional[Dict[str, Any]]=None, **extras
+# ):
+#    print(
+#        f"[BEFORE] Running task {sender.name} rss:{_get_rss()} ({task_id}) with args={args}, kwargs={kwargs}"
+#    )
+#
+#
+# @signals.task_postrun.connect
+# def task_postrun_handler(
+#    sender:Optional[Any]=None,
+#    task_id : Optional[str]=None,
+#    task: Optional[Task]=None,
+#    args:Optional[Any] = None,
+#    kwargs:Optional[Dict[str, Any]] =None,
+#    retval:Any = None,
+#    state : Any=None,
+#    **extras,
+# ):
+#    print(
+#        f"[AFTER] Finished task {sender.name} rss:{_get_rss()} ({task_id}) with result={retval}, state={state}"
+#    )
 
 
 if __name__ == "__main__":

--- a/breadbox/breadbox/io/data_validation.py
+++ b/breadbox/breadbox/io/data_validation.py
@@ -563,7 +563,8 @@ def read_and_validate_matrix_df(
 
     if data_file_format == "parquet":
         df_wrapper = _read_parquet(file_path)
-
+    elif data_file_format == "hdf5":
+        df_wrapper = _read_hdf5(file_path)
     elif data_file_format == "csv":
         with open(file_path, "rb") as fd:
             df_wrapper = _read_csv(fd, value_type)

--- a/breadbox/breadbox/io/hdf5_utils.py
+++ b/breadbox/breadbox/io/hdf5_utils.py
@@ -55,7 +55,7 @@ def write_hdf5_file(
                     ),  # Arbitrarily set size since it at least appears to yield smaller storage size than autochunking
                 )
                 # only insert nonnull values into hdf5 at given positions
-                for row_idx, col_idx in df_wrapper.nonnull_indices:
+                for row_idx, col_idx in df_wrapper.get_nonnull_indices():
                     dataset[row_idx, col_idx] = df.iloc[row_idx, col_idx]
             else:
                 if dtype == "str":

--- a/breadbox/breadbox/io/hdf5_utils.py
+++ b/breadbox/breadbox/io/hdf5_utils.py
@@ -4,7 +4,6 @@ from breadbox.schemas.custom_http_exception import (
     FileValidationError,
     LargeDatasetReadError,
 )
-from breadbox.schemas.dataframe_wrapper import ParquetDataFrameWrapper
 import h5py
 import numpy as np
 import pandas as pd
@@ -70,8 +69,6 @@ def write_hdf5_file(
                     data=df.values,
                 )
         else:
-            assert isinstance(df_wrapper, ParquetDataFrameWrapper)
-            # For ParquetDataFrameWrapper
             # NOTE: Our number of columns are usually much larger than rows so we batch by columns to avoid memory issues
             # TODO: If hdf5 file size becomes an issue, we can consider using compression or chunking
             cols = df_wrapper.get_column_names()

--- a/breadbox/breadbox/schemas/dataframe_wrapper.py
+++ b/breadbox/breadbox/schemas/dataframe_wrapper.py
@@ -1,12 +1,22 @@
-from typing import Protocol, List
+from typing import Protocol, List, Optional, Any
+
+import h5py
 import pandas as pd
 from pandas.api.types import is_numeric_dtype
 import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
+import pyarrow
+
+from breadbox.schemas.custom_http_exception import FileValidationError
+
+# fetching more than this number of columns at one time will result in an exception being thrown
+MAX_COLUMNS_FETCHED = 10000
 
 
 class DataFrameWrapper(Protocol):
+    """Used to encapsulate a dataframe without necessarily reading the entire thing into memory"""
+
     def get_index_names(self) -> List[str]:
         ...
 
@@ -26,11 +36,93 @@ class DataFrameWrapper(Protocol):
         ...
 
 
-class ParquetDataFrameWrapper:
+class HDF5DataFrameWrapper(DataFrameWrapper):
+    def __init__(self, filename: str):
+        self.filename = filename
+        self.file = h5py.File(filename, "r")
+        # cached mapping from name to index
+        self.dim_0 = None
+        self.dim_1 = None
+        self.dim_0_to_index = None
+        self.dim_1_to_index = None
+
+    def close(self):
+        self.file.close()
+
+    def get_index_names(self) -> List[str]:
+        if self.dim_0 is None:
+            self.dim_0 = [x.decode("utf8") for x in self.file["dim_0"]]
+        return self.dim_0
+
+    def get_column_names(self) -> List[str]:
+        if self.dim_1 is None:
+            self.dim_1 = [x.decode("utf8") for x in self.file["dim_1"]]
+        return self.dim_1
+
+    def _get_column_names_to_index(self):
+        if self.dim_1_to_index is None:
+            mapping = {
+                name: index for index, name in enumerate(self.get_column_names())
+            }
+            self.dim_1_to_index = mapping
+        return self.dim_1_to_index
+
+    def read_columns(self, columns: list[str]) -> pd.DataFrame:
+        # columns can be from [index] + dim_1, so we need to special case handling of "index"
+
+        mapping = self._get_column_names_to_index()
+        column_src_index_with_dest_index = [
+            (
+                # source index
+                mapping[name],
+                # dest index
+                dest_index,
+                # column name
+                name,
+            )
+            for dest_index, name in enumerate(columns)
+        ]
+
+        # read the columns from the hdf5 file
+        matrix = self.file["data"][
+            :, [src_index for src_index, _, _ in column_src_index_with_dest_index]
+        ]
+
+        # now copy them into a map that we'll use to construct the dataframe
+        df_columns = {}
+        for _, matrix_index, column_name in column_src_index_with_dest_index:
+            df_columns[column_name] = matrix[:, matrix_index]
+
+        return pd.DataFrame(df_columns, columns=columns, index=self.get_index_names())
+
+    def is_sparse(self) -> bool:
+        # For now, we bypass checking sparsity for hdf5 files to keep things simple
+        return False
+
+    def get_df(self) -> pd.DataFrame:
+        if len(self.get_column_names()) > MAX_COLUMNS_FETCHED:
+            raise Exception(
+                "HDF5 file has too many columns to read into memory at once."
+            )
+        return self.read_columns(self.get_column_names())
+
+    def is_numeric_cols(self) -> bool:
+        # assuming all hdf5 files are numeric
+        return True
+
+
+class ParquetDataFrameWrapper(DataFrameWrapper):
     def __init__(self, parquet_path: str):
         self.parquet_path = parquet_path
         self.file = pq.ParquetFile(parquet_path)
         self.schema = self.file.schema_arrow
+
+        # the first column will be treated as the index. Make sure it's of type string
+        index_col = self.schema.names[0]
+        if not pyarrow.types.is_string(self.schema.field(index_col).type):
+            raise FileValidationError(
+                f"Make sure the first column in the parquet file is the index and is of type string."
+            )
 
     def get_index_names(self) -> List[str]:
         index_col = self.schema.names[0]
@@ -52,7 +144,7 @@ class ParquetDataFrameWrapper:
         return False
 
     def get_df(self) -> pd.DataFrame:
-        if len(self.get_column_names()) > 10000:
+        if len(self.get_column_names()) > MAX_COLUMNS_FETCHED:
             raise Exception(
                 "Parquet file has too many columns to read into memory at once."
             )
@@ -76,9 +168,7 @@ class ParquetDataFrameWrapper:
 class PandasDataFrameWrapper:
     def __init__(self, df: pd.DataFrame):
         self.df = df
-        # Get the row,col positions where df values are not null
-        rows_idx, cols_idx = np.where(df.notnull())
-        self.nonnull_indices = list(zip(rows_idx, cols_idx))
+        self.nonnull_indices = None
 
     def get_index_names(self) -> List[str]:
         return self.df.index.to_list()
@@ -89,8 +179,15 @@ class PandasDataFrameWrapper:
     def read_columns(self, columns: list[str]) -> pd.DataFrame:
         return self.df.loc[:, columns]
 
+    def get_nonnull_indices(self):
+        if self.nonnull_indices is None:
+            # Get the row,col positions where df values are not null
+            rows_idx, cols_idx = np.where(self.df.notnull())
+            self.nonnull_indices = list(zip(rows_idx, cols_idx))
+        return self.nonnull_indices
+
     def is_sparse(self) -> bool:
-        total_nulls = self.df.size - len(self.nonnull_indices)
+        total_nulls = self.df.size - len(self.get_nonnull_indices())
         # Determine whether matrix is considered sparse (~2/3 elements are null). Use chunked storage for sparse matrices for more optimal storage
         is_sparse = total_nulls / self.df.size > 0.6
         return is_sparse

--- a/breadbox/breadbox/schemas/dataframe_wrapper.py
+++ b/breadbox/breadbox/schemas/dataframe_wrapper.py
@@ -51,12 +51,16 @@ class HDF5DataFrameWrapper(DataFrameWrapper):
 
     def get_index_names(self) -> List[str]:
         if self.dim_0 is None:
-            self.dim_0 = [x.decode("utf8") for x in self.file["dim_0"]]
+            self.dim_0 = [
+                x.decode("utf8") for x in self.file["dim_0"]
+            ]  # pyright: ignore
         return self.dim_0
 
     def get_column_names(self) -> List[str]:
         if self.dim_1 is None:
-            self.dim_1 = [x.decode("utf8") for x in self.file["dim_1"]]
+            self.dim_1 = [
+                x.decode("utf8") for x in self.file["dim_1"]
+            ]  # pyright: ignore
         return self.dim_1
 
     def _get_column_names_to_index(self):
@@ -86,14 +90,16 @@ class HDF5DataFrameWrapper(DataFrameWrapper):
         # read the columns from the hdf5 file
         matrix = self.file["data"][
             :, [src_index for src_index, _, _ in column_src_index_with_dest_index]
-        ]
+        ]  # pyright: ignore
 
         # now copy them into a map that we'll use to construct the dataframe
         df_columns = {}
         for _, matrix_index, column_name in column_src_index_with_dest_index:
-            df_columns[column_name] = matrix[:, matrix_index]
+            df_columns[column_name] = matrix[:, matrix_index]  # pyright: ignore
 
-        return pd.DataFrame(df_columns, columns=columns, index=self.get_index_names())
+        return pd.DataFrame(
+            df_columns, columns=columns, index=self.get_index_names()
+        )  # pyright: ignore
 
     def is_sparse(self) -> bool:
         # For now, we bypass checking sparsity for hdf5 files to keep things simple

--- a/breadbox/breadbox/schemas/dataset.py
+++ b/breadbox/breadbox/schemas/dataset.py
@@ -11,7 +11,6 @@ from .group import Group
 import enum
 
 
-
 # NOTE: Using multivalue Literals seems to be creating errors in pydantic models and fastapi request params.
 # It is possible that for our version of pydantic, the schema for Literals is messed up
 # (see: https://github.com/tiangolo/fastapi/issues/562).
@@ -147,9 +146,9 @@ class MatrixDatasetParams(SharedDatasetParams):
     ] = None
 
     data_file_format: Annotated[
-        Literal["csv", "parquet"],
+        Literal["csv", "parquet", "hdf5"],
         Field(
-            description="The format of the uploaded data file. May either be 'csv' or 'parquet'"
+            description="The format of the uploaded data file. May either be 'csv', 'parquet' or 'hdf5'.",
         ),
     ] = "csv"
 

--- a/breadbox/poetry.lock
+++ b/breadbox/poetry.lock
@@ -2309,6 +2309,28 @@ files = [
 ]
 
 [[package]]
+name = "psutil"
+version = "7.1.0"
+description = "Cross-platform lib for process and system monitoring."
+optional = false
+python-versions = ">=3.6"
+files = [
+    {file = "psutil-7.1.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:76168cef4397494250e9f4e73eb3752b146de1dd950040b29186d0cce1d5ca13"},
+    {file = "psutil-7.1.0-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:5d007560c8c372efdff9e4579c2846d71de737e4605f611437255e81efcca2c5"},
+    {file = "psutil-7.1.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:22e4454970b32472ce7deaa45d045b34d3648ce478e26a04c7e858a0a6e75ff3"},
+    {file = "psutil-7.1.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c70e113920d51e89f212dd7be06219a9b88014e63a4cec69b684c327bc474e3"},
+    {file = "psutil-7.1.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7d4a113425c037300de3ac8b331637293da9be9713855c4fc9d2d97436d7259d"},
+    {file = "psutil-7.1.0-cp37-abi3-win32.whl", hash = "sha256:09ad740870c8d219ed8daae0ad3b726d3bf9a028a198e7f3080f6a1888b99bca"},
+    {file = "psutil-7.1.0-cp37-abi3-win_amd64.whl", hash = "sha256:57f5e987c36d3146c0dd2528cd42151cf96cd359b9d67cfff836995cc5df9a3d"},
+    {file = "psutil-7.1.0-cp37-abi3-win_arm64.whl", hash = "sha256:6937cb68133e7c97b6cc9649a570c9a18ba0efebed46d8c5dae4c07fa1b67a07"},
+    {file = "psutil-7.1.0.tar.gz", hash = "sha256:655708b3c069387c8b77b072fc429a57d0e214221d01c0a772df7dfedcb3bcd2"},
+]
+
+[package.extras]
+dev = ["abi3audit", "black", "check-manifest", "coverage", "packaging", "pylint", "pyperf", "pypinfo", "pyreadline", "pytest", "pytest-cov", "pytest-instafail", "pytest-subtests", "pytest-xdist", "pywin32", "requests", "rstcheck", "ruff", "setuptools", "sphinx", "sphinx_rtd_theme", "toml-sort", "twine", "virtualenv", "vulture", "wheel", "wheel", "wmi"]
+test = ["pytest", "pytest-instafail", "pytest-subtests", "pytest-xdist", "pywin32", "setuptools", "wheel", "wmi"]
+
+[[package]]
 name = "pyarrow"
 version = "20.0.0"
 description = "Python library for Apache Arrow"
@@ -3474,4 +3496,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "932286dc71c4bc9130bf17ba8a46e2e6609bf308bcf51210e03e8765587ad97d"
+content-hash = "c945346d0880314ea4c725794d31450ba6698cd1fb90d82ccdc2903c12fe6d80"

--- a/breadbox/pyproject.toml
+++ b/breadbox/pyproject.toml
@@ -37,6 +37,7 @@ packed-cor-tables = {version = "^0.2.0", source = "public-python"}
 orjson = "^3.10.16"
 pypatch-and-run = {version = "^0.3.1", source = "public-python"}
 python-multipart = "^0.0.20" # fastapi 0.115.12 needs this
+psutil = "^7.1.0"
 
 [tool.poetry.group.dev.dependencies]
 pyright-ratchet = {git = "https://github.com/pgm/pyright-ratchet.git", rev = "v0.3.1"}

--- a/breadbox/tests/io/test_hdf5_utils.py
+++ b/breadbox/tests/io/test_hdf5_utils.py
@@ -4,15 +4,18 @@ import pandas as pd
 from breadbox.schemas.dataframe_wrapper import (
     ParquetDataFrameWrapper,
     PandasDataFrameWrapper,
+    HDF5DataFrameWrapper,
 )
 from breadbox.schemas.custom_http_exception import LargeDatasetReadError
 from breadbox.io.hdf5_utils import write_hdf5_file, read_hdf5_file
 import pytest
 import h5py
 
+TEST_COLUMN_COUNT = 20
+
 
 @pytest.fixture
-def test_dataframe(row_length: int = 500, col_length: int = 11000):
+def test_dataframe(row_length: int = 500, col_length: int = TEST_COLUMN_COUNT):
     cols = [f"Col-{i}" for i in range(col_length)]
     rows = [f"Row-{i}" for i in range(row_length)]
     data = np.round(np.random.uniform(0.0, 10.0, size=(row_length, col_length)), 6)
@@ -22,23 +25,54 @@ def test_dataframe(row_length: int = 500, col_length: int = 11000):
 
 @pytest.fixture
 def test_parquet_file(tmpdir, test_dataframe):
-    # NOTE: the client reads in a dataframe with index as a column, so reset the index
-    test_dataframe.reset_index(inplace=True)
     path = tmpdir.join("test.parquet")
-    test_dataframe.to_parquet(path, index=False)
+    test_dataframe.reset_index().to_parquet(path, index=False)
     return str(path)
 
 
-def test_parquet_wrapper(tmpdir, test_dataframe, test_parquet_file):
+def _write_hdf5_file(filename, df):
+    # assuming index is in the first column
+    with h5py.File(filename, "w") as f:
+        f["data"] = df.values
+        f["dim_0"] = [x.encode("utf-8") for x in df.index]
+        f["dim_1"] = [x.encode("utf-8") for x in df.columns]
+
+
+def test_hdf5_wrapper(tmpdir, test_dataframe):
+    hdf5_file = str(tmpdir.join("test.hdf5"))
+
+    src_dfw = PandasDataFrameWrapper(test_dataframe)
+    _write_hdf5_file(hdf5_file, test_dataframe)
+
+    # now verify hdf5 wrapper matches the source
+    hdf5w = HDF5DataFrameWrapper(hdf5_file)
+
+    assert src_dfw.get_index_names() == hdf5w.get_index_names()
+    assert src_dfw.get_column_names() == hdf5w.get_column_names()
+    for column_name in src_dfw.get_column_names():
+        pd.testing.assert_frame_equal(
+            src_dfw.read_columns([column_name]), hdf5w.read_columns([column_name])
+        )
+
+
+def test_parquet_wrapper(tmpdir, test_dataframe, test_parquet_file, monkeypatch):
+    import breadbox.schemas.dataframe_wrapper
+
     parquet_wrapper = ParquetDataFrameWrapper(parquet_path=test_parquet_file)
-    assert parquet_wrapper.get_index_names() == test_dataframe["index"].to_list()
-    assert parquet_wrapper.get_column_names() == test_dataframe.columns[1:].to_list()
+    assert parquet_wrapper.get_index_names() == test_dataframe.index.to_list()
+    assert parquet_wrapper.get_column_names() == test_dataframe.columns.to_list()
     assert parquet_wrapper.read_columns(["Col-0", "Col-1"]).shape == (
         len(test_dataframe),
         2,
     )
     assert parquet_wrapper.is_sparse() == False
     assert parquet_wrapper.is_numeric_cols() == True
+
+    # this should work fine
+    parquet_wrapper.get_df()
+
+    # but if we lower max columns fetched we should get an exception
+    monkeypatch.setattr(breadbox.schemas.dataframe_wrapper, "MAX_COLUMNS_FETCHED", 5)
     with pytest.raises(Exception):
         parquet_wrapper.get_df()
 
@@ -68,9 +102,9 @@ def test_write_parquet_to_hdf5(tmpdir, test_dataframe, test_parquet_file):
     # Verify output
     with h5py.File(output_h5, "r") as f:
         data = f["data"][:]
-        assert data.shape == (500, 11000)
+        assert data.shape == (500, TEST_COLUMN_COUNT)
         # Check if the first column matches the first column of the original dataframe
-        assert (data[:, 0] == test_dataframe.iloc[:, 1]).all()
+        assert (data[:, 0] == test_dataframe.iloc[:, 0]).all()
         indices: h5py.Dataset = f["samples"][:]
         expected_indices = wrapper.get_index_names()
         assert indices[0].decode("utf-8") == expected_indices[0]
@@ -91,7 +125,6 @@ def test_write_parquet_nulls_to_hdf5(tmpdir):
 
     # Create DataFrame
     test_df = pd.DataFrame(data, columns=cols, index=rows).convert_dtypes()
-
     test_df.reset_index(inplace=True)
 
     path = tmpdir.join("test.parquet")


### PR DESCRIPTION
Incrementally loading Parquet has resulted in large memory utilization due to some inherit assumptions built into parquet and pyarrow's parsing of them. However, HDF5 files don't have these problems, so moving to upload numerical matrices as HDF5 files which can be incrementally read efficiently.