### PR TITLE
fix for dataset description rendering bug

### DIFF
--- a/frontend/packages/@depmap/common-components/src/components/Markdown/LazyMarkdownCore.tsx
+++ b/frontend/packages/@depmap/common-components/src/components/Markdown/LazyMarkdownCore.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import "github-markdown-css/github-markdown.css";
+import "github-markdown-css/github-markdown-light.css";
 
 export const LazyMarkdownCore = React.lazy(async () => {
   const ReactMarkdown = (await import("react-markdown")).default;


### PR DESCRIPTION
Fixes a bug in Data Explorer where the dataset description could be rendered with very light text (this was hard to reproduce because it only happened when you had the operating system set to Dark Mode).