### PR TITLE
ensure embedded plots can be served behind a proxy

### DIFF
--- a/frontend/packages/@depmap/api/src/breadboxAPI/client.ts
+++ b/frontend/packages/@depmap/api/src/breadboxAPI/client.ts
@@ -1,4 +1,4 @@
-import { getUrlPrefix, isElara } from "@depmap/globals";
+import { getUrlPrefix, isPortal } from "@depmap/globals";
 import createJsonClient from "../createJsonClient";
 
 const {
@@ -8,7 +8,7 @@ const {
   deleteJson,
   postMultipart,
   patchMultipart,
-} = createJsonClient(`${getUrlPrefix()}${isElara ? "" : "/breadbox"}`);
+} = createJsonClient(`${getUrlPrefix()}${isPortal ? "/breadbox" : ""}`);
 
 export {
   getJson,

--- a/frontend/packages/@depmap/api/src/deprecatedBreadboxAPI.ts
+++ b/frontend/packages/@depmap/api/src/deprecatedBreadboxAPI.ts
@@ -1,4 +1,4 @@
-import { getUrlPrefix, isElara } from "@depmap/globals";
+import { getUrlPrefix, isPortal } from "@depmap/globals";
 import {
   FeatureType,
   FeatureTypeUpdateArgs,
@@ -8,7 +8,7 @@ import {
 import createJsonClient from "./createJsonClient";
 
 const { getJson, deleteJson, patchMultipart, postMultipart } = createJsonClient(
-  `${getUrlPrefix()}${isElara ? "" : "/breadbox"}`
+  `${getUrlPrefix()}${isPortal ? "/breadbox" : ""}`
 );
 
 function getSampleTypes() {

--- a/frontend/packages/@depmap/api/src/legacyPortalAPI/client.ts
+++ b/frontend/packages/@depmap/api/src/legacyPortalAPI/client.ts
@@ -1,4 +1,4 @@
-import { getUrlPrefix, isElara } from "@depmap/globals";
+import { getUrlPrefix, isPortal } from "@depmap/globals";
 import createJsonClient from "../createJsonClient";
 
 const createAutoFailClient = () => {
@@ -45,7 +45,7 @@ const {
   deleteJson,
   postMultipart,
   patchMultipart,
-} = isElara ? createAutoFailClient() : createJsonClient(getUrlPrefix());
+} = isPortal ? createJsonClient(getUrlPrefix()) : createAutoFailClient();
 
 export {
   getJson,

--- a/frontend/packages/@depmap/custom-analyses/src/utils/getDataExplorerLink.ts
+++ b/frontend/packages/@depmap/custom-analyses/src/utils/getDataExplorerLink.ts
@@ -1,7 +1,7 @@
 import qs from "qs";
 import { breadboxAPI, cached } from "@depmap/api";
 import { persistContext } from "@depmap/data-explorer-2";
-import { isElara } from "@depmap/globals";
+import { isPortal } from "@depmap/globals";
 import { ComputeResponseResult, DataExplorerContextV2 } from "@depmap/types";
 import {
   AnalysisConfiguration,
@@ -14,7 +14,7 @@ async function getDataExplorerLink(
   result: ComputeResponseResult
 ) {
   const firstFeature = result.data[0].label;
-  const baseUrl = isElara ? "../elara" : "../data_explorer_2";
+  const baseUrl = isPortal ? "../data_explorer_2" : "../elara";
   // Encode the current query string so this analysis can later be reproduced.
   const encodedAnalysis = btoa(window.location.search.slice(1));
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/RightHandSide/useSlicePreview.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/RightHandSide/useSlicePreview.tsx
@@ -5,7 +5,7 @@ import {
   promptForValue,
   PromptComponentProps,
 } from "@depmap/common-components";
-import { isElara, toPortalLink } from "@depmap/globals";
+import { isPortal, toPortalLink } from "@depmap/globals";
 import { SlicePreview } from "@depmap/slice-table";
 import { DataExplorerContextVariable, SliceQuery } from "@depmap/types";
 import { usePlotlyLoader } from "../../../../../../contexts/PlotlyLoaderContext";
@@ -48,7 +48,7 @@ function useSlicePreview({ expr, op, path, variable }: Props) {
   const handleClickShowSlicePreview = useCallback(async () => {
     let nextValue: unknown = expr;
 
-    if (!isElara && isGeneList(variable as SliceQuery)) {
+    if (isPortal && isGeneList(variable as SliceQuery)) {
       openInGeneTea(expr as string[]);
       return;
     }

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/AnalysisResult.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/AnalysisResult.tsx
@@ -5,7 +5,7 @@ import { Button } from "react-bootstrap";
 import { breadboxAPI, cached } from "@depmap/api";
 import { Spinner } from "@depmap/common-components";
 import { CustomAnalysisResult } from "@depmap/compute";
-import { isElara } from "@depmap/globals";
+import { isPortal } from "@depmap/globals";
 import {
   ComputeResponseResult,
   Dataset,
@@ -142,7 +142,9 @@ function AnalysisResult({ plot, dispatch }: Props) {
       );
     }
 
-    const baseUrl = isElara ? "../elara/custom_analysis" : "../custom_analyses";
+    const baseUrl = isPortal
+      ? "../custom_analyses"
+      : "../elara/custom_analysis";
 
     // The Custom Analyses page embeds an encoded version of all its
     // parameters into the query string so it can be easily re-run.

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/StartScreen/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/StartScreen/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { Button } from "react-bootstrap";
-import { isElara } from "@depmap/globals";
+import { isPortal } from "@depmap/globals";
 import { UploadFormat, UserUploadModal } from "@depmap/user-upload";
 import StartScreenExamples from "./StartScreenExamples";
 import styles from "../../styles/DataExplorer2.scss";
@@ -28,7 +28,7 @@ function StartScreen({ tutorialLink }: Props) {
       <div className={styles.startScreenActions}>
         <Button
           href={
-            isElara ? "./custom_analysis" : "../interactive/custom_analysis"
+            isPortal ? "../interactive/custom_analysis" : "./custom_analysis"
           }
           bsStyle="primary"
           rel="noreferrer"
@@ -40,7 +40,7 @@ function StartScreen({ tutorialLink }: Props) {
           Plot from CSV
         </Button>
       </div>
-      {!isElara && (
+      {isPortal && (
         <>
           <h3>Using Data Explorer 2.0</h3>
           <StartScreenExamples />

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerDensity1DPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerDensity1DPlot.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useDataExplorerSettings } from "../../../../contexts/DataExplorerSettingsContext";
-import { isElara } from "@depmap/globals";
+import { isPortal } from "@depmap/globals";
 import SpinnerOverlay from "./SpinnerOverlay";
 import type ExtendedPlotType from "../../ExtendedPlotType";
 import {
@@ -265,7 +265,7 @@ function DataExplorerDensity1DPlot({
               }}
             />
           </StackableSection>
-          {!isElara && plotConfig.index_type === "gene" ? (
+          {isPortal && plotConfig.index_type === "gene" ? (
             <StackableSection
               title="GeneTEA Enriched Terms"
               minHeight={200}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerScatterPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerScatterPlot.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
-import { isElara } from "@depmap/globals";
+import { isPortal } from "@depmap/globals";
 import {
   DataExplorerContextV2,
   DataExplorerPlotConfig,
@@ -273,7 +273,7 @@ function DataExplorerScatterPlot({
               }}
             />
           </StackableSection>
-          {!isElara && plotConfig.index_type === "gene" ? (
+          {isPortal && plotConfig.index_type === "gene" ? (
             <StackableSection
               title="GeneTEA Enriched Terms"
               minHeight={200}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerWaterfallPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerWaterfallPlot.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useDataExplorerSettings } from "../../../../contexts/DataExplorerSettingsContext";
-import { isElara } from "@depmap/globals";
+import { isPortal } from "@depmap/globals";
 import SpinnerOverlay from "./SpinnerOverlay";
 import type ExtendedPlotType from "../../ExtendedPlotType";
 import {
@@ -272,7 +272,7 @@ function DataExplorerWaterfallPlot({
               }}
             />
           </StackableSection>
-          {!isElara && plotConfig.index_type === "gene" ? (
+          {isPortal && plotConfig.index_type === "gene" ? (
             <StackableSection
               title="GeneTEA Enriched Terms"
               minHeight={200}

--- a/frontend/packages/@depmap/data-explorer-2/src/utils/context-storage.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/context-storage.ts
@@ -1,5 +1,5 @@
 import stableStringify from "json-stable-stringify";
-import { getUrlPrefix, isElara } from "@depmap/globals";
+import { getUrlPrefix, isPortal } from "@depmap/globals";
 import { DataExplorerContext, DataExplorerContextV2 } from "@depmap/types";
 import getContextHash from "./get-context-hash";
 
@@ -35,9 +35,9 @@ const fallbackInMemoryCache: Record<
 // implements the same set of endpoints but stores them in its database
 // instead.
 const getCasUrl = () => {
-  return isElara
-    ? `${getUrlPrefix()}/temp/cas`
-    : `${getUrlPrefix()}/breadbox/temp/cas`;
+  return isPortal
+    ? `${getUrlPrefix()}/breadbox/temp/cas`
+    : `${getUrlPrefix()}/temp/cas`;
 };
 
 const getContextUrl = (hash: string) => {

--- a/frontend/packages/@depmap/data-explorer-2/src/utils/context.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/context.ts
@@ -1,5 +1,5 @@
 import { LocalStorageListStore } from "./compatibility/ListStorage";
-import { isElara } from "@depmap/globals";
+import { isPortal } from "@depmap/globals";
 import type {
   DataExplorerContext,
   DataExplorerContextV2,
@@ -30,11 +30,7 @@ export function isNegatedContext(
 }
 
 export const userContextStorageKey = () => {
-  if (isElara) {
-    return "elara_contexts";
-  }
-
-  return "user_contexts";
+  return isPortal ? "user_contexts" : "elara_contexts";
 };
 
 export function loadContextsFromLocalStorage(context_type: string) {
@@ -44,7 +40,7 @@ export function loadContextsFromLocalStorage(context_type: string) {
   // ContextSelector component has smarts that will convert them to proper
   // contexts upon selection. This means they will gradually disappear over
   // time.
-  if (context_type === "depmap_model" && !isElara) {
+  if (context_type === "depmap_model" && isPortal) {
     const store = new LocalStorageListStore();
     store.importFromOldCellLineHighlighterIfExists();
 

--- a/frontend/packages/@depmap/globals/src/globals.ts
+++ b/frontend/packages/@depmap/globals/src/globals.ts
@@ -38,18 +38,28 @@ export const depmapContactUrl: string = (window as any).depmapContactUrl;
 export const enabledFeatures: Record<string, boolean> =
   (window as any).enabledFeatures || makeMockEnabledFeatures();
 
-// Just a convenience function for looking up this flag.
-export const isElara: boolean = Boolean(enabledFeatures.elara);
+export const isPortal: boolean = Boolean(
+  document.getElementById("webpack-config")
+);
 
 export const getUrlPrefix = () => {
   if (process.env.JEST_WORKER_ID) {
     return "";
   }
 
-  if (isElara) {
+  if (enabledFeatures.elara) {
     // Detect when Elara is being served behind the DepMap Portal proxy.
     if (window.location.pathname.includes("/breadbox/elara")) {
       return window.location.pathname.replace(/\/elara\/.*$/, "");
+    }
+
+    return "";
+  }
+
+  if (enabledFeatures.embed) {
+    // Detect when Embed is being served behind the DepMap Portal proxy.
+    if (window.location.pathname.includes("/breadbox/embed")) {
+      return window.location.pathname.replace(/\/embed\/.*$/, "");
     }
 
     return "";
@@ -76,8 +86,8 @@ export const getUrlPrefix = () => {
 };
 
 export function toPortalLink(relativeUrl: string) {
-  if (isElara) {
-    throw new Error("Portal links are not supported in Elara!");
+  if (!isPortal) {
+    throw new Error("Portal links are not supported in this environment!");
   }
 
   const trimmed = relativeUrl.trim().replace(/^\//, "");
@@ -102,7 +112,13 @@ export function toStaticUrl(relativeUrl: string) {
 
   const encodedPath = path.split("/").map(encodeURIComponent).join("/");
   const assetUrl = `${encodedPath}${queryAndFragment || ""}`;
-  const staticFolder = isElara ? "elara/static" : "static";
+  const staticFolder = [
+    enabledFeatures.elara && "elara/",
+    enabledFeatures.embed && "embed/",
+    "static",
+  ]
+    .filter(Boolean)
+    .join("");
 
   return `${encodeURI(getUrlPrefix())}/${staticFolder}/${assetUrl}`;
 }
@@ -163,9 +179,11 @@ export const DepMap =
               `Cannot call \`window.DepMap.${
                 prop as string
               }()\` because that function is not defined. `,
-              isElara &&
+              enabledFeatures.elara &&
                 "Elara only supports a subset of the global DepMap object's properties.",
-              !isElara &&
+              enabledFeatures.embed &&
+                "The embeddable frontend does not support the global DepMap object.",
+              isPortal &&
                 "Only exported functions from " +
                   "frontend/packages/portal-frontend/src/index.tsx " +
                   "are callable.",

--- a/frontend/packages/@depmap/slice-table/src/components/useData.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/useData.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef, useCallback } from "react";
 import { breadboxAPI, cached } from "@depmap/api";
 import { ExternalLink, WordBreaker } from "@depmap/common-components";
-import { isElara, toPortalLink } from "@depmap/globals";
+import { isPortal, toPortalLink } from "@depmap/globals";
 import { serializeSliceQuery } from "@depmap/selects";
 import Papa from "papaparse";
 import type {
@@ -167,7 +167,7 @@ async function extractColumnRenames(
 }
 
 const isLinkable = (dimension_type?: string | null) =>
-  !isElara &&
+  isPortal &&
   dimension_type &&
   ["depmap_model", "gene", "compound_v2"].includes(dimension_type);
 

--- a/frontend/packages/embed-frontend/public/index.html
+++ b/frontend/packages/embed-frontend/public/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <base href="/embed/">
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>DepMap Embed</title>

--- a/frontend/packages/embed-frontend/src/index.tsx
+++ b/frontend/packages/embed-frontend/src/index.tsx
@@ -10,13 +10,22 @@ const EmbeddedPlot = lazy(() => import("./surfaces/EmbeddedPlot"));
 const EmbeddedTable = lazy(() => import("./surfaces/EmbeddedTable"));
 const McpView = lazy(() => import("./surfaces/McpView"));
 
-const BASE = "/embed";
-
 function App() {
   const path = window.location.pathname
     .replace(/\/index\.html$/, "")
     .replace(/\/$/, "");
-  const route = path.startsWith(BASE) ? path.slice(BASE.length) : path;
+
+  // Take everything after the LAST /embed/ segment. The frontend may be
+  // served at any depth depending on proxy configuration:
+  //   /embed/plot                            (local dev)
+  //   /portal/breadbox/embed/plot            (production, behind proxy)
+  //   /my/mock/proxy/embed/plot              (mock proxy for testing)
+  // lastIndexOf is defensive against the unlikely case where some prefix
+  // happens to contain "/embed" itself.
+  const embedIndex = path.lastIndexOf("/embed");
+  const route =
+    embedIndex >= 0 ? path.slice(embedIndex + "/embed".length) : path;
+
   let surface;
 
   switch (route) {
@@ -35,7 +44,8 @@ function App() {
     default:
       return (
         <div style={{ padding: 20 }}>
-          Please specify one of these supported routes:
+          Please specify one of these supported routes after{" "}
+          <code>/embed/</code>:
           <ul>
             <li>/plot</li>
             <li>/table</li>

--- a/frontend/packages/embed-frontend/webpack.common.js
+++ b/frontend/packages/embed-frontend/webpack.common.js
@@ -14,9 +14,7 @@ module.exports = {
       publicPath: "",
     }),
     new webpack.DefinePlugin({
-      // HACK: For now we'll simulate Elara. But there should really
-      // be an `embedded` flag or some such.
-      "window.enabledFeatures": JSON.stringify({ elara: true }),
+      "window.enabledFeatures": JSON.stringify({ embed: true }),
     }),
   ],
 


### PR DESCRIPTION
In production, embedded plots will be served from, for example, depmap.org/portal/breadbox/embed. This makes sure the embedded UI will make requests to Breadbox with the correct URL prefix.