### PR TITLE
Bug: Custom analysis run on uploaded dataset not working

### DIFF
--- a/frontend/packages/@depmap/api/package.json
+++ b/frontend/packages/@depmap/api/package.json
@@ -14,7 +14,8 @@
     "@depmap/types": "1.0.0",
     "@depmap/user-upload": "1.0.0",
     "papaparse": "^4.6.0",
-    "qs": "^6.14.0"
+    "qs": "^6.14.0",
+    "spark-md5": "^3.0.2"
   },
   "devDependencies": {
     "@types/papaparse": "^4.5.2"

--- a/frontend/packages/@depmap/api/src/breadboxAPI/resources/dataset_v2.ts
+++ b/frontend/packages/@depmap/api/src/breadboxAPI/resources/dataset_v2.ts
@@ -1,7 +1,273 @@
-import { DatasetParams } from "@depmap/types";
-import { postJson } from "../client";
+import SparkMD5 from "spark-md5";
+import * as Papa from "papaparse";
+import { FailedCeleryTask } from "@depmap/compute";
+import {
+  AddDatasetOneRowArgs,
+  DatasetParams,
+  DatasetValueType,
+  MatrixDatasetParams,
+} from "@depmap/types";
+import { UploadTask, UploadTaskUserError } from "@depmap/user-upload";
+import { postJson, postMultipart } from "../client";
+
+interface AddDatasetResponse {
+  state: string;
+  id: string;
+  message?: string | null;
+  result?: Record<string, unknown> | null;
+  percentComplete?: number | null;
+}
 
 export function postDatasetUpload(datasetParams: DatasetParams) {
-  // TODO: Figure out return type.
-  return postJson<any>("/dataset-v2/", datasetParams);
+  return postJson<AddDatasetResponse>("/dataset-v2/", datasetParams);
+}
+
+async function uploadFile(file: File | Blob): Promise<string> {
+  const response = await postMultipart<{ file_id: string }>("/uploads/file", {
+    file,
+  });
+
+  return response.file_id;
+}
+
+/**
+ * Compute the MD5 hex digest of a File or Blob.
+ *
+ * Uses SparkMD5's incremental/chunked API to avoid loading
+ * the entire file into memory at once.
+ */
+export function computeFileMd5(
+  file: File | Blob,
+  chunkSize = 2 * 1024 * 1024 // 2MB chunks
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const spark = new SparkMD5.ArrayBuffer();
+    const reader = new FileReader();
+    const totalChunks = Math.ceil(file.size / chunkSize);
+    let currentChunk = 0;
+
+    const loadNextChunk = () => {
+      const start = currentChunk * chunkSize;
+      const end = Math.min(start + chunkSize, file.size);
+      reader.readAsArrayBuffer(file.slice(start, end));
+    };
+
+    reader.onload = (e) => {
+      if (e.target?.result) {
+        spark.append(e.target.result as ArrayBuffer);
+      }
+
+      currentChunk += 1;
+
+      if (currentChunk < totalChunks) {
+        loadNextChunk();
+      } else {
+        resolve(spark.end());
+      }
+    };
+
+    reader.onerror = () => {
+      reject(new Error("Failed to read file for MD5 computation"));
+    };
+
+    if (file.size === 0) {
+      // MD5 of empty input
+      resolve(spark.end());
+    } else {
+      loadNextChunk();
+    }
+  });
+}
+
+async function createDatasetV2(
+  file: File | Blob,
+  params: Omit<
+    MatrixDatasetParams,
+    "file_ids" | "dataset_md5" | "priority" | "taiga_id" | "allowed_values"
+  >
+) {
+  const [fileId, md5] = await Promise.all([
+    uploadFile(file),
+    computeFileMd5(file),
+  ]);
+
+  const payload: MatrixDatasetParams = {
+    ...params,
+    file_ids: [fileId],
+    dataset_md5: md5 as any,
+    priority: null,
+    taiga_id: null,
+    allowed_values: null,
+  };
+
+  return postJson<AddDatasetResponse>("/dataset-v2/", payload);
+}
+
+const assertCsvSingleColumnNoHeader = (
+  dataRow: any[],
+  index: number
+): UploadTaskUserError | null => {
+  if (dataRow.length > 2) {
+    return {
+      message: "File has too many columns",
+    };
+  }
+
+  if (index === 0) {
+    if (dataRow[0] === undefined || dataRow[0] === null || dataRow[0] === "") {
+      return {
+        message:
+          "Index of first row is NaN. Please upload a file without a header.",
+      };
+    }
+  }
+
+  return null;
+};
+
+const parseFileToAddHeader = (rawFile: any, headerStr: string) => {
+  return new Promise<any>((resolve, reject) => {
+    Papa.parse(rawFile, {
+      complete: (results) => {
+        results.data.map((val, index) => {
+          const error = assertCsvSingleColumnNoHeader(val, index);
+          if (error) {
+            reject(new Error(error.message));
+          }
+
+          return error;
+        });
+
+        results.data.splice(0, 0, ["", headerStr]);
+
+        resolve(results.data);
+      },
+    });
+  });
+};
+
+function taskResponseToUploadTask(response: AddDatasetResponse): UploadTask {
+  if (response.state === "SUCCESS") {
+    return {
+      id: response.id,
+      state: "SUCCESS",
+      nextPollDelay: 0,
+      percentComplete: 100,
+      result: {
+        datasetId: response.result?.datasetId as string,
+        warnings: (response.result?.warnings as string[]) || [],
+        dataset: response.result?.dataset,
+      },
+      message: response.message || "",
+    };
+  }
+
+  if (response.state === "FAILURE") {
+    return {
+      id: response.id,
+      state: "FAILURE",
+      nextPollDelay: 1000,
+      percentComplete: undefined,
+      result: undefined,
+      message: response.message || "Dataset creation failed",
+    } as FailedCeleryTask;
+  }
+
+  // PENDING or PROGRESS — the caller may need to poll /api/task/{id}
+  return {
+    id: response.id,
+    state: response.state as "PENDING",
+    nextPollDelay: 1000,
+    percentComplete: undefined,
+    result: undefined,
+    message: response.message || "",
+  } as UploadTask;
+}
+
+export async function postCustomCsv(config: {
+  displayName: string;
+  units: string;
+  transposed: boolean;
+  uploadFile: File;
+}): Promise<UploadTask> {
+  const { displayName, units, transposed, uploadFile: file } = config;
+
+  if (!transposed) {
+    throw new Error(
+      "Uploading CSV with cell lines as columns is not currently supported."
+    );
+  }
+
+  try {
+    const response = await createDatasetV2(file, {
+      name: displayName,
+      units,
+      data_type: "user_upload",
+      sample_type: "depmap_model",
+      feature_type: null as any,
+      value_type: DatasetValueType.continuous,
+      is_transient: true,
+      format: "matrix",
+      group_id: "11111111-1111-1111-1111-111111111111", // transient file group
+    });
+
+    return taskResponseToUploadTask(response);
+  } catch (error: any) {
+    return {
+      id: "",
+      message: error.message || "Upload failed",
+      nextPollDelay: 1000,
+      percentComplete: undefined,
+      result: undefined,
+      state: "FAILURE",
+    } as FailedCeleryTask;
+  }
+}
+
+export async function postCustomCsvOneRow(
+  config: AddDatasetOneRowArgs
+): Promise<UploadTask> {
+  const { uploadFile: rawFile } = config;
+
+  if (!rawFile) {
+    return {
+      id: "",
+      message: "No file provided",
+      nextPollDelay: 1000,
+      percentComplete: undefined,
+      result: undefined,
+      state: "FAILURE",
+    } as FailedCeleryTask;
+  }
+
+  const { name } = rawFile;
+
+  try {
+    const parsedData = await parseFileToAddHeader(rawFile, "custom data");
+    const csvString = Papa.unparse(parsedData);
+    const csvBlob = new Blob([csvString], { type: "text/csv" });
+
+    const response = await createDatasetV2(csvBlob, {
+      name,
+      units: "float",
+      data_type: "user_upload",
+      sample_type: "depmap_model",
+      feature_type: null as any,
+      value_type: DatasetValueType.continuous,
+      is_transient: true,
+      format: "matrix",
+      group_id: "11111111-1111-1111-1111-111111111111", // transient file group
+    });
+
+    return taskResponseToUploadTask(response);
+  } catch (error: any) {
+    return {
+      id: "",
+      message: error.message || "Upload failed",
+      nextPollDelay: 1000,
+      percentComplete: undefined,
+      result: undefined,
+      state: "FAILURE",
+    } as FailedCeleryTask;
+  }
 }

--- a/frontend/packages/@depmap/api/src/breadboxAPI/resources/datasets.ts
+++ b/frontend/packages/@depmap/api/src/breadboxAPI/resources/datasets.ts
@@ -1,26 +1,14 @@
-import * as Papa from "papaparse";
-import { FailedCeleryTask } from "@depmap/compute";
 import {
-  AddCustDatasetArgs,
-  AddDatasetOneRowArgs,
   Dataset,
   DatasetUpdateArgs,
-  DatasetValueType,
   ErrorTypeError,
   SearchDimenionsRequest,
   SearchDimenionsResponse,
   SliceQuery,
   TabularDatasetDataArgs,
 } from "@depmap/types";
-import { UploadTask, UploadTaskUserError } from "@depmap/user-upload";
 import { uri } from "../../uriTemplateTag";
-import {
-  getJson,
-  patchJson,
-  postJson,
-  deleteJson,
-  postMultipart,
-} from "../client";
+import { getJson, patchJson, postJson, deleteJson } from "../client";
 
 export function getDatasets(
   params?: Partial<{
@@ -184,115 +172,4 @@ export function getDimensionData(sliceQuery: SliceQuery) {
     labels: string[];
     values: string[];
   }>("/datasets/dimension/data/", sliceQuery);
-}
-
-const assertCsvSingleColumnNoHeader = (
-  dataRow: any[],
-  index: number
-): UploadTaskUserError | null => {
-  if (dataRow.length > 2) {
-    return {
-      message: "File has too many columns",
-    };
-  }
-
-  if (index === 0) {
-    if (dataRow[0] === undefined || dataRow[0] === null || dataRow[0] === "") {
-      return {
-        message:
-          "Index of first row is NaN. Please upload a file without a header.",
-      };
-    }
-  }
-
-  return null;
-};
-
-const parseFileToAddHeader = (rawFile: any, headerStr: string) => {
-  return new Promise<any>((resolve, reject) => {
-    Papa.parse(rawFile, {
-      complete: (results) => {
-        results.data.map((val, index) => {
-          const error = assertCsvSingleColumnNoHeader(val, index);
-          if (error) {
-            reject(new Error(error.message));
-          }
-
-          return error;
-        });
-
-        results.data.splice(0, 0, ["", headerStr]);
-
-        resolve(results.data);
-      },
-    });
-  });
-};
-
-export function postCustomCsv(config: {
-  displayName: string;
-  units: string;
-  transposed: boolean;
-  uploadFile: File;
-}) {
-  const { displayName, units, transposed, uploadFile } = config;
-
-  if (!transposed) {
-    throw new Error(
-      "Uploading CSV with cell lines as columns is not currently supported."
-    );
-  }
-
-  const args = {
-    name: displayName,
-    units,
-    data_type: "user_upload",
-    sample_type: "depmap_model",
-    feature_type: undefined,
-    value_type: DatasetValueType.continuous,
-    data_file: uploadFile,
-    is_transient: true,
-  };
-
-  return postMultipart<UploadTask>("/datasets/", args);
-}
-
-export function postCustomCsvOneRow(
-  config: AddDatasetOneRowArgs
-): Promise<UploadTask> {
-  const { uploadFile } = config;
-  const { name } = uploadFile;
-
-  return parseFileToAddHeader(config.uploadFile, "custom data")
-    .then((parsedFile) => {
-      const unparsedFile = Papa.unparse(parsedFile);
-      const finalUploadFile = new Blob([unparsedFile], {
-        type: "text/csv",
-      });
-
-      const finalConfig: Readonly<AddCustDatasetArgs> = {
-        name,
-        units: "float",
-        data_type: "user_upload",
-        sample_type: "depmap_model",
-        feature_type: null,
-        value_type: DatasetValueType.continuous,
-        data_file: finalUploadFile,
-        is_transient: true,
-      };
-
-      return postMultipart<UploadTask>("/datasets/", finalConfig);
-    })
-    .catch((error: Error) => {
-      const failedUploadTask: FailedCeleryTask = {
-        id: "",
-        message: error.message,
-        nextPollDelay: 1000,
-        percentComplete: undefined,
-        result: undefined,
-        state: "FAILURE",
-      };
-
-      return failedUploadTask;
-    });
 }

--- a/frontend/packages/@depmap/api/src/legacyPortalAPI/resources/interactive.ts
+++ b/frontend/packages/@depmap/api/src/legacyPortalAPI/resources/interactive.ts
@@ -1,6 +1,4 @@
-import { AddDatasetOneRowArgs } from "@depmap/types";
-import { UploadTask, UserUploadArgs } from "@depmap/user-upload";
-import { getJson, postMultipart } from "../client";
+import { getJson } from "../client";
 
 export function getCustomAnalysisDatasets() {
   return getJson<{ label: string; value: string }[]>(
@@ -10,15 +8,4 @@ export function getCustomAnalysisDatasets() {
 
 export function getCellLineUrlRoot() {
   return getJson<string>("/interactive/api/cellLineUrlRoot");
-}
-
-export function postCustomCsv(config: UserUploadArgs) {
-  return postMultipart<UploadTask>("/interactive/api/dataset/add-csv", config);
-}
-
-export function postCustomCsvOneRow(config: Readonly<AddDatasetOneRowArgs>) {
-  return postMultipart<UploadTask>(
-    "/interactive/api/dataset/add-csv-one-row",
-    config
-  );
 }

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/StartScreen/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/StartScreen/index.tsx
@@ -1,9 +1,7 @@
 import React, { useState } from "react";
 import { Button } from "react-bootstrap";
-import { breadboxAPI, legacyPortalAPI } from "@depmap/api";
 import { isElara } from "@depmap/globals";
 import { UploadFormat, UserUploadModal } from "@depmap/user-upload";
-import { isBreadboxOnlyMode } from "../../../../isBreadboxOnlyMode";
 import StartScreenExamples from "./StartScreenExamples";
 import styles from "../../styles/DataExplorer2.scss";
 
@@ -49,28 +47,13 @@ function StartScreen({ tutorialLink }: Props) {
         </>
       )}
       <UserUploadModal
-        disableOrientationOptions={isBreadboxOnlyMode}
+        disableOrientationOptions
         key={`${showCsvUploadModal}`}
         show={showCsvUploadModal}
         onHide={() => setShowCsvUploadModal(false)}
         uploadFormat={UploadFormat.File}
         isPrivate={false}
         isTransient
-        taskKickoffFunction={(args) => {
-          if (isBreadboxOnlyMode) {
-            return breadboxAPI.postCustomCsv(args);
-          }
-
-          return legacyPortalAPI.postCustomCsv({
-            ...args,
-            useDataExplorer2: true,
-          });
-        }}
-        getTaskStatus={
-          isBreadboxOnlyMode
-            ? breadboxAPI.getTaskStatus
-            : legacyPortalAPI.getTaskStatus
-        }
       />
     </div>
   );

--- a/frontend/packages/@depmap/types/index.ts
+++ b/frontend/packages/@depmap/types/index.ts
@@ -36,6 +36,7 @@ export type {
   DatasetUpdateArgs,
   TabularDataset,
   MatrixDataset,
+  MatrixDatasetParams,
   DatasetAssociations,
   TabularDatasetDataArgs,
 } from "./src/Dataset";

--- a/frontend/packages/@depmap/user-upload/src/components/UserUploadModal.tsx
+++ b/frontend/packages/@depmap/user-upload/src/components/UserUploadModal.tsx
@@ -34,10 +34,8 @@ type UserUploadModalProps = {
   uploadFormat: UploadFormat;
   isPrivate: boolean;
   isTransient: boolean;
-  taskKickoffFunction: (userUploadArgs: UserUploadArgs) => Promise<UploadTask>;
   groups?: Array<{ groupId: number; displayName: string }>;
   dataTypes?: DataTypeEnum[]; // Required for private uploads, but I think this modal is also used for non-private custom uploads
-  getTaskStatus: (taskIds: string) => Promise<ComputeResponse>;
   disableOrientationOptions?: boolean;
 };
 
@@ -157,8 +155,6 @@ export const UploadForm = (
   isTransient: boolean,
   groups: Array<{ groupId: number; displayName: string }>,
   dataTypes: DataTypeEnum[],
-  taskKickoffFunction: (userUploadArgs: UserUploadArgs) => Promise<UploadTask>,
-  getTaskStatus: (taskIds: string) => Promise<ComputeResponse>,
   disableOrientationOptions: boolean
 ) => {
   // Form inputs
@@ -224,9 +220,7 @@ export const UploadForm = (
       setTaskRunning(true);
 
       // make the submission
-      setSubmissionResponse(
-        taskKickoffFunction(taskKickoffFunctionArgs) as Promise<UploadTask>
-      );
+      setSubmissionResponse(breadboxAPI.postCustomCsv(taskKickoffFunctionArgs));
     } else if (
       displayName === "" ||
       units === "" ||
@@ -448,7 +442,7 @@ export const UploadForm = (
           submissionResponse={submissionResponse}
           onSuccess={onComplete}
           onFailure={onComplete}
-          getTaskStatus={getTaskStatus}
+          getTaskStatus={breadboxAPI.getTaskStatus}
         />
       )}
 
@@ -484,10 +478,8 @@ const UserUploadModal = ({
   uploadFormat,
   isPrivate,
   isTransient,
-  taskKickoffFunction,
   groups = [],
   dataTypes = [],
-  getTaskStatus,
   disableOrientationOptions = false,
 }: UserUploadModalProps) => {
   const modalTitle = isTransient
@@ -506,8 +498,6 @@ const UserUploadModal = ({
           isTransient,
           groups,
           dataTypes,
-          taskKickoffFunction,
-          getTaskStatus,
           disableOrientationOptions
         )}
       </Modal.Body>


### PR DESCRIPTION
The underlying issue is that submitting a POST to /datasets/ is no longer supported by Breadbox.

This updates a couple of compontents (Custom Analysis and the "Plot from CSV" button on the Data Explorer landing page) to use the /dataset-v2/ endpoint instead.