### PR TITLE
PR 3 — Null-guarded negated operators and `is_null`/`not_null`

### DIFF
--- a/breadbox/breadbox/depmap_compute_embed/context.py
+++ b/breadbox/breadbox/depmap_compute_embed/context.py
@@ -27,6 +27,23 @@ operations.update(
             if isinstance(a, list) and isinstance(b, list)
             else True
         ),
+        # Unary null-checking operators. These are necessary because the
+        # implicit complement desugaring (below) closes off the old accidental
+        # way of matching null values through negated operators.
+        "is_null": lambda a: a is None,
+        "not_null": lambda a: a is not None,
+        # Note: When used with {"var": ...} references, !in, !has_any, and !=
+        # are desugared by _resolve_complements into null-guarded negations
+        # during ContextEvaluator.__init__. This prevents null values from being
+        # incorrectly matched (e.g. null !in ["a", "b"] would otherwise be True).
+        #
+        # Note: "complement" is not an operator users write directly — it is
+        # synthesized by the UI when a user selects the "NOT My Context" version
+        # of a positive context for use as an outgroup in a two-class comparison.
+        # It is desugared by _resolve_complements into a null-guarded negation
+        # so that the synthesized outgroup respects the same data-completeness
+        # gates as the positive. See _resolve_complements for the full rules.
+        #
         # Note: {"context": "<name>"} references are not standard JsonLogic.
         # They are resolved during ContextEvaluator.__init__ by
         # _resolve_context_refs, which recursively evaluates the named
@@ -143,6 +160,9 @@ class ContextEvaluator:
 
         # Resolve { "context": "<name>" } references into flat ID lists
         self.expr = self._resolve_context_refs(self.expr, context.get("contexts", {}))
+
+        # Desugar negated operators and complement into null-guarded negations
+        self.expr = _resolve_complements(self.expr)
 
         # Validate that all var references in the expression are defined
         _validate_var_refs(self.expr, self.slice_data)
@@ -272,3 +292,122 @@ def _validate_var_refs(expr, slice_data: dict):
                 f"Expression references var '{name}' but it is not defined "
                 f"in 'vars'. Defined vars: {defined}"
             )
+
+
+# Negated operators that should be desugared into null-guarded negations.
+# This prevents null values from being incorrectly matched by negated operators
+# (e.g. null !in ["Breast", "Lung"] would otherwise evaluate to True).
+_NEGATED_OPS = {"!in": "in", "!has_any": "has_any", "!=": "=="}
+
+
+# is_null is the only operator whose correct behavior on null is to return
+# True. Every other operator (==, >, in, has_any, and even not_null) returns
+# False on null, which is what makes null-guarding them safe. Null-guarding
+# is_null would destroy its meaning: complement(is_null(x)) without a guard
+# is "entities where x is not null," which is sensible; with a guard it
+# excludes every entity with null x, which is exactly the wrong answer.
+#
+# not_null is deliberately NOT in this set. In practice, not_null is most
+# commonly used as a gate inside a larger AND expression (e.g. "entities
+# where lineage is known AND expression > 5"), and users expect the
+# complement of such an expression to preserve that gate — otherwise the
+# positive group and the complement aren't a clean partition of the
+# entities the user actually cared about.
+_NULL_CHECK_OPS = {"is_null"}
+
+
+def _collect_data_vars(expr) -> set[str]:
+    """Like _collect_vars, but skips vars that appear only inside is_null
+    subexpressions. Used when computing null guards for complement
+    desugaring, where is_null must pass through unmodified."""
+    if isinstance(expr, dict):
+        if "var" in expr:
+            return {expr["var"]}
+        op = next(iter(expr))
+        if op in _NULL_CHECK_OPS:
+            return set()
+        return set().union(*(_collect_data_vars(v) for v in expr.values()))
+    if isinstance(expr, list):
+        return set().union(*(_collect_data_vars(x) for x in expr), set())
+    return set()
+
+
+def _resolve_complements(expr):
+    """
+    Desugars negated operators (!in, !has_any, !=) and explicit "complement"
+    nodes into null-guarded negations.
+    For example:
+        {"!in": [{"var": "0"}, ["Breast", "Lung"]]}
+    becomes:
+        {"and": [{"not_null": [{"var": "0"}]}, {"!": {"in": [{"var": "0"}, ["Breast", "Lung"]]}}]}
+
+    Design note — why operators are treated asymmetrically:
+
+    The ContextEvaluator powers a UI where every user-defined "positive"
+    context is automatically paired with an auto-synthesized "NOT" version,
+    presented as a separate outgroup option in the context picker. Users
+    building two-class comparisons rely on this pairing: they select their
+    positive group from a "my contexts" list and the negative group from
+    a parallel "out groups" list, and they expect the two to form a clean
+    partition of the entities they actually cared about.
+
+    This means `complement` isn't an operator users write — it's one the
+    system synthesizes to implement "NOT My Context." The rules below are
+    what make that synthesis produce results that match user intuition
+    for every possible shape of positive context.
+
+    Every operator in JsonLogic returns False on null input EXCEPT is_null,
+    which returns True. That single fact is what makes null-guarding safe
+    for most operators and unsafe for is_null:
+
+    - For !=, !in, !has_any, and any expression wrapped in "complement":
+      a null input would flip to True under plain negation, matching
+      entities the user didn't intend to include. Null-guarding prevents
+      that by requiring the var to be present before the negated clause
+      can fire.
+
+    - For is_null specifically: null-guarding destroys the operator's
+      meaning. complement(is_null(x)) should mean "entities where x is
+      not null," but under a null guard it becomes "entities where x is
+      not null AND x is not null AND it isn't the case that x is null,"
+      which excludes every entity with null x — exactly the ones the
+      inner is_null was identifying. So is_null is exempted from null
+      guards via _NULL_CHECK_OPS and _collect_data_vars.
+
+    not_null is deliberately NOT exempted, even though it looks symmetric
+    to is_null. It returns False on null like every other operator, so
+    null-guarding it is safe. More importantly, the common use case for
+    not_null is as a data-completeness gate inside a larger AND expression
+    (e.g. "entities where lineage is known AND expression > 5" as part of
+    a two-class comparison). Users expect the complement of such an
+    expression to preserve that gate — otherwise the positive group and
+    the complement aren't a clean partition of the entities the user
+    actually cared about. Null-guarding not_null is what makes that work.
+
+    The operators look symmetric at the syntax level but are asymmetric
+    in their relationship to missing data. See test_operator__complement_*
+    for the tests that pin this down.
+    """
+    if isinstance(expr, dict):
+        op = next(iter(expr))
+        if op in _NEGATED_OPS:
+            positive_op = _NEGATED_OPS[op]
+            inner = _resolve_complements(expr[op])
+            vars_used = sorted(_collect_data_vars(inner) - {"given_id"})
+            null_guards = [{"not_null": [{"var": v}]} for v in vars_used]
+            negated = {"!": {positive_op: inner}}
+            if not null_guards:
+                return negated
+            return {"and": [*null_guards, negated]}
+        if op == "complement":
+            inner = _resolve_complements(expr["complement"])
+            vars_used = sorted(_collect_data_vars(inner) - {"given_id"})
+            null_guards = [{"not_null": [{"var": v}]} for v in vars_used]
+            negated = {"!": inner}
+            if not null_guards:
+                return negated
+            return {"and": [*null_guards, negated]}
+        return {k: _resolve_complements(v) for k, v in expr.items()}
+    if isinstance(expr, list):
+        return [_resolve_complements(x) for x in expr]
+    return expr

--- a/breadbox/tests/depmap_compute_embed/test_context.py
+++ b/breadbox/tests/depmap_compute_embed/test_context.py
@@ -89,6 +89,424 @@ def test_operator__not_has_any():
     )
 
 
+def test_operator__not_in_with_none():
+    """None is not a member of any list, so !in should return True."""
+    assert expressions_are_equivalent(True, {"!in": [None, ["a", "b"]]},)
+
+    assert expressions_are_equivalent(True, {"!in": [None, []]},)
+
+
+def test_operator__in_with_none():
+    """None is not a member of any list, so `in` should return False."""
+    assert expressions_are_equivalent(False, {"in": [None, ["a", "b"]]},)
+
+
+def test_operator__has_any_with_none():
+    """has_any expects two lists. If either operand is None (not a list),
+    it should return False."""
+    assert expressions_are_equivalent(False, {"has_any": [None, ["a", "b"]]},)
+
+    assert expressions_are_equivalent(False, {"has_any": [["a", "b"], None]},)
+
+    assert expressions_are_equivalent(False, {"has_any": [None, None]},)
+
+
+def test_operator__not_has_any_with_none():
+    """!has_any expects two lists. If either operand is None (not a list),
+    it should return True (they trivially don't overlap)."""
+    assert expressions_are_equivalent(True, {"!has_any": [None, ["a", "b"]]},)
+
+    assert expressions_are_equivalent(True, {"!has_any": [["a", "b"], None]},)
+
+    assert expressions_are_equivalent(True, {"!has_any": [None, None]},)
+
+
+def test_comparison_operators_with_none():
+    """Standard comparison operators should handle None gracefully."""
+    assert expressions_are_equivalent(True, {"!=": [None, "foo"]},)
+
+    assert expressions_are_equivalent(False, {"==": [None, "foo"]},)
+
+
+def test_operator__complement_negates_when_data_present():
+    """complement behaves as negation when all referenced vars have values."""
+    context = {
+        "dimension_type": "dummy",
+        "expr": {"complement": {">": [{"var": "0"}, 1.5]}},
+        "vars": {
+            "0": {"dataset_id": "ds", "identifier": "col", "identifier_type": "column",}
+        },
+    }
+
+    get_slice_data = lambda _: pd.Series({"high": 2.0, "low": 0.5})
+    get_labels = lambda _: {"high": "High", "low": "Low"}
+
+    evaluator = ContextEvaluator(context, get_slice_data, get_labels)
+    result = evaluator.evaluate()
+
+    # high=2.0 > 1.5, so complement is False. low=0.5 <= 1.5, so complement is True.
+    assert result.ids == ["low"]
+
+
+def test_operator__complement_returns_false_when_var_is_null():
+    """complement returns False for entities with missing data,
+    letting them fall through to 'Other' instead of being misclassified."""
+    context = {
+        "dimension_type": "dummy",
+        "expr": {"complement": {">": [{"var": "0"}, 1.5]}},
+        "vars": {
+            "0": {"dataset_id": "ds", "identifier": "col", "identifier_type": "column",}
+        },
+    }
+
+    # "missing" has no entry in the slice data
+    get_slice_data = lambda _: pd.Series({"has_data": 0.5})
+    get_labels = lambda _: {"has_data": "Has Data", "missing": "Missing"}
+
+    evaluator = ContextEvaluator(context, get_slice_data, get_labels)
+    result = evaluator.evaluate()
+
+    # has_data: 0.5 <= 1.5, complement is True -> matches
+    # missing: null, complement returns False -> doesn't match (falls to "Other")
+    assert result.ids == ["has_data"]
+
+
+def test_operator__complement_vs_plain_not():
+    """Demonstrates the bug that complement fixes: plain '!' misclassifies
+    entities with null data into the outgroup."""
+    vars_def = {
+        "0": {"dataset_id": "ds", "identifier": "col", "identifier_type": "column",}
+    }
+    inner_expr = {">": [{"var": "0"}, 1.5]}
+
+    # "present" has data below threshold, "missing" has no data at all
+    get_slice_data = lambda _: pd.Series({"present": 0.5})
+    get_labels = lambda _: {"present": "Present", "missing": "Missing"}
+
+    # With plain "!" — the old buggy behavior
+    not_evaluator = ContextEvaluator(
+        {"dimension_type": "dummy", "expr": {"!": inner_expr}, "vars": vars_def},
+        get_slice_data,
+        get_labels,
+    )
+    not_result = not_evaluator.evaluate()
+
+    # BUG: "missing" is incorrectly included because !(null > 1.5) => !(False) => True
+    assert "missing" in not_result.ids
+
+    # With "complement" — the correct behavior
+    complement_evaluator = ContextEvaluator(
+        {
+            "dimension_type": "dummy",
+            "expr": {"complement": inner_expr},
+            "vars": vars_def,
+        },
+        get_slice_data,
+        get_labels,
+    )
+    complement_result = complement_evaluator.evaluate()
+
+    # FIXED: "missing" is excluded, only "present" matches
+    assert complement_result.ids == ["present"]
+
+
+def test_operator__complement_multiple_vars_any_null():
+    """If any referenced var is null, complement returns False —
+    even if other vars have data. This includes vars referenced inside
+    not_null gates: see test_operator__complement_with_not_null_gate
+    for the motivating two-class-comparison use case."""
+    context = {
+        "dimension_type": "dummy",
+        "expr": {
+            "complement": {
+                "and": [{">": [{"var": "a"}, 1.0]}, {"==": [{"var": "b"}, "yes"]},]
+            }
+        },
+        "vars": {
+            "a": {
+                "dataset_id": "ds1",
+                "identifier": "col_a",
+                "identifier_type": "column",
+            },
+            "b": {
+                "dataset_id": "ds2",
+                "identifier": "col_b",
+                "identifier_type": "column",
+            },
+        },
+    }
+
+    slice_data = {
+        ("ds1", "col_a", "column"): pd.Series({"full": 0.5, "partial": 0.5}),
+        ("ds2", "col_b", "column"): pd.Series({"full": "no"}),
+        # "partial" has no entry in ds2
+    }
+
+    def get_slice_data(q):
+        return slice_data[(q.dataset_id, q.identifier, q.identifier_type)]
+
+    get_labels = lambda _: {"full": "Full", "partial": "Partial"}
+
+    evaluator = ContextEvaluator(context, get_slice_data, get_labels)
+    result = evaluator.evaluate()
+
+    # full: a=0.5, b="no" — both present, inner=(0.5>1.0 and "no"=="yes")=False,
+    #   complement=True -> matches
+    # partial: a=0.5, b=None — b is null, complement returns False
+    assert result.ids == ["full"]
+
+
+def test_operator__complement_of_is_null_passes_through():
+    """`complement` should NOT null-guard `is_null` — it is the one operator
+    whose correct behavior on null is to return True, so wrapping it in a
+    null guard would destroy its meaning. Null-guarding `is_null(x)` would
+    exclude exactly the entities the user is trying to identify.
+
+    {"complement": {"is_null": [{"var": "x"}]}} should behave the same as
+    {"not_null": [{"var": "x"}]}: true for entities where x has data, false
+    where x is null. Credit to Phil for catching this asymmetry in review."""
+    context = {
+        "dimension_type": "dummy",
+        "expr": {"complement": {"is_null": [{"var": "0"}]}},
+        "vars": {
+            "0": {"dataset_id": "ds", "identifier": "col", "identifier_type": "column"}
+        },
+    }
+
+    get_slice_data = lambda _: pd.Series({"has_data": "foo"})
+    get_labels = lambda _: {"has_data": "Has Data", "missing": "Missing"}
+
+    evaluator = ContextEvaluator(context, get_slice_data, get_labels)
+    result = evaluator.evaluate()
+
+    # has_data: is_null is False, complement is True -> included
+    # missing:  is_null is True,  complement is False -> excluded
+    assert result.ids == ["has_data"]
+
+
+def test_operator__complement_with_not_null_gate():
+    """`not_null` IS null-guarded like any other operator, because the
+    typical use case is a data-completeness gate in a two-class comparison.
+    Given `complement(and(not_null(metadata), expression > 5))`, the user's
+    intent is "entities where metadata is known AND expression > 5", and
+    the complement should be "other entities where metadata is known" —
+    NOT "other entities plus entities with unknown metadata." The positive
+    and complement groups should form a clean partition of the entities
+    the user actually cared about (those with known metadata).
+    """
+    context = {
+        "dimension_type": "dummy",
+        "expr": {
+            "complement": {
+                "and": [
+                    {"not_null": [{"var": "metadata"}]},
+                    {">": [{"var": "expression"}, 5]},
+                ]
+            }
+        },
+        "vars": {
+            "metadata": {
+                "dataset_id": "ds1",
+                "identifier": "meta_col",
+                "identifier_type": "column",
+            },
+            "expression": {
+                "dataset_id": "ds2",
+                "identifier": "expr_col",
+                "identifier_type": "column",
+            },
+        },
+    }
+
+    slice_data = {
+        ("ds1", "meta_col", "column"): pd.Series(
+            {"high_with_meta": "tag", "low_with_meta": "tag"}
+            # "low_without_meta" and "all_missing" have no metadata
+        ),
+        ("ds2", "expr_col", "column"): pd.Series(
+            {"high_with_meta": 10.0, "low_with_meta": 1.0, "low_without_meta": 1.0}
+            # "all_missing" has no expression either
+        ),
+    }
+
+    def get_slice_data(q):
+        return slice_data[(q.dataset_id, q.identifier, q.identifier_type)]
+
+    get_labels = lambda _: {
+        "high_with_meta": "High + Meta",
+        "low_with_meta": "Low + Meta",
+        "low_without_meta": "Low, No Meta",
+        "all_missing": "All Missing",
+    }
+
+    evaluator = ContextEvaluator(context, get_slice_data, get_labels)
+    result = evaluator.evaluate()
+
+    # high_with_meta: both vars present, inner=(True AND True)=True
+    #   -> complement=False -> excluded (correctly in positive group)
+    # low_with_meta: both vars present, inner=(True AND False)=False
+    #   -> complement=True -> INCLUDED (correctly in outgroup)
+    # low_without_meta: metadata null -> null guard on `metadata` fails
+    #   -> complement returns False -> EXCLUDED (gate is preserved)
+    # all_missing: both vars null -> null guards fail -> excluded
+    #
+    # Key property: positive and complement together cover only entities
+    # with known metadata. Users running a two-class comparison can trust
+    # that their data-completeness gate is respected in both groups.
+    assert result.ids == ["low_with_meta"]
+
+
+def test_operator__is_null():
+    """is_null returns True when the value is None."""
+    context = {
+        "dimension_type": "dummy",
+        "expr": {"is_null": [{"var": "0"}]},
+        "vars": {
+            "0": {"dataset_id": "ds", "identifier": "col", "identifier_type": "column"}
+        },
+    }
+
+    get_slice_data = lambda _: pd.Series({"has_data": "foo"})
+    get_labels = lambda _: {"has_data": "Has Data", "missing": "Missing"}
+
+    evaluator = ContextEvaluator(context, get_slice_data, get_labels)
+    result = evaluator.evaluate()
+
+    # has_data: "foo" is not None -> False
+    # missing: None (not in slice) -> True
+    assert result.ids == ["missing"]
+
+
+def test_operator__not_null():
+    """not_null returns True when the value is not None."""
+    context = {
+        "dimension_type": "dummy",
+        "expr": {"not_null": [{"var": "0"}]},
+        "vars": {
+            "0": {"dataset_id": "ds", "identifier": "col", "identifier_type": "column"}
+        },
+    }
+
+    get_slice_data = lambda _: pd.Series({"has_data": "foo"})
+    get_labels = lambda _: {"has_data": "Has Data", "missing": "Missing"}
+
+    evaluator = ContextEvaluator(context, get_slice_data, get_labels)
+    result = evaluator.evaluate()
+
+    # has_data: "foo" is not None -> True
+    # missing: None -> False
+    assert result.ids == ["has_data"]
+
+
+def test_not_in_excludes_null_var_values():
+    """!in with a var reference now excludes entities where the var is null.
+    This fixes the bug where null !in ["a", "b"] would incorrectly match."""
+    context = {
+        "dimension_type": "dummy",
+        "expr": {"!in": [{"var": "0"}, ["Breast", "Lung"]]},
+        "vars": {
+            "0": {"dataset_id": "ds", "identifier": "col", "identifier_type": "column"}
+        },
+    }
+
+    get_slice_data = lambda _: pd.Series({"breast": "Breast", "other": "Skin"})
+    get_labels = lambda _: {
+        "breast": "Breast",
+        "other": "Other",
+        "missing": "Missing",
+    }
+
+    evaluator = ContextEvaluator(context, get_slice_data, get_labels)
+    result = evaluator.evaluate()
+
+    # breast: "Breast" in ["Breast", "Lung"] -> negated -> False
+    # other: "Skin" not in list, not null -> True
+    # missing: null -> null guard fails -> False (previously would have matched!)
+    assert result.ids == ["other"]
+
+
+def test_not_has_any_excludes_null_var_values():
+    """!has_any with a var reference now excludes entities where the var is null."""
+    context = {
+        "dimension_type": "dummy",
+        "expr": {"!has_any": [{"var": "0"}, ["a", "b"]]},
+        "vars": {
+            "0": {"dataset_id": "ds", "identifier": "col", "identifier_type": "column"}
+        },
+    }
+
+    get_slice_data = lambda _: pd.Series(
+        {"overlaps": ["a", "c"], "disjoint": ["d", "e"]}
+    )
+    get_labels = lambda _: {
+        "overlaps": "Overlaps",
+        "disjoint": "Disjoint",
+        "missing": "Missing",
+    }
+
+    evaluator = ContextEvaluator(context, get_slice_data, get_labels)
+    result = evaluator.evaluate()
+
+    # overlaps: ["a", "c"] overlaps ["a", "b"] -> negated -> False
+    # disjoint: ["d", "e"] no overlap, not null -> True
+    # missing: null -> null guard fails -> False
+    assert result.ids == ["disjoint"]
+
+
+def test_nested_not_in_excludes_null():
+    """!in correctly excludes null values even when nested inside 'and'."""
+    context = {
+        "dimension_type": "dummy",
+        "expr": {
+            "and": [
+                {"!in": [{"var": "0"}, ["Breast", "Lung"]]},
+                {"==": [{"var": "1"}, "yes"]},
+            ]
+        },
+        "vars": {
+            "0": {
+                "dataset_id": "ds1",
+                "identifier": "col1",
+                "identifier_type": "column",
+            },
+            "1": {
+                "dataset_id": "ds2",
+                "identifier": "col2",
+                "identifier_type": "column",
+            },
+        },
+    }
+
+    slice_data = {
+        ("ds1", "col1", "column"): pd.Series({"full": "Skin", "partial": "Skin"}),
+        ("ds2", "col2", "column"): pd.Series({"full": "yes"}),
+    }
+
+    def get_slice_data(q):
+        return slice_data[(q.dataset_id, q.identifier, q.identifier_type)]
+
+    get_labels = lambda _: {
+        "full": "Full",
+        "partial": "Partial",
+        "missing": "Missing",
+    }
+
+    evaluator = ContextEvaluator(context, get_slice_data, get_labels)
+    result = evaluator.evaluate()
+
+    # full: "Skin" !in list (with guard pass), "yes"=="yes" -> match
+    # partial: "Skin" !in list (with guard pass), but col2=None, None=="yes" -> False
+    # missing: col1=None -> null guard on !in fails -> False
+    assert result.ids == ["full"]
+
+
+def test_not_in_with_literal_none_still_works():
+    """Literal None (not a var reference) in !in still behaves as before.
+    The null guard only applies to var references."""
+    assert expressions_are_equivalent(True, {"!in": [None, ["a", "b"]]})
+    assert expressions_are_equivalent(True, {"!in": [None, []]})
+
+
 # ============================================================
 # Tests for reindex_through passthrough in ContextEvaluator
 # ============================================================
@@ -216,3 +634,110 @@ def test_context_evaluator_reindex_through_ignored_fields():
     evaluator = ContextEvaluator(context, mock_get_slice_data, mock_get_labels)
     result = evaluator.evaluate()
     assert result.ids == ["id1"]
+
+
+# ============================================================
+# Tests for nested context references containing complement
+# ============================================================
+
+
+def test_nested_context_ref_with_complement_in_inner():
+    """A gene_pair context can reference a gene-level outgroup (complement)
+    via {"context": "<name>"}. The inner complement should resolve against
+    the gene dimension type, producing a flat list of gene IDs, and the
+    outer expression should use that list for membership testing. The
+    data-completeness gate on the inner should carry forward: genes with
+    unknown essentiality belong neither to the positive nor the outgroup,
+    so gene pairs referencing such genes should be excluded.
+
+    This is the one situation where `complement` can legitimately appear
+    in user-generated output: as the inner `expr` of a context referenced
+    by another context. The top-level context is still always positive,
+    but the embedded reference can be to an auto-synthesized outgroup.
+    """
+    context = {
+        "dimension_type": "gene_pair",
+        "expr": {"in": [{"var": "gene_1"}, {"context": "non_essential"}]},
+        "vars": {
+            "gene_1": {
+                "dataset_id": "pair_meta",
+                "identifier": "gene_1_id",
+                "identifier_type": "column",
+            }
+        },
+        "contexts": {
+            "non_essential": {
+                "dimension_type": "gene",
+                "expr": {"complement": {"==": [{"var": "0"}, "common essential"]}},
+                "vars": {
+                    "0": {
+                        "dataset_id": "gene_meta",
+                        "identifier": "essentiality",
+                        "identifier_type": "column",
+                    }
+                },
+            }
+        },
+    }
+
+    # Three genes exercising all the interesting cases:
+    #   ESSENTIAL_GENE: known essential    -> in positive, NOT in outgroup
+    #   NONESS_GENE:   known non-essential -> NOT in positive, in outgroup
+    #   UNKNOWN_GENE:  unknown essentiality -> in neither (gate'd out by null guard)
+    gene_essentiality = pd.Series(
+        {
+            "ESSENTIAL_GENE": "common essential",
+            "NONESS_GENE": "not common essential",
+            # UNKNOWN_GENE has no entry: essentiality is null
+        }
+    )
+
+    # Four pairs, one per gene scenario plus one edge case:
+    #   PAIR_E: gene_1 = ESSENTIAL_GENE -> should be EXCLUDED
+    #   PAIR_N: gene_1 = NONESS_GENE   -> should be INCLUDED
+    #   PAIR_U: gene_1 = UNKNOWN_GENE  -> should be EXCLUDED (gate)
+    #   PAIR_X: gene_1 = nonexistent   -> should be EXCLUDED
+    pair_gene_1 = pd.Series(
+        {
+            "PAIR_E": "ESSENTIAL_GENE",
+            "PAIR_N": "NONESS_GENE",
+            "PAIR_U": "UNKNOWN_GENE",
+            "PAIR_X": "SOME_OTHER_GENE_NOT_IN_TABLE",
+        }
+    )
+
+    slice_data = {
+        ("gene_meta", "essentiality"): gene_essentiality,
+        ("pair_meta", "gene_1_id"): pair_gene_1,
+    }
+
+    def get_slice_data(q):
+        return slice_data[(q.dataset_id, q.identifier)]
+
+    def get_labels(dim_type):
+        if dim_type == "gene":
+            return {
+                "ESSENTIAL_GENE": "Essential Gene",
+                "NONESS_GENE": "Non-Essential Gene",
+                "UNKNOWN_GENE": "Unknown Gene",
+            }
+        if dim_type == "gene_pair":
+            return {
+                "PAIR_E": "Pair with Essential",
+                "PAIR_N": "Pair with Non-Essential",
+                "PAIR_U": "Pair with Unknown",
+                "PAIR_X": "Pair with Other",
+            }
+        raise ValueError(f"unexpected dim_type {dim_type!r}")
+
+    evaluator = ContextEvaluator(context, get_slice_data, get_labels)
+    result = evaluator.evaluate()
+
+    # Only PAIR_N should match — its gene_1 is in the non_essential outgroup.
+    # PAIR_E is excluded because ESSENTIAL_GENE is in the positive, not the
+    # outgroup. PAIR_U is excluded because UNKNOWN_GENE is gate'd out of the
+    # outgroup by the null guard — the positive-and-complement partition
+    # only covers genes with known essentiality, and this property is
+    # preserved through the nested context reference. PAIR_X is excluded
+    # because SOME_OTHER_GENE_NOT_IN_TABLE isn't a member of any gene group.
+    assert result.ids == ["PAIR_N"]


### PR DESCRIPTION
Fixes a latent bug where entities with missing data were incorrectly matched by negated filter operators, and adds explicit null-checking operators since the old implicit null-matching path is now closed.

Builds on PR 2.

## Changes

- **`depmap_compute_embed/context.py`**:
  - New `is_null` / `not_null` unary operators.
  - New `_resolve_complements` preprocessing pass, called from `__init__` after slice loading. Desugars `!in`, `!has_any`, `!=`, and the `complement` node into null-guarded negations (`and` of `not_null` guards plus `!` of the positive form). Applies per variable reference in the expression.
  - Supporting helpers: `_collect_vars`, `_validate_var_refs`, and the `_NEGATED_OPS` table.
- **`tests/depmap_compute_embed/test_context.py`**: adds 15 tests covering the null behavior of each operator, the `complement` node, `is_null`/`not_null`, and nested expressions.

## Behavior change (release notes)

Previously, filters using "is not", "is not in list", or "has none of" could include items with no data for the selected property. For example, filtering for cell lines where lineage "is not" Breast would include cell lines with no lineage information at all, even though we don't actually know their lineage.

Items with missing data are now excluded from these filters. When using these operators to define groups (e.g., in a two-class comparison), items with missing data will fall into the "Other" category rather than being assigned to either group. Two new operators, "has no value" and "has a value", are available for filters that need to explicitly find items with missing data.

## How to test

```
pytest breadbox/tests/depmap_compute_embed/test_context.py
```