### PR TITLE
PR 2 — Refactor `ContextEvaluator` and add nested context references

### DIFF
--- a/breadbox/breadbox/api/temp/context.py
+++ b/breadbox/breadbox/api/temp/context.py
@@ -1,10 +1,10 @@
 from typing import Annotated
-from breadbox.crud.dimension_ids import get_dimension_type_labels_by_id
-from fastapi import Body, Depends, HTTPException
+from logging import getLogger
+from fastapi import Body, Depends
 
+from breadbox.crud.dimension_ids import get_dimension_type_labels_by_id
 from breadbox.api.dependencies import get_db_with_user
 from breadbox.config import Settings, get_settings
-from breadbox.crud import dimension_types as types_crud
 from breadbox.schemas.custom_http_exception import UserError
 from breadbox.db.session import SessionWithUser
 from breadbox.schemas.context import (
@@ -16,6 +16,8 @@ from breadbox.service import slice as slice_service
 from breadbox.depmap_compute_embed.context import ContextEvaluator
 
 from .router import router
+
+log = getLogger(__name__)
 
 
 @router.post(
@@ -36,29 +38,28 @@ def evaluate_context(
     Also get the total number of "candidate" records (all records with labels belonging to the dimension type).
     Requests must be in the version 2 context format.
     """
-    slice_loader_function = lambda slice_query: slice_service.get_slice_data(
-        db, settings.filestore_location, slice_query
-    )
-    context_evaluator = ContextEvaluator(context.dict(), slice_loader_function)
 
-    # Load all dimension labels and ids
-    all_labels_by_id = get_dimension_type_labels_by_id(db, context.dimension_type)
+    def slice_loader(slice_query):
+        return slice_service.get_slice_data(
+            db, settings.filestore_location, slice_query
+        )
 
-    # Evaluate each against the context
-    matching_ids = []
-    matching_labels = []
+    def label_loader(dimension_type):
+        return get_dimension_type_labels_by_id(db, dimension_type)
+
     try:
-        for given_id, label in all_labels_by_id.items():
-            if context_evaluator.is_match(given_id):
-                matching_ids.append(given_id)
-                matching_labels.append(label)
+        evaluator = ContextEvaluator(context.dict(), slice_loader, label_loader)
+        result = evaluator.evaluate()
     except LookupError as e:
-        # This happens when the request is malformed
-        # TODO: Should this be returning a FEATURE_NOT_FOUND or SAMPLE_NOT_FOUND error instead?
-        raise UserError(f"Encountered lookup error: {e}")
+        raise UserError(f"Encountered lookup error: {e}") from e
+    except (ValueError, TypeError) as e:
+        log.error(
+            "Context evaluation failed: %s\nContext: %s",
+            e,
+            context.model_dump_json(indent=2),
+        )
+        raise UserError(f"Context evaluation error: {e}") from e
 
     return ContextMatchResponse(
-        ids=matching_ids,
-        labels=matching_labels,
-        num_candidates=len(all_labels_by_id.keys()),
+        ids=result.ids, labels=result.labels, num_candidates=result.num_candidates,
     )

--- a/breadbox/breadbox/depmap_compute_embed/context.py
+++ b/breadbox/breadbox/depmap_compute_embed/context.py
@@ -1,10 +1,12 @@
+from dataclasses import dataclass
+
 # Note: There is another python implementation of JsonLogic floating out there.
 # It looks very robust but it's 10 times slower! I've decided against using it
 # but it serves as a good reference for patching operators:
 # https://github.com/panzi/panzi-json-logic
 from json_logic import jsonLogic, operations  # type: ignore
 import pandas as pd
-from typing import Any, Callable
+from typing import Callable
 
 from breadbox.depmap_compute_embed.slice import SliceQuery
 
@@ -25,36 +27,59 @@ operations.update(
             if isinstance(a, list) and isinstance(b, list)
             else True
         ),
+        # Note: {"context": "<name>"} references are not standard JsonLogic.
+        # They are resolved during ContextEvaluator.__init__ by
+        # _resolve_context_refs, which recursively evaluates the named
+        # context and replaces the node with a flat list of matching IDs
+        # before any expression evaluation occurs.
     }
 )
+
+
+@dataclass
+class ContextMatch:
+    """Result of evaluating a context."""
+
+    ids: list[str]
+    labels: list[str]
+    num_candidates: int
 
 
 def _dict_to_slice_query(d: dict) -> SliceQuery:
     """Convert a raw dict (from a deserialized Context) to a SliceQuery dataclass,
     including any nested reindex_through chain."""
+    identifier_type = d["identifier_type"]
+    if hasattr(identifier_type, "value"):
+        identifier_type = identifier_type.value
+
     reindex_through = None
     if d.get("reindex_through") is not None:
         reindex_through = _dict_to_slice_query(d["reindex_through"])
     return SliceQuery(
         dataset_id=d["dataset_id"],
         identifier=d["identifier"],
-        identifier_type=d["identifier_type"],
+        identifier_type=identifier_type,
         reindex_through=reindex_through,
     )
 
 
 class ContextEvaluator:
     """
-    Instantiated for a specific context. 
-    Caches data for the slices referenced in the context (in memory).
+    Instantiated for a specific context.
+    Eagerly loads slice data and resolves any nested context references.
     For context examples, see tests.
     """
 
     def __init__(
-        self, context: dict, get_slice_data: Callable[[SliceQuery], pd.Series],
+        self,
+        context: dict,
+        get_slice_data: Callable[[SliceQuery], pd.Series],
+        get_labels_by_id: Callable[[str], dict[str, str]],
+        max_depth: int = 5,
     ):
         """
         A `context` dict should have:
+            - a `dimension_type` such as "gene" or "gene_pair"
             - an `expr` such as { "==": [ { "var": "var1" }, "Breast" ] }
             - a dictionary of `vars` which assigns names to slice queries, such as
               {
@@ -77,91 +102,122 @@ class ContextEvaluator:
                       }
                   }
               }
+            - an optional dictionary of `contexts` which assigns names to nested
+              context definitions. These are referenced in `expr` via
+              { "context": "<name>" } and resolve to a list of matching IDs.
+
+        Example using a nested context:
+            {
+                "dimension_type": "gene_pair",
+                "expr": { "in": [ { "var": "gene_1" }, { "context": "selective" } ] },
+                "vars": { "gene_1": { "dataset_id": "...", ... } },
+                "contexts": {
+                    "selective": {
+                        "dimension_type": "gene",
+                        "expr": { "==": [ { "var": "0" }, "strongly selective" ] },
+                        "vars": { "0": { "dataset_id": "...", ... } }
+                    }
+                }
+            }
         """
+        if max_depth <= 0:
+            raise ValueError("Maximum context nesting depth exceeded")
+
+        self.dimension_type = context["dimension_type"]
         self.expr = _encode_dots_in_vars(context["expr"])
-        self.slice_query_vars = _escape_dots(context.get("vars", {}))
+        slice_query_vars = _escape_dots(context.get("vars", {}))
 
-        # Takes a slice query, returns a dictionary of slice values (indexed by ID)
-        self.get_slice_data = get_slice_data
+        # Stored for recursive construction of inner contexts
+        self._get_slice_data = get_slice_data
+        self._get_labels_by_id = get_labels_by_id
+        self._max_depth = max_depth
 
-        # The cache is used so that slice values only need to be looked up once per context.
-        # - The keys in this dictionary match the values of an any { "var": "<var_name>" }
-        # expressions (and therefore should also match the keys of context["vars"]).
-        # - The values are each an entire dictionary of slice values (indexed by given ID)
-        self.cache = {}
+        # Eagerly load all slice data as {var_name: {given_id: value}} dicts
+        self.slice_data: dict[str, dict] = {}
+        for var_name, raw_query in slice_query_vars.items():
+            try:
+                slice_query = _dict_to_slice_query(raw_query)
+                self.slice_data[var_name] = get_slice_data(slice_query).to_dict()
+            except (KeyError, TypeError, ValueError) as e:
+                raise LookupError(e) from e
 
-    def is_match(self, given_id: str):
+        # Resolve { "context": "<name>" } references into flat ID lists
+        self.expr = self._resolve_context_refs(self.expr, context.get("contexts", {}))
+
+        # Validate that all var references in the expression are defined
+        _validate_var_refs(self.expr, self.slice_data)
+
+    def evaluate(self) -> ContextMatch:
         """
-        This evaluates `expr` against a `given_id`. It returns
-        True/False depending on if `given_id` satifies the conditions of
-        the expression, including any variables ("var" subexpressions) which
-        are bound by using a magic dict (_JsonLogicVarLookup) that does lookups lazily.
+        Returns all matching IDs and labels for this context's dimension_type.
         """
-        dictionary_override = _JsonLogicVarLookup(
-            given_id, self.cache, self.get_slice_data, self.slice_query_vars,
+        all_labels_by_id = self._get_labels_by_id(self.dimension_type)
+        matching_ids = []
+        matching_labels = []
+        for given_id, label in all_labels_by_id.items():
+            if self._is_match(given_id):
+                matching_ids.append(given_id)
+                matching_labels.append(label)
+
+        return ContextMatch(
+            ids=matching_ids,
+            labels=matching_labels,
+            num_candidates=len(all_labels_by_id),
         )
-        return jsonLogic(self.expr, dictionary_override)
 
+    def _evaluate_ids(self) -> list[str]:
+        """Used internally for resolving nested context references."""
+        all_labels_by_id = self._get_labels_by_id(self.dimension_type)
+        return [cid for cid in all_labels_by_id if self._is_match(cid)]
 
-class _JsonLogicVarLookup(dict):
-    """
-    Context expressions use `var` fields to load data on the fly. 
-        For example, the following expression might be used to exclude certain given IDs from a query:
-            - { "!in": [ { "var": "given_id" }, ["1", "2", "3"] ] }
-
-    In order to populate these with real values, the JsonLogic library 
-    wants to be passed a dictionary it can use to look up values by variable name. 
-
-    However, we need to inject our own special cases and
-    caching, so we override the dictionary class with special functionality.
-    We don't need to "perfectly" override it; just well enough to trick the JsonLogic library.
-    Interesting thread on overriding the Dict class:
-    https://stackoverflow.com/questions/3387691/how-to-perfectly-override-a-dict
-    """
-
-    def __init__(
-        self,
-        given_id: str,
-        cache: dict,
-        get_slice_data: Callable[[SliceQuery], pd.Series],
-        slice_query_vars: dict[str, dict[str, str]],
-    ):
-        self.given_id = given_id
-        self.get_slice_data = get_slice_data
-        # The cache is stored outside of this class so it can be reused.
-        self.cache = cache
-        self.slice_query_vars = slice_query_vars
-
-    def __getitem__(self, var_name: str) -> Any:
+    def _is_match(self, given_id: str) -> bool:
         """
-        Given a variable from the context definition, load the corresponding slice value. 
-        Look up the value by the "given_id" that's already been passed into the constructor of this class.
-        Context vars can be either:
-        - a slice query (used to reference a dimension value)
-        - the string "given_id" (used to reference an id)
+        Evaluates `expr` for a `given_id`. Missing slice values are passed
+        as None, letting JsonLogic handle them according to operator semantics.
         """
-        # There is a special case where "given_id" may be specified instead of
-        # a slice query. This allows our context definitions to reference ids, which
-        # wouldn't otherwise be possible because slice queries are used to load dataset values.
-        if var_name == "given_id":
-            return self.given_id
+        data: dict = {"given_id": given_id}
+        for var_name, slice_values in self.slice_data.items():
+            data[var_name] = slice_values.get(given_id)
 
-        else:
-            if var_name not in self.cache:
+        try:
+            return bool(jsonLogic(self.expr, data))
+        except (ValueError, TypeError) as e:
+            raise ValueError(
+                f"{e} (while evaluating given_id={given_id!r} with data={data!r})"
+            ) from e
+
+    def _resolve_context_refs(self, node, contexts: dict):
+        """
+        Walk the expression tree. When a { "context": "<name>" } node is found,
+        look up the named context definition, recursively evaluate it, and
+        replace the node with a flat list of matching IDs.
+        """
+        if isinstance(node, dict):
+            if "context" in node:
+                context_name = node["context"]
                 try:
-                    slice_query = _dict_to_slice_query(self.slice_query_vars[var_name])
-                    self.cache[var_name] = self.get_slice_data(slice_query).to_dict()
-                except (KeyError, TypeError, ValueError) as e:
-                    raise LookupError(e)
+                    inner_context = contexts[context_name]
+                except KeyError as e:
+                    raise LookupError(
+                        f"Context reference '{context_name}' not found in contexts"
+                    ) from e
 
-            slice_values = self.cache[var_name]
-            return slice_values[self.given_id]
+                inner_evaluator = ContextEvaluator(
+                    inner_context,
+                    self._get_slice_data,
+                    self._get_labels_by_id,
+                    max_depth=self._max_depth - 1,
+                )
+                # pylint: disable-next=protected-access
+                result = inner_evaluator._evaluate_ids()
+                return result
 
-    # We don't want our virtual dictionary to appear empty.
-    # Otherwise, the JsonLogic library will stomp it out with an empty default dict:
-    # https://github.com/nadirizr/json-logic-py/blob/master/json_logic/__init__.py#L180
-    def __bool__(self):
-        return True
+            return {k: self._resolve_context_refs(v, contexts) for k, v in node.items()}
+
+        if isinstance(node, list):
+            return [self._resolve_context_refs(x, contexts) for x in node]
+
+        return node
 
 
 def _encode_dots_in_vars(expr: dict):
@@ -194,3 +250,25 @@ def _escape_dots(d: dict) -> dict:
     return {
         (k.replace(".", "%2E") if isinstance(k, str) else k): v for k, v in d.items()
     }
+
+
+def _collect_vars(expr) -> set[str]:
+    """Extract all {"var": "<name>"} references from a JsonLogic expression."""
+    if isinstance(expr, dict):
+        if "var" in expr:
+            return {expr["var"]}
+        return set().union(*(_collect_vars(v) for v in expr.values()))
+    if isinstance(expr, list):
+        return set().union(*(_collect_vars(x) for x in expr), set())
+    return set()
+
+
+def _validate_var_refs(expr, slice_data: dict):
+    """Raise LookupError if the expression references any undefined variables."""
+    for name in _collect_vars(expr):
+        if name != "given_id" and name not in slice_data:
+            defined = ", ".join(sorted(slice_data.keys())) or "(none)"
+            raise LookupError(
+                f"Expression references var '{name}' but it is not defined "
+                f"in 'vars'. Defined vars: {defined}"
+            )

--- a/breadbox/breadbox/schemas/context.py
+++ b/breadbox/breadbox/schemas/context.py
@@ -31,9 +31,14 @@ class Context(BaseModel):
     # - { "!": [ { "var": "model1_lineage" }, "Breast" ] }
     # - { "==": [ { "var": "entity_id"}, "ACH-000001" ] }
     # - { ">": [ {"var": "model2_expression"}, 0.5 ] }
+    # - { "in": [ { "var": "gene_1" }, { "context": "selective" } ] }
     # - True
     expr: ContextExpression
     name: Optional[str] = None
     dimension_type: str
-    # This vars field is a dictionary of variable names to slice queries
-    vars: dict[str, dict[str, str]] = {}
+    # Maps variable names to slice queries, referenced in expr via { "var": "<name>" }
+    vars: dict[str, SliceQueryRef] = {}
+    # Maps context names to nested context definitions, referenced in expr via
+    # { "context": "<name>" }. Inner contexts can themselves define their own
+    # vars and contexts, enabling recursive nesting.
+    contexts: dict[str, "Context"] = {}

--- a/breadbox/tests/depmap_compute_embed/test_context.py
+++ b/breadbox/tests/depmap_compute_embed/test_context.py
@@ -6,6 +6,20 @@ from breadbox.depmap_compute_embed.slice import SliceQuery
 # These tests ensure that behavior is continuing to work as expected.
 
 
+def expressions_are_equivalent(boolean_value, json_logic_expr):
+    context = {
+        "dimension_type": "dummy",
+        "expr": json_logic_expr,
+    }
+
+    # These expressions don't use variables (just pure logic)
+    get_slice_data_mock = lambda _: pd.Series(dtype=object)
+    get_labels_by_id_mock = lambda _: {"dummy_id": "dummy_label"}
+    evaluator = ContextEvaluator(context, get_slice_data_mock, get_labels_by_id_mock)
+
+    return evaluator._is_match("dummy_id") == boolean_value
+
+
 def test_operator__not_in():
     assert expressions_are_equivalent(
         # python
@@ -75,19 +89,6 @@ def test_operator__not_has_any():
     )
 
 
-def expressions_are_equivalent(boolean_value, json_logic_expr):
-    context = {"context_type": "don't care", "expr": json_logic_expr}
-
-    # These expressions don't use variables (just pure logic)
-    var_name = "dummy variable"
-    get_slice_data_mock = lambda _: pd.Series(dtype=object)
-    result = ContextEvaluator(context, get_slice_data_mock).is_match(
-        var_name
-    )  # pyright: ignore
-
-    return result == boolean_value
-
-
 # ============================================================
 # Tests for reindex_through passthrough in ContextEvaluator
 # ============================================================
@@ -136,11 +137,17 @@ def test_context_evaluator_with_reindex_through():
         # Return data as if the chain was already resolved to screen_pair IDs
         return pd.Series({"PAIR_1": "Breast", "PAIR_2": "Lung", "PAIR_3": "Breast"})
 
-    evaluator = ContextEvaluator(context, mock_get_slice_data)
-    matches = [pid for pid in ["PAIR_1", "PAIR_2", "PAIR_3"] if evaluator.is_match(pid)]
+    mock_get_labels = lambda dim_type: {
+        "PAIR_1": "Pair 1",
+        "PAIR_2": "Pair 2",
+        "PAIR_3": "Pair 3",
+    }
+
+    evaluator = ContextEvaluator(context, mock_get_slice_data, mock_get_labels)
+    result = evaluator.evaluate()
 
     # Only screen_pairs with Lineage == "Breast" should match
-    assert matches == ["PAIR_1", "PAIR_3"]
+    assert sorted(result.ids) == ["PAIR_1", "PAIR_3"]
 
 
 def test_context_evaluator_without_reindex_through_still_works():
@@ -163,16 +170,22 @@ def test_context_evaluator_without_reindex_through_still_works():
         assert sq.reindex_through is None
         return pd.Series({"MODEL_A": "Breast", "MODEL_B": "Lung"})
 
-    evaluator = ContextEvaluator(context, mock_get_slice_data)
-    matches = [mid for mid in ["MODEL_A", "MODEL_B"] if evaluator.is_match(mid)]
+    mock_get_labels = lambda dim_type: {
+        "MODEL_A": "Model A",
+        "MODEL_B": "Model B",
+    }
 
-    assert matches == ["MODEL_A"]
+    evaluator = ContextEvaluator(context, mock_get_slice_data, mock_get_labels)
+    result = evaluator.evaluate()
+
+    assert result.ids == ["MODEL_A"]
 
 
 def test_context_evaluator_reindex_through_ignored_fields():
     """
-    _dict_to_slice_query only reads the three core fields + reindex_through
-    from each var dict, so any extra fields are silently dropped.
+    SliceQueryRef has extra='ignore', so unknown fields in the vars dict
+    should be silently dropped. This also verifies that only the three core
+    fields + reindex_through are passed through.
     """
     context = {
         "dimension_type": "dummy",
@@ -198,5 +211,8 @@ def test_context_evaluator_reindex_through_ignored_fields():
         assert sq.reindex_through.dataset_id == "root_ds"
         return pd.Series({"id1": "yes"})
 
-    evaluator = ContextEvaluator(context, mock_get_slice_data)
-    assert evaluator.is_match("id1") is True
+    mock_get_labels = lambda _: {"id1": "Label 1"}
+
+    evaluator = ContextEvaluator(context, mock_get_slice_data, mock_get_labels)
+    result = evaluator.evaluate()
+    assert result.ids == ["id1"]


### PR DESCRIPTION
Two changes bundled because they share the same motivation: the refactor exists to make recursive context evaluation tractable, and the nested-context feature is what makes the refactor worth doing.

Builds on PR 1.

## Changes

**ContextEvaluator refactor (`depmap_compute_embed/context.py`)**

- Replaces lazy per-id lookup via `_JsonLogicVarLookup` with eager slice loading in `__init__`. The helper class is deleted.
- New public `evaluate()` method returns a `ContextMatch` dataclass (`ids`, `labels`, `num_candidates`). Callers no longer drive the label iteration themselves.
- Constructor now takes a `get_labels_by_id: Callable[[str], dict[str, str]]` callback and a `max_depth: int = 5` parameter.
- `is_match()` → private `_is_match()` (confirmed only one caller in the codebase).
- `context["dimension_type"]` is now stored on the evaluator and used by `evaluate()` to look up the candidate set.

**Nested `{"context": "<name>"}` references**

- New `_resolve_context_refs` walks the expression tree at `__init__` time; each `{"context": "<name>"}` node is replaced with a flat list of matching IDs from a recursively-evaluated inner `ContextEvaluator`.
- `Context.contexts: dict[str, "Context"]` added to the schema. `Context.vars` retyped from `dict[str, dict[str, str]]` to `dict[str, SliceQueryRef]`.
- `max_depth` enforced during recursion to catch runaway nesting.

**Endpoint rewrite (`api/temp/context.py`)**

- `evaluate_context` now constructs the evaluator with both callbacks and calls `.evaluate()` directly. Adds structured logging on `ValueError`/`TypeError` for easier debugging of malformed contexts. Drops now-unused `HTTPException` and `types_crud` imports.

## How to test

```
pytest breadbox/tests/depmap_compute_embed/test_context.py
```

All existing tests updated to the new API; the three reindex_through passthrough tests are rewritten to use `evaluate()`.