### PR TITLE
PR 1 — Add `reindex_through` support to `SliceQuery`

### DIFF
--- a/breadbox/breadbox/api/datasets.py
+++ b/breadbox/breadbox/api/datasets.py
@@ -57,6 +57,7 @@ from ..schemas.dataset import (
     DimensionDataResponse,
     SliceQueryIdentifierType,
 )
+from breadbox.schemas.context import SliceQueryRef
 from breadbox.service import dataset as dataset_service
 from breadbox.service import metadata as metadata_service
 from breadbox.service import slice as slice_service
@@ -67,6 +68,26 @@ from ..utils.caching import CachingCaller
 
 router = APIRouter(prefix="/datasets", tags=["datasets"])
 log = getLogger(__name__)
+
+
+def _to_internal_slice_query(ref: SliceQueryRef) -> SliceQuery:
+    """Convert a Pydantic SliceQueryRef to the internal SliceQuery dataclass."""
+    return SliceQuery(
+        dataset_id=ref.dataset_id,
+        identifier=ref.identifier,
+        identifier_type=ref.identifier_type,
+        reindex_through=_to_internal_slice_query(ref.reindex_through)
+        if ref.reindex_through
+        else None,
+    )
+
+
+def _get_root_query(sq: SliceQuery) -> SliceQuery:
+    """Chase reindex_through to find the root (innermost) step in the chain."""
+    current = sq
+    while current.reindex_through is not None:
+        current = current.reindex_through
+    return current
 
 
 @router.get(
@@ -411,7 +432,13 @@ def get_dimensions(
     response_model=DimensionDataResponse,
 )
 def get_dimension_data(
-    # The request body should be a SliceQuery with the following three fields:
+    # TODO: This endpoint inlines the SliceQuery fields as individual Body() params
+    # instead of referencing the SliceQuery schema directly. This is historical drift.
+    # We're keeping it this way for now to avoid breaking the auto-generated Breadbox
+    # Python client and the Breadbox Facade, which may depend on the Body_get_dimension_data
+    # schema name and structure. Once we've confirmed those consumers can handle the
+    # change, we should refactor this to accept a single SliceQuery (or SliceQueryRef)
+    # body parameter, which would also make the OpenAPI spec self-documenting.
     dataset_id: Annotated[str, Body(description="The UUID or given ID of a dataset.")],
     identifier: Annotated[
         str,
@@ -425,6 +452,12 @@ def get_dimension_data(
             description="Denotes the type of identifier being used and the axis being queried."
         ),
     ],
+    reindex_through: Annotated[
+        Optional[SliceQueryRef],
+        Body(
+            description="Optional chain of FK joins to reindex the result by a different dimension type."
+        ),
+    ] = None,
     db: SessionWithUser = Depends(get_db_with_user),
     settings: Settings = Depends(get_settings),
 ):
@@ -435,11 +468,21 @@ def get_dimension_data(
         dataset_id=dataset_id,
         identifier=identifier,
         identifier_type=identifier_type.name,
+        reindex_through=_to_internal_slice_query(reindex_through)
+        if reindex_through
+        else None,
     )
     slice_values_by_id = slice_service.get_slice_data(
         db, settings.filestore_location, parsed_slice_query
     )
-    labels_by_id = metadata_service.get_labels_for_slice_type(db, parsed_slice_query)
+
+    # When reindex_through is present, the result is indexed by the root's entity IDs,
+    # so labels must come from the root's dimension type, not the leaf's.
+    label_query = parsed_slice_query
+    if parsed_slice_query.reindex_through is not None:
+        label_query = _get_root_query(parsed_slice_query)
+
+    labels_by_id = metadata_service.get_labels_for_slice_type(db, label_query)
 
     # Only the values which have corresponding metadata should be returned
     all_dataset_given_ids = slice_values_by_id.index.to_list()

--- a/breadbox/breadbox/api/datasets.py
+++ b/breadbox/breadbox/api/datasets.py
@@ -75,7 +75,7 @@ def _to_internal_slice_query(ref: SliceQueryRef) -> SliceQuery:
     return SliceQuery(
         dataset_id=ref.dataset_id,
         identifier=ref.identifier,
-        identifier_type=ref.identifier_type,
+        identifier_type=ref.identifier_type.value,
         reindex_through=_to_internal_slice_query(ref.reindex_through)
         if ref.reindex_through
         else None,

--- a/breadbox/breadbox/depmap_compute_embed/context.py
+++ b/breadbox/breadbox/depmap_compute_embed/context.py
@@ -29,6 +29,20 @@ operations.update(
 )
 
 
+def _dict_to_slice_query(d: dict) -> SliceQuery:
+    """Convert a raw dict (from a deserialized Context) to a SliceQuery dataclass,
+    including any nested reindex_through chain."""
+    reindex_through = None
+    if d.get("reindex_through") is not None:
+        reindex_through = _dict_to_slice_query(d["reindex_through"])
+    return SliceQuery(
+        dataset_id=d["dataset_id"],
+        identifier=d["identifier"],
+        identifier_type=d["identifier_type"],
+        reindex_through=reindex_through,
+    )
+
+
 class ContextEvaluator:
     """
     Instantiated for a specific context. 
@@ -48,6 +62,19 @@ class ContextEvaluator:
                       "dataset_id": "depmap_model_metadata",
                       "identifier": "OncotreeLineage",
                       "identifier_type": "column"
+                  }
+              }
+              Vars may also include a `reindex_through` field for FK-chain traversal:
+              {
+                  "var1": {
+                      "dataset_id": "depmap_model_metadata",
+                      "identifier": "OncotreeLineage",
+                      "identifier_type": "column",
+                      "reindex_through": {
+                          "dataset_id": "screen_metadata",
+                          "identifier": "ModelID",
+                          "identifier_type": "column"
+                      }
                   }
               }
         """
@@ -122,11 +149,7 @@ class _JsonLogicVarLookup(dict):
         else:
             if var_name not in self.cache:
                 try:
-                    # fmt: off
-                    slice_query = SliceQuery(
-                        **self.slice_query_vars[var_name] # pyright: ignore
-                    )
-                    # fmt: on
+                    slice_query = _dict_to_slice_query(self.slice_query_vars[var_name])
                     self.cache[var_name] = self.get_slice_data(slice_query).to_dict()
                 except (KeyError, TypeError, ValueError) as e:
                     raise LookupError(e)
@@ -139,7 +162,6 @@ class _JsonLogicVarLookup(dict):
     # https://github.com/nadirizr/json-logic-py/blob/master/json_logic/__init__.py#L180
     def __bool__(self):
         return True
-
 
 
 def _encode_dots_in_vars(expr: dict):

--- a/breadbox/breadbox/depmap_compute_embed/slice.py
+++ b/breadbox/breadbox/depmap_compute_embed/slice.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Optional
 
 from urllib.parse import unquote
 
@@ -11,6 +11,7 @@ class SliceQuery:
     identifier_type: Literal[
         "feature_id", "feature_label", "sample_id", "sample_label", "column"
     ]
+    reindex_through: Optional["SliceQuery"] = None
 
 
 def decode_slice_id(slice_id) -> tuple[str, str, str]:

--- a/breadbox/breadbox/schemas/context.py
+++ b/breadbox/breadbox/schemas/context.py
@@ -13,6 +13,18 @@ ContextExpression = Annotated[
 ]
 
 
+class SliceQueryRef(BaseModel):
+    """A reference to a slice of data in a dataset."""
+
+    dataset_id: str
+    identifier: str
+    identifier_type: str
+    reindex_through: Optional["SliceQueryRef"] = None
+
+    class Config:
+        extra = "ignore"
+
+
 class Context(BaseModel):
     # Context expression examples:
     # - { "!": [ { "var": "model1_lineage" }, "Breast" ] }

--- a/breadbox/breadbox/schemas/context.py
+++ b/breadbox/breadbox/schemas/context.py
@@ -1,5 +1,6 @@
 from pydantic import Field, BaseModel
 from typing import Annotated, Any, Optional, Union
+from breadbox.schemas.dataset import SliceQueryIdentifierType
 
 
 class ContextMatchResponse(BaseModel):
@@ -18,7 +19,7 @@ class SliceQueryRef(BaseModel):
 
     dataset_id: str
     identifier: str
-    identifier_type: str
+    identifier_type: SliceQueryIdentifierType
     reindex_through: Optional["SliceQueryRef"] = None
 
     class Config:

--- a/breadbox/breadbox/service/slice.py
+++ b/breadbox/breadbox/service/slice.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from typing import List
+from logging import getLogger
 
 import pandas as pd
 
@@ -26,6 +27,7 @@ from breadbox.crud.dimension_ids import (
     get_dataset_feature_by_given_id,
 )
 
+log = getLogger(__name__)
 
 _MAX_REINDEX_DEPTH = 10
 
@@ -135,16 +137,35 @@ def _resolve_reindex_chain(
                 f"identifier '{step.identifier}'."
             )
 
-    # Load each step's data as a simple (non-chained) slice query
+    # Load each step's data as a simple (non-chained) slice query. Wrap each
+    # call in a try/except so any failure (missing column, missing dataset,
+    # etc.) is re-raised with chain context, making it obvious which step of
+    # the reindex_through traversal failed.
     series_chain: List[pd.Series] = []
-    for step in chain:
+    for i, step in enumerate(chain):
+        if i == 0:
+            role = "root"
+        elif i == len(chain) - 1:
+            role = "leaf"
+        else:
+            role = f"intermediate step {i}"
+
         simple_query = SliceQuery(
             dataset_id=step.dataset_id,
             identifier=step.identifier,
             identifier_type=step.identifier_type,
         )
-        series_chain.append(get_slice_data(db, filestore_location, simple_query))
-
+        try:
+            series_chain.append(get_slice_data(db, filestore_location, simple_query))
+        except Exception as e:
+            message = (
+                f"Failed to resolve reindex_through chain at {role} "
+                f"(dataset_id={step.dataset_id!r}, "
+                f"identifier={step.identifier!r}, "
+                f"identifier_type={step.identifier_type!r}): {e}"
+            )
+            log.warning(message, exc_info=True)
+            raise UserError(message) from e
     # Compose: root maps root_ids → step1_ids, step1 maps step1_ids → step2_ids, etc.
     # The leaf maps final_ids → values. Chaining .map() yields root_ids → values.
     result = series_chain[0]

--- a/breadbox/breadbox/service/slice.py
+++ b/breadbox/breadbox/service/slice.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from typing import List
 
 import pandas as pd
 
@@ -24,6 +25,9 @@ from breadbox.crud.dimension_ids import (
     get_dataset_sample_by_given_id,
     get_dataset_feature_by_given_id,
 )
+
+
+_MAX_REINDEX_DEPTH = 10
 
 
 @dataclass
@@ -83,6 +87,73 @@ def resolve_slice_to_components(
     return ResolvedSliceIdentifiers(dataset=dataset, label=label, given_id=given_id)
 
 
+def _flatten_reindex_chain(leaf: SliceQuery) -> List[SliceQuery]:
+    """
+    Flatten the nested reindex_through chain into a list ordered [root, ..., leaf].
+    The leaf is the outermost query (the data you want), and the root is the
+    innermost reindex_through (the caller's index type).
+    """
+    chain = [leaf]
+    current = leaf
+    seen_datasets: set[tuple[str, str]] = {
+        (leaf.dataset_id, leaf.identifier)
+    }  # seed with leaf
+    while current.reindex_through is not None:
+        key = (current.reindex_through.dataset_id, current.reindex_through.identifier)
+        if key in seen_datasets:
+            raise UserError(
+                f"Circular reference detected in reindex_through chain: "
+                f"dataset '{key[0]}', identifier '{key[1]}' appears more than once."
+            )
+        if len(chain) >= _MAX_REINDEX_DEPTH:
+            raise UserError(
+                f"reindex_through chain exceeds maximum depth of {_MAX_REINDEX_DEPTH}."
+            )
+        seen_datasets.add(key)
+        chain.append(current.reindex_through)
+        current = current.reindex_through
+    chain.reverse()
+    return chain
+
+
+def _resolve_reindex_chain(
+    db: SessionWithUser, filestore_location: str, slice_query: SliceQuery
+) -> pd.Series:
+    """
+    Resolve a SliceQuery with reindex_through by walking the FK chain.
+    Each intermediate step loads an FK column, and the leaf loads the target data.
+    Returns a Series indexed by the root's entity IDs with values from the leaf.
+    """
+    chain = _flatten_reindex_chain(slice_query)
+
+    # Validate: all intermediate steps must use identifier_type "column"
+    for step in chain[:-1]:
+        if step.identifier_type != "column":
+            raise UserError(
+                f"Intermediate reindex_through steps must use identifier_type 'column', "
+                f"but got '{step.identifier_type}' for dataset '{step.dataset_id}', "
+                f"identifier '{step.identifier}'."
+            )
+
+    # Load each step's data as a simple (non-chained) slice query
+    series_chain: List[pd.Series] = []
+    for step in chain:
+        simple_query = SliceQuery(
+            dataset_id=step.dataset_id,
+            identifier=step.identifier,
+            identifier_type=step.identifier_type,
+        )
+        series_chain.append(get_slice_data(db, filestore_location, simple_query))
+
+    # Compose: root maps root_ids → step1_ids, step1 maps step1_ids → step2_ids, etc.
+    # The leaf maps final_ids → values. Chaining .map() yields root_ids → values.
+    result = series_chain[0]
+    for next_series in series_chain[1:]:
+        result = result.map(next_series)
+
+    return result.dropna()
+
+
 def get_slice_data(
     db: SessionWithUser, filestore_location: str, slice_query: SliceQuery
 ) -> pd.Series:
@@ -91,7 +162,13 @@ def get_slice_data(
     The result will be a pandas series indexed by sample/feature ID 
     (regardless of the identifier_type used in the query).
     Note: the result may contain given_ids which do not exist in the metadata. These should not be returned to users.
+
+    If slice_query.reindex_through is set, the result will be reindexed through
+    a chain of FK joins, returning data indexed by the root entity IDs.
     """
+    if slice_query.reindex_through is not None:
+        return _resolve_reindex_chain(db, filestore_location, slice_query)
+
     dataset_id = slice_query.dataset_id
     dataset = dataset_crud.get_dataset(db=db, user=db.user, dataset_id=dataset_id)
     if dataset is None:

--- a/breadbox/tests/depmap_compute_embed/test_context.py
+++ b/breadbox/tests/depmap_compute_embed/test_context.py
@@ -80,7 +80,7 @@ def expressions_are_equivalent(boolean_value, json_logic_expr):
 
     # These expressions don't use variables (just pure logic)
     var_name = "dummy variable"
-    get_slice_data_mock = lambda _: {}
+    get_slice_data_mock = lambda _: pd.Series(dtype=object)
     result = ContextEvaluator(context, get_slice_data_mock).is_match(
         var_name
     )  # pyright: ignore

--- a/breadbox/tests/depmap_compute_embed/test_context.py
+++ b/breadbox/tests/depmap_compute_embed/test_context.py
@@ -1,7 +1,10 @@
+import pandas as pd
 from breadbox.depmap_compute_embed.context import ContextEvaluator
+from breadbox.depmap_compute_embed.slice import SliceQuery
 
 # Our ContextEvaluator makes heavy use of an extension to the 3rd party library: json_logic
-# These tests ensure that behavior is continuing to work as expected. 
+# These tests ensure that behavior is continuing to work as expected.
+
 
 def test_operator__not_in():
     assert expressions_are_equivalent(
@@ -78,6 +81,122 @@ def expressions_are_equivalent(boolean_value, json_logic_expr):
     # These expressions don't use variables (just pure logic)
     var_name = "dummy variable"
     get_slice_data_mock = lambda _: {}
-    result = ContextEvaluator(context, get_slice_data_mock).is_match(var_name) # pyright: ignore
+    result = ContextEvaluator(context, get_slice_data_mock).is_match(
+        var_name
+    )  # pyright: ignore
 
     return result == boolean_value
+
+
+# ============================================================
+# Tests for reindex_through passthrough in ContextEvaluator
+# ============================================================
+
+
+def test_context_evaluator_with_reindex_through():
+    """
+    The ContextEvaluator should pass reindex_through through to get_slice_data,
+    and the returned data should be indexed by the root entity IDs.
+    """
+    context = {
+        "dimension_type": "screen_pair",
+        "expr": {"==": [{"var": "lineage"}, "Breast"]},
+        "vars": {
+            "lineage": {
+                "dataset_id": "model_meta",
+                "identifier": "Lineage",
+                "identifier_type": "column",
+                "reindex_through": {
+                    "dataset_id": "screen_meta",
+                    "identifier": "ModelID",
+                    "identifier_type": "column",
+                    "reindex_through": {
+                        "dataset_id": "screen_pair_meta",
+                        "identifier": "ScreenID",
+                        "identifier_type": "column",
+                    },
+                },
+            }
+        },
+    }
+
+    def mock_get_slice_data(sq: SliceQuery):
+        """
+        When the evaluator calls get_slice_data, it should pass a SliceQuery
+        with the full reindex_through chain. We simulate the resolved result:
+        screen_pair IDs → Lineage values.
+        """
+        assert sq.dataset_id == "model_meta"
+        assert sq.identifier == "Lineage"
+        assert sq.reindex_through is not None
+        assert sq.reindex_through.dataset_id == "screen_meta"
+        assert sq.reindex_through.reindex_through is not None
+        assert sq.reindex_through.reindex_through.dataset_id == "screen_pair_meta"
+
+        # Return data as if the chain was already resolved to screen_pair IDs
+        return pd.Series({"PAIR_1": "Breast", "PAIR_2": "Lung", "PAIR_3": "Breast"})
+
+    evaluator = ContextEvaluator(context, mock_get_slice_data)
+    matches = [pid for pid in ["PAIR_1", "PAIR_2", "PAIR_3"] if evaluator.is_match(pid)]
+
+    # Only screen_pairs with Lineage == "Breast" should match
+    assert matches == ["PAIR_1", "PAIR_3"]
+
+
+def test_context_evaluator_without_reindex_through_still_works():
+    """
+    Ensure the existing behavior is unchanged when reindex_through is absent.
+    """
+    context = {
+        "dimension_type": "model",
+        "expr": {"==": [{"var": "lineage"}, "Breast"]},
+        "vars": {
+            "lineage": {
+                "dataset_id": "model_meta",
+                "identifier": "Lineage",
+                "identifier_type": "column",
+            }
+        },
+    }
+
+    def mock_get_slice_data(sq: SliceQuery):
+        assert sq.reindex_through is None
+        return pd.Series({"MODEL_A": "Breast", "MODEL_B": "Lung"})
+
+    evaluator = ContextEvaluator(context, mock_get_slice_data)
+    matches = [mid for mid in ["MODEL_A", "MODEL_B"] if evaluator.is_match(mid)]
+
+    assert matches == ["MODEL_A"]
+
+
+def test_context_evaluator_reindex_through_ignored_fields():
+    """
+    _dict_to_slice_query only reads the three core fields + reindex_through
+    from each var dict, so any extra fields are silently dropped.
+    """
+    context = {
+        "dimension_type": "dummy",
+        "expr": {"==": [{"var": "0"}, "yes"]},
+        "vars": {
+            "0": {
+                "dataset_id": "ds",
+                "identifier": "col",
+                "identifier_type": "column",
+                "some_unknown_field": "should be ignored",
+                "reindex_through": {
+                    "dataset_id": "root_ds",
+                    "identifier": "fk_col",
+                    "identifier_type": "column",
+                    "another_unknown": 42,
+                },
+            }
+        },
+    }
+
+    def mock_get_slice_data(sq: SliceQuery):
+        assert sq.reindex_through is not None
+        assert sq.reindex_through.dataset_id == "root_ds"
+        return pd.Series({"id1": "yes"})
+
+    evaluator = ContextEvaluator(context, mock_get_slice_data)
+    assert evaluator.is_match("id1") is True

--- a/breadbox/tests/service/test_slice.py
+++ b/breadbox/tests/service/test_slice.py
@@ -14,6 +14,7 @@ from breadbox.schemas.custom_http_exception import UserError
 
 from breadbox.depmap_compute_embed.slice import SliceQuery
 
+from typing import cast
 from tests import factories
 
 
@@ -288,7 +289,9 @@ def test_resolve_rejects_non_column_intermediate():
     )
     with pytest.raises(UserError, match="identifier_type 'column'"):
         # db and filestore_location won't be reached because validation fails first
-        _resolve_reindex_chain(None, None, leaf)
+        _resolve_reindex_chain(
+            cast(SessionWithUser, None), cast(str, None), leaf,
+        )
 
 
 def test_resolve_allows_non_column_leaf():
@@ -306,7 +309,9 @@ def test_resolve_allows_non_column_leaf():
     )
     # Should fail on DB access (None db), not on validation
     with pytest.raises(Exception) as exc_info:
-        _resolve_reindex_chain(None, None, leaf)
+        _resolve_reindex_chain(
+            cast(SessionWithUser, None), cast(str, None), leaf,
+        )
     assert "identifier_type 'column'" not in str(exc_info.value)
 
 

--- a/breadbox/tests/service/test_slice.py
+++ b/breadbox/tests/service/test_slice.py
@@ -1,10 +1,16 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from breadbox.db.session import SessionWithUser
-from breadbox.service.slice import get_slice_data
+from breadbox.service.slice import (
+    get_slice_data,
+    _flatten_reindex_chain,
+    _resolve_reindex_chain,
+)
 from breadbox.models.dataset import AnnotationType
 from breadbox.schemas.dataset import ColumnMetadata
+from breadbox.schemas.custom_http_exception import UserError
 
 from breadbox.depmap_compute_embed.slice import SliceQuery
 
@@ -169,3 +175,453 @@ def test_get_slice_data_with_tabular_dataset(minimal_db: SessionWithUser, settin
     result_series = get_slice_data(minimal_db, filestore_location, count_column_query)
     assert result_series.index.tolist() == ["sampleID1", "sampleID2", "sampleID3"]
     assert result_series.values.tolist() == [1, 2, 3]
+
+
+# ============================================================
+# Tests for _flatten_reindex_chain
+# ============================================================
+
+
+def test_flatten_single_step():
+    """A query with no reindex_through returns a single-element chain."""
+    leaf = SliceQuery(dataset_id="ds1", identifier="col1", identifier_type="column")
+    chain = _flatten_reindex_chain(leaf)
+    assert len(chain) == 1
+    assert chain[0].dataset_id == "ds1"
+
+
+def test_flatten_two_hops():
+    """A two-step chain flattens to [root, leaf] order."""
+    root = SliceQuery(
+        dataset_id="root_ds", identifier="fk_col", identifier_type="column"
+    )
+    leaf = SliceQuery(
+        dataset_id="leaf_ds",
+        identifier="data_col",
+        identifier_type="column",
+        reindex_through=root,
+    )
+    chain = _flatten_reindex_chain(leaf)
+    assert len(chain) == 2
+    assert chain[0].dataset_id == "root_ds"
+    assert chain[1].dataset_id == "leaf_ds"
+
+
+def test_flatten_three_hops():
+    """screen_pair → screen → model, reading a column from model metadata."""
+    innermost = SliceQuery(
+        dataset_id="screen_pair_meta", identifier="ScreenID", identifier_type="column",
+    )
+    middle = SliceQuery(
+        dataset_id="screen_meta",
+        identifier="ModelID",
+        identifier_type="column",
+        reindex_through=innermost,
+    )
+    leaf = SliceQuery(
+        dataset_id="model_meta",
+        identifier="Lineage",
+        identifier_type="column",
+        reindex_through=middle,
+    )
+    chain = _flatten_reindex_chain(leaf)
+    assert len(chain) == 3
+    assert [s.dataset_id for s in chain] == [
+        "screen_pair_meta",
+        "screen_meta",
+        "model_meta",
+    ]
+
+
+def test_flatten_detects_circular_reference():
+    """A chain that revisits the same (dataset_id, identifier) should raise."""
+    root = SliceQuery(dataset_id="ds_a", identifier="col_a", identifier_type="column")
+    mid = SliceQuery(
+        dataset_id="ds_b",
+        identifier="col_b",
+        identifier_type="column",
+        reindex_through=root,
+    )
+    leaf = SliceQuery(
+        dataset_id="ds_a",
+        identifier="col_a",
+        identifier_type="column",
+        reindex_through=mid,
+    )
+    with pytest.raises(UserError, match="Circular reference"):
+        _flatten_reindex_chain(leaf)
+
+
+def test_flatten_rejects_excessive_depth():
+    """A chain deeper than _MAX_REINDEX_DEPTH should raise."""
+    current = SliceQuery(
+        dataset_id="ds_0", identifier="col_0", identifier_type="column"
+    )
+    for i in range(1, 15):
+        current = SliceQuery(
+            dataset_id=f"ds_{i}",
+            identifier=f"col_{i}",
+            identifier_type="column",
+            reindex_through=current,
+        )
+    with pytest.raises(UserError, match="maximum depth"):
+        _flatten_reindex_chain(current)
+
+
+# ============================================================
+# Tests for _resolve_reindex_chain validation
+# ============================================================
+
+
+def test_resolve_rejects_non_column_intermediate():
+    """Intermediate steps must use identifier_type='column'."""
+    root = SliceQuery(
+        dataset_id="ds_root",
+        identifier="some_feature",
+        identifier_type="feature_id",  # Invalid for an intermediate step
+    )
+    leaf = SliceQuery(
+        dataset_id="ds_leaf",
+        identifier="data_col",
+        identifier_type="column",
+        reindex_through=root,
+    )
+    with pytest.raises(UserError, match="identifier_type 'column'"):
+        # db and filestore_location won't be reached because validation fails first
+        _resolve_reindex_chain(None, None, leaf)
+
+
+def test_resolve_allows_non_column_leaf():
+    """The leaf step CAN use non-column identifier types (feature_id, sample_label, etc.).
+    This test just validates the chain structure — it will fail on DB access,
+    but should NOT fail on the intermediate identifier_type check."""
+    root = SliceQuery(
+        dataset_id="ds_root", identifier="fk_col", identifier_type="column",
+    )
+    leaf = SliceQuery(
+        dataset_id="ds_leaf",
+        identifier="some_feature",
+        identifier_type="feature_id",
+        reindex_through=root,
+    )
+    # Should fail on DB access (None db), not on validation
+    with pytest.raises(Exception) as exc_info:
+        _resolve_reindex_chain(None, None, leaf)
+    assert "identifier_type 'column'" not in str(exc_info.value)
+
+
+# ============================================================
+# Integration tests for get_slice_data with reindex_through
+# ============================================================
+
+
+def _setup_chained_dimension_types(minimal_db, settings):
+    """
+    Set up three dimension types with FK relationships:
+        screen_pair → screen (via ScreenID column)
+        screen → model (via ModelID column)
+
+    And populate metadata for each with test data.
+    Returns the given_ids of the three metadata datasets.
+    """
+    user = settings.admin_users[0]
+
+    # 1. Create the "model" dimension type with metadata
+    factories.add_dimension_type(
+        minimal_db,
+        settings,
+        user=user,
+        name="test-model",
+        display_name="Test Model",
+        id_column="ID",
+        annotation_type_mapping={
+            "ID": AnnotationType.text,
+            "label": AnnotationType.text,
+            "Lineage": AnnotationType.text,
+        },
+        axis="sample",
+        metadata_df=pd.DataFrame(
+            {
+                "ID": ["MODEL_A", "MODEL_B", "MODEL_C"],
+                "label": ["Model A", "Model B", "Model C"],
+                "Lineage": ["Breast", "Lung", "Skin"],
+            }
+        ),
+    )
+
+    # 2. Create the "screen" dimension type with metadata
+    factories.add_dimension_type(
+        minimal_db,
+        settings,
+        user=user,
+        name="test-screen",
+        display_name="Test Screen",
+        id_column="ID",
+        annotation_type_mapping={
+            "ID": AnnotationType.text,
+            "label": AnnotationType.text,
+            "ModelID": AnnotationType.text,
+        },
+        axis="sample",
+        metadata_df=pd.DataFrame(
+            {
+                "ID": ["SCREEN_1", "SCREEN_2", "SCREEN_3"],
+                "label": ["Screen 1", "Screen 2", "Screen 3"],
+                "ModelID": ["MODEL_A", "MODEL_B", "MODEL_C"],
+            }
+        ),
+    )
+
+    # 3. Create the "screen_pair" dimension type with metadata
+    factories.add_dimension_type(
+        minimal_db,
+        settings,
+        user=user,
+        name="test-screen-pair",
+        display_name="Test Screen Pair",
+        id_column="ID",
+        annotation_type_mapping={
+            "ID": AnnotationType.text,
+            "label": AnnotationType.text,
+            "ScreenID": AnnotationType.text,
+        },
+        axis="sample",
+        metadata_df=pd.DataFrame(
+            {
+                "ID": ["PAIR_X", "PAIR_Y", "PAIR_Z"],
+                "label": ["Pair X", "Pair Y", "Pair Z"],
+                "ScreenID": ["SCREEN_1", "SCREEN_2", "SCREEN_3"],
+            }
+        ),
+    )
+
+    # Now create tabular datasets for each dimension type so get_slice_data can load them
+    factories.tabular_dataset(
+        minimal_db,
+        settings,
+        given_id="test-model-metadata",
+        index_type_name="test-model",
+        columns_metadata={
+            "ID": ColumnMetadata(col_type=AnnotationType.text),
+            "label": ColumnMetadata(col_type=AnnotationType.text),
+            "Lineage": ColumnMetadata(col_type=AnnotationType.text),
+        },
+        data_df=pd.DataFrame(
+            {
+                "ID": ["MODEL_A", "MODEL_B", "MODEL_C"],
+                "label": ["Model A", "Model B", "Model C"],
+                "Lineage": ["Breast", "Lung", "Skin"],
+            }
+        ),
+    )
+
+    factories.tabular_dataset(
+        minimal_db,
+        settings,
+        given_id="test-screen-metadata",
+        index_type_name="test-screen",
+        columns_metadata={
+            "ID": ColumnMetadata(col_type=AnnotationType.text),
+            "label": ColumnMetadata(col_type=AnnotationType.text),
+            "ModelID": ColumnMetadata(
+                col_type=AnnotationType.text, references="test-model"
+            ),
+        },
+        data_df=pd.DataFrame(
+            {
+                "ID": ["SCREEN_1", "SCREEN_2", "SCREEN_3"],
+                "label": ["Screen 1", "Screen 2", "Screen 3"],
+                "ModelID": ["MODEL_A", "MODEL_B", "MODEL_C"],
+            }
+        ),
+    )
+
+    factories.tabular_dataset(
+        minimal_db,
+        settings,
+        given_id="test-screen-pair-metadata",
+        index_type_name="test-screen-pair",
+        columns_metadata={
+            "ID": ColumnMetadata(col_type=AnnotationType.text),
+            "label": ColumnMetadata(col_type=AnnotationType.text),
+            "ScreenID": ColumnMetadata(
+                col_type=AnnotationType.text, references="test-screen"
+            ),
+        },
+        data_df=pd.DataFrame(
+            {
+                "ID": ["PAIR_X", "PAIR_Y", "PAIR_Z"],
+                "label": ["Pair X", "Pair Y", "Pair Z"],
+                "ScreenID": ["SCREEN_1", "SCREEN_2", "SCREEN_3"],
+            }
+        ),
+    )
+
+    return {
+        "model": "test-model-metadata",
+        "screen": "test-screen-metadata",
+        "screen_pair": "test-screen-pair-metadata",
+    }
+
+
+def test_single_hop_reindex(minimal_db: SessionWithUser, settings):
+    """
+    screen → model: load Lineage from model metadata, indexed by screen IDs.
+    """
+    ds_ids = _setup_chained_dimension_types(minimal_db, settings)
+
+    query = SliceQuery(
+        dataset_id=ds_ids["model"],
+        identifier="Lineage",
+        identifier_type="column",
+        reindex_through=SliceQuery(
+            dataset_id=ds_ids["screen"], identifier="ModelID", identifier_type="column",
+        ),
+    )
+    result = get_slice_data(minimal_db, settings.filestore_location, query)
+
+    # Result should be indexed by screen IDs, with model Lineage values
+    assert set(result.index.tolist()) == {"SCREEN_1", "SCREEN_2", "SCREEN_3"}
+    assert result["SCREEN_1"] == "Breast"
+    assert result["SCREEN_2"] == "Lung"
+    assert result["SCREEN_3"] == "Skin"
+
+
+def test_two_hop_reindex(minimal_db: SessionWithUser, settings):
+    """
+    screen_pair → screen → model: load Lineage from model metadata,
+    indexed by screen_pair IDs.
+    """
+    ds_ids = _setup_chained_dimension_types(minimal_db, settings)
+
+    query = SliceQuery(
+        dataset_id=ds_ids["model"],
+        identifier="Lineage",
+        identifier_type="column",
+        reindex_through=SliceQuery(
+            dataset_id=ds_ids["screen"],
+            identifier="ModelID",
+            identifier_type="column",
+            reindex_through=SliceQuery(
+                dataset_id=ds_ids["screen_pair"],
+                identifier="ScreenID",
+                identifier_type="column",
+            ),
+        ),
+    )
+    result = get_slice_data(minimal_db, settings.filestore_location, query)
+
+    # Result should be indexed by screen_pair IDs
+    assert set(result.index.tolist()) == {"PAIR_X", "PAIR_Y", "PAIR_Z"}
+    assert result["PAIR_X"] == "Breast"  # PAIR_X → SCREEN_1 → MODEL_A → Breast
+    assert result["PAIR_Y"] == "Lung"  # PAIR_Y → SCREEN_2 → MODEL_B → Lung
+    assert result["PAIR_Z"] == "Skin"  # PAIR_Z → SCREEN_3 → MODEL_C → Skin
+
+
+def test_reindex_with_missing_fk_values(minimal_db: SessionWithUser, settings):
+    """
+    When an FK column has a value that doesn't match any entity in the target,
+    that entry should be dropped (NaN propagation via map + dropna).
+    """
+    user = settings.admin_users[0]
+
+    factories.add_dimension_type(
+        minimal_db,
+        settings,
+        user=user,
+        name="target-type",
+        display_name="Target",
+        id_column="ID",
+        annotation_type_mapping={
+            "ID": AnnotationType.text,
+            "label": AnnotationType.text,
+            "Value": AnnotationType.text,
+        },
+        axis="sample",
+        metadata_df=pd.DataFrame(
+            {
+                "ID": ["T1", "T2"],
+                "label": ["Target 1", "Target 2"],
+                "Value": ["val1", "val2"],
+            }
+        ),
+    )
+
+    factories.add_dimension_type(
+        minimal_db,
+        settings,
+        user=user,
+        name="source-type",
+        display_name="Source",
+        id_column="ID",
+        annotation_type_mapping={
+            "ID": AnnotationType.text,
+            "label": AnnotationType.text,
+            "TargetID": AnnotationType.text,
+        },
+        axis="sample",
+        metadata_df=pd.DataFrame(
+            {
+                "ID": ["S1", "S2", "S3"],
+                "label": ["Source 1", "Source 2", "Source 3"],
+                "TargetID": ["T1", "NONEXISTENT", "T2"],
+            }
+        ),
+    )
+
+    factories.tabular_dataset(
+        minimal_db,
+        settings,
+        given_id="target-metadata",
+        index_type_name="target-type",
+        columns_metadata={
+            "ID": ColumnMetadata(col_type=AnnotationType.text),
+            "label": ColumnMetadata(col_type=AnnotationType.text),
+            "Value": ColumnMetadata(col_type=AnnotationType.text),
+        },
+        data_df=pd.DataFrame(
+            {
+                "ID": ["T1", "T2"],
+                "label": ["Target 1", "Target 2"],
+                "Value": ["val1", "val2"],
+            }
+        ),
+    )
+
+    factories.tabular_dataset(
+        minimal_db,
+        settings,
+        given_id="source-metadata",
+        index_type_name="source-type",
+        columns_metadata={
+            "ID": ColumnMetadata(col_type=AnnotationType.text),
+            "label": ColumnMetadata(col_type=AnnotationType.text),
+            "TargetID": ColumnMetadata(
+                col_type=AnnotationType.text, references="target-type"
+            ),
+        },
+        data_df=pd.DataFrame(
+            {
+                "ID": ["S1", "S2", "S3"],
+                "label": ["Source 1", "Source 2", "Source 3"],
+                "TargetID": ["T1", "NONEXISTENT", "T2"],
+            }
+        ),
+    )
+
+    query = SliceQuery(
+        dataset_id="target-metadata",
+        identifier="Value",
+        identifier_type="column",
+        reindex_through=SliceQuery(
+            dataset_id="source-metadata",
+            identifier="TargetID",
+            identifier_type="column",
+        ),
+    )
+    result = get_slice_data(minimal_db, settings.filestore_location, query)
+
+    # S2 pointed to NONEXISTENT which isn't in target, so it's dropped
+    assert set(result.index.tolist()) == {"S1", "S3"}
+    assert result["S1"] == "val1"
+    assert result["S3"] == "val2"


### PR DESCRIPTION
Extends `SliceQuery` with an optional `reindex_through` field that describes a chain of FK joins needed to reach data from a different index type. The chain nests leaf-outward: the outermost query is the data column, each `reindex_through` level is one step closer to the caller's index type.

## Changes

- **`depmap_compute_embed/slice.py`**: adds `reindex_through: Optional["SliceQuery"] = None` to the dataclass.
- **`service/slice.py`**: adds `_flatten_reindex_chain` (with cycle detection keyed on `(dataset_id, identifier)` and a max depth of 10) and `_resolve_reindex_chain`. `get_slice_data` now walks the chain and composes the FK joins into a single Series indexed by the root entity type.
- **`schemas/context.py`**: adds the `SliceQueryRef` Pydantic model (used by the endpoint below). Deliberately scoped to just the class — `Context.vars` retains its current type, `contexts` field is not added.
- **`api/datasets.py`**: `get_dimension_data` accepts an optional `reindex_through` body param typed as `SliceQueryRef`. Helpers `_to_internal_slice_query` and `_get_root_query` handle conversion and label lookup. Label resolution uses the root query so chained results get labels for the root's dimension type.
- **`depmap_compute_embed/context.py`**: adds the `_dict_to_slice_query` recursive helper and wires it into `_JsonLogicVarLookup.__getitem__` so context vars with `reindex_through` are passed through to `get_slice_data`.
- Tests added in `tests/service/test_slice.py` (chain validation, cycle detection, depth limit, single/two-hop integration, missing FK values) and `tests/depmap_compute_embed/test_context.py` (three passthrough tests).

## How to test

```
pytest breadbox/tests/service/test_slice.py breadbox/tests/depmap_compute_embed/test_context.py
```

## Notes

Frontend counterparts (`AnnotationSelectV2`, `SliceTable`) live on a separate branch and will get their own PRs after this stack lands.