### PR TITLE
Misc Data Explorer bug fixes

### DIFF
--- a/breadbox/breadbox/depmap_compute_embed/context.py
+++ b/breadbox/breadbox/depmap_compute_embed/context.py
@@ -154,7 +154,11 @@ class ContextEvaluator:
         for var_name, raw_query in slice_query_vars.items():
             try:
                 slice_query = _dict_to_slice_query(raw_query)
-                self.slice_data[var_name] = get_slice_data(slice_query).to_dict()
+                series_dict = get_slice_data(slice_query).to_dict()
+                self.slice_data[var_name] = {
+                    k: (None if isinstance(v, list) and len(v) == 0 else v)
+                    for k, v in series_dict.items()
+                }
             except (KeyError, TypeError, ValueError) as e:
                 raise LookupError(e) from e
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/RightHandSide/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/RightHandSide/index.tsx
@@ -51,6 +51,7 @@ function RightHandSide({ op, expr, path, varName, isLoading, domain }: Props) {
         type="button"
         className={styles.unaryOpDetailsButton}
         onClick={handleClickShowSlicePreview}
+        disabled={expr == null}
       >
         see plot
       </button>

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/utils/expressionUtils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/utils/expressionUtils.ts
@@ -40,9 +40,9 @@ export const operatorsByValueType = {
     "is_null",
     "not_null",
   ]),
-  text: new Set(["==", "!=", "in", "!in", "is_null", "not_null"]),
-  categorical: new Set(["==", "!=", "in", "!in", "is_null", "not_null"]),
-  list_strings: new Set(["has_any", "!has_any"]),
+  text: new Set(["==", "!=", "in", "!in", "not_null", "is_null"]),
+  categorical: new Set(["==", "!=", "in", "!in", "not_null", "is_null"]),
+  list_strings: new Set(["has_any", "!has_any", "not_null", "is_null"]),
 };
 
 export type ValueType = keyof typeof operatorsByValueType;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/PlotLegend.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/PlotLegend.tsx
@@ -102,7 +102,7 @@ function SliceDescription({ data }: { data: DataExplorerPlotResponse | null }) {
     return (
       <div className={styles.colorDimensionLabels}>
         <div>{label}</div>
-        {units && <div>{units}</div>}
+        {units && units !== "unitless" && <div>{units}</div>}
         {dataset_label && <div>{dataset_label}</div>}
       </div>
     );

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/computeOptions.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/computeOptions.ts
@@ -534,8 +534,10 @@ export async function computeUnitsOptions(
   }
 
   const sliceAxis =
-    dimensionTypes.find((dt) => dt.name === dimension.slice_type)?.axis ||
-    "sample";
+    dimension.slice_type === null
+      ? "feature"
+      : dimensionTypes.find((dt) => dt.name === dimension.slice_type)?.axis ||
+        "sample";
 
   const unitsOptions = [
     ...new Set(

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/breadboxMethods.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/breadboxMethods.ts
@@ -55,7 +55,15 @@ async function fetchAxisLabel(dimension?: DataExplorerPlotConfigDimension) {
     return d.id === dimension.dataset_id || d.given_id === dimension.dataset_id;
   });
 
-  const units = dataset && "units" in dataset ? dataset.units : "";
+  let units = "";
+
+  if (dataset && "units" in dataset) {
+    units = dataset.units;
+  }
+
+  if (units === "unitless") {
+    units = "";
+  }
 
   if (dimension.axis_type === "raw_slice") {
     return `${context.name} ${units}`;

--- a/frontend/packages/@depmap/data-explorer-2/src/styles/ContextBuilderV2.scss
+++ b/frontend/packages/@depmap/data-explorer-2/src/styles/ContextBuilderV2.scss
@@ -229,6 +229,10 @@
     outline: 5px auto -webkit-focus-ring-color;
     outline-offset: 3px;
   }
+
+  &[disabled] {
+    visibility: hidden;
+  }
 }
 
 .unaryOpDetailsButton {

--- a/frontend/packages/@depmap/data-explorer-2/src/utils/slice-id.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/slice-id.ts
@@ -78,7 +78,7 @@ export function sliceIdToSliceQuery(
       return {
         dataset_id: "depmap_model_metadata",
         identifier_type: "column",
-        identifier: "CellLineName",
+        identifier: "StrippedCellLineName",
       };
 
     case "age_category":

--- a/frontend/packages/@depmap/slice-table/src/components/SlicePreview/index.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/SlicePreview/index.tsx
@@ -119,9 +119,22 @@ function SlicePreview({
   const { idLabel, units, datasetName } = column.meta;
   const isFiltered =
     visibleRowIds !== undefined && scopedData.length < previewData.length;
-  const xAxisTitle =
-    `${idLabel} ${units}<br>${datasetName}` +
-    (isFiltered ? " <i>(filtered rows only)</i>" : "");
+
+  let xAxisTitle = `${idLabel}`;
+
+  if (units && units !== "unitless") {
+    xAxisTitle += ` (${units})`;
+  }
+
+  if (datasetName) {
+    xAxisTitle += `<br>${datasetName}`;
+  } else {
+    xAxisTitle += `<br><br>`;
+  }
+
+  if (isFiltered) {
+    xAxisTitle += " <i>(filtered rows only)</i>";
+  }
 
   return (
     <PlotlyLoaderProvider PlotlyLoader={PlotlyLoader}>

--- a/frontend/packages/@depmap/slice-table/src/components/useData.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/useData.tsx
@@ -4,12 +4,7 @@ import { ExternalLink, WordBreaker } from "@depmap/common-components";
 import { isPortal, toPortalLink } from "@depmap/globals";
 import { serializeSliceQuery } from "@depmap/selects";
 import Papa from "papaparse";
-import type {
-  Dataset,
-  DimensionType,
-  MatrixDataset,
-  SliceQuery,
-} from "@depmap/types";
+import type { Dataset, DimensionType, SliceQuery } from "@depmap/types";
 
 export interface ColumnDisplayOptions {
   header?: ({
@@ -446,11 +441,10 @@ function transformToTableData(
         ? ""
         : dataset.name || "";
 
-    // Find the dataset units (empty for tabular datasets)
     const units =
-      slice.identifier_type === "column"
-        ? ""
-        : (dataset as MatrixDataset).units || "";
+      dataset.format === "matrix_dataset"
+        ? dataset.units
+        : dataset.columns_metadata[slice.identifier]?.units;
 
     const value_type =
       dataset.format === "matrix_dataset"


### PR DESCRIPTION
- Default `sliceAxis` to "feature" when `dimension.slice_type` is null in `computeUnitsOptions`, instead of falling through to "sample".

- Add `is_null` / `not_null` operators for the `list_strings` value type in the Context Builder. Empty lists returned by `get_slice_data` are now coerced to `None` in `ContextEvaluator` so these operators classify rows correctly. The "see plot" preview button is also hidden when no value has been entered yet.

- Fix `SlicePreview` x-axis title: show units on tabular columns, drop the placeholder "unitless" label, and tolerate a missing dataset name. Also corrects the units lookup in `useData` so tabular columns pull from `columns_metadata[identifier].units` rather than always returning an empty string.

- Suppress "unitless" in `PlotLegend` and `fetchAxisLabel` so it no longer surfaces as a visible unit.

- Use `StrippedCellLineName` (not `CellLineName`) when converting legacy contexts to Breadbox-compatible contexts.

Follow-up: axis-label construction is now duplicated across PlotLegend, SlicePreview, and breadboxMethods. Consolidate into a shared utility.