### PR TITLE
Support list-valued FK columns in reindex_through chains

### DIFF
--- a/breadbox/breadbox/depmap_compute_embed/context.py
+++ b/breadbox/breadbox/depmap_compute_embed/context.py
@@ -11,11 +11,45 @@ from typing import Callable
 from breadbox.depmap_compute_embed.slice import SliceQuery
 
 
+def _in_context(a, b):
+    """Membership of a var against the resolved id-list of a context reference.
+
+    Designed for the form
+        { "in_context": [{"var": "x"}, {"context": "<name>"}] }
+    By the time this operator runs, _resolve_context_refs has already replaced
+    the {"context": ...} node with a flat list of matching ids, so `b` is
+    always that list.
+
+    `a` is permissive: it may be a scalar (the var resolved to a single id) or
+    a list (the var resolved to a list of ids via a list_strings column,
+    typically through a reindex_through chain). Returns True iff `a` overlaps
+    `b` — for a scalar `a`, that's `a in b`; for a list `a`, that's set
+    overlap. None and other malformed shapes return False, matching how
+    has_any handles its degenerate cases.
+
+    The {"!in_context": "in_context"} entry in _NEGATED_OPS lets
+    _resolve_complements null-guard the negated form for free.
+    """
+    if not isinstance(b, list):
+        return False
+    if isinstance(a, list):
+        return not set(a).isdisjoint(set(b))
+    if a is None:
+        return False
+    return a in b
+
+
 # Custom JsonLogic operators
 operations.update(
     {
         # a more convenient version of { "!": { "in": [...] } }
         "!in": lambda a, b: not operations["in"](a, b),
+        # Membership against a resolved context's id-list. Permissive on the
+        # LHS: scalar vars and list-valued vars (e.g. from a list_strings
+        # column traversed via reindex_through) are both accepted, with set
+        # overlap semantics in the list case. See _in_context for the contract.
+        "in_context": _in_context,
+        "!in_context": lambda a, b: not operations["in_context"](a, b),
         # tests if list `a` overlaps with list `b`
         "has_any": (
             lambda a, b: not set(a).isdisjoint(set(b))
@@ -32,10 +66,11 @@ operations.update(
         # way of matching null values through negated operators.
         "is_null": lambda a: a is None,
         "not_null": lambda a: a is not None,
-        # Note: When used with {"var": ...} references, !in, !has_any, and !=
-        # are desugared by _resolve_complements into null-guarded negations
-        # during ContextEvaluator.__init__. This prevents null values from being
-        # incorrectly matched (e.g. null !in ["a", "b"] would otherwise be True).
+        # Note: When used with {"var": ...} references, !in, !has_any,
+        # !in_context, and != are desugared by _resolve_complements into
+        # null-guarded negations during ContextEvaluator.__init__. This
+        # prevents null values from being incorrectly matched (e.g.
+        # null !in ["a", "b"] would otherwise be True).
         #
         # Note: "complement" is not an operator users write directly — it is
         # synthesized by the UI when a user selects the "NOT My Context" version
@@ -301,7 +336,12 @@ def _validate_var_refs(expr, slice_data: dict):
 # Negated operators that should be desugared into null-guarded negations.
 # This prevents null values from being incorrectly matched by negated operators
 # (e.g. null !in ["Breast", "Lung"] would otherwise evaluate to True).
-_NEGATED_OPS = {"!in": "in", "!has_any": "has_any", "!=": "=="}
+_NEGATED_OPS = {
+    "!in": "in",
+    "!in_context": "in_context",
+    "!has_any": "has_any",
+    "!=": "==",
+}
 
 
 # is_null is the only operator whose correct behavior on null is to return

--- a/breadbox/breadbox/service/slice.py
+++ b/breadbox/breadbox/service/slice.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List
+from typing import List, cast
 from logging import getLogger
 
 import pandas as pd
@@ -118,6 +118,64 @@ def _flatten_reindex_chain(leaf: SliceQuery) -> List[SliceQuery]:
     return chain
 
 
+def _chain_step(current: pd.Series, next_series: pd.Series) -> pd.Series:
+    """
+    Apply one hop of a reindex_through chain.
+
+    For each cell in `current`, treat the cell's value(s) as keys into
+    `next_series` and collect the resolved values. Handles list-valued
+    cells on either side of the join:
+
+      - If a cell in `current` is a list (e.g. an FK column like
+        antibody_v2_metadata.target_entrez_id storing a list of entrez
+        IDs per row), the lookup fans out over the list elements.
+      - If `next_series[k]` is itself a list, its elements are spliced
+        into the result.
+      - Duplicates are removed in first-occurrence order so the result
+        is stable for downstream rendering (e.g. SliceTable's join(", ")).
+
+    The output cell shape is determined per cell:
+
+      - If the input cell was a list OR any lookup yielded a list, the
+        output cell is a list (`list_strings`-shaped). Empty results
+        collapse to `None` so the caller's `dropna()` removes them.
+      - Otherwise the output is a scalar, preserving the pre-list-aware
+        behavior for fully-scalar chains.
+
+    `next_series` is materialized to a dict once per hop so lookups
+    don't depend on pandas' duplicate-index semantics, and so list cells
+    in the input never reach pandas as unhashable keys.
+    """
+    next_lookup = next_series.to_dict()
+
+    def step(cell):
+        produced_list = isinstance(cell, list)
+        keys = cell if produced_list else [cell]
+        collected: list = []
+        seen: set = set()
+        for k in keys:
+            if k is None:
+                continue
+            v = next_lookup.get(k)
+            if v is None:
+                continue
+            if isinstance(v, list):
+                produced_list = True
+                items = v
+            else:
+                items = [v]
+            for item in items:
+                if item is None or item in seen:
+                    continue
+                seen.add(item)
+                collected.append(item)
+        if produced_list:
+            return collected if collected else None
+        return collected[0] if collected else None
+
+    return cast(pd.Series, current.apply(step))
+
+
 def _resolve_reindex_chain(
     db: SessionWithUser, filestore_location: str, slice_query: SliceQuery
 ) -> pd.Series:
@@ -167,10 +225,14 @@ def _resolve_reindex_chain(
             log.warning(message, exc_info=True)
             raise UserError(message) from e
     # Compose: root maps root_ids → step1_ids, step1 maps step1_ids → step2_ids, etc.
-    # The leaf maps final_ids → values. Chaining .map() yields root_ids → values.
+    # The leaf maps final_ids → values. Chaining yields root_ids → values.
+    # _chain_step (instead of Series.map) is what makes this work for
+    # list-valued FK columns: a cell holding e.g. ["207", "208", "10000"]
+    # fans out into three lookups in the next hop and the deduplicated
+    # results are collected back into a list. See _chain_step for details.
     result = series_chain[0]
     for next_series in series_chain[1:]:
-        result = result.map(next_series)
+        result = _chain_step(result, next_series)
 
     return result.dropna()
 

--- a/breadbox/tests/depmap_compute_embed/test_context.py
+++ b/breadbox/tests/depmap_compute_embed/test_context.py
@@ -121,6 +121,51 @@ def test_operator__not_has_any_with_none():
     assert expressions_are_equivalent(True, {"!has_any": [None, None]},)
 
 
+def test_operator__in_context():
+    """in_context: list LHS overlaps with the resolved id-list on the RHS.
+    By the time the operator runs, _resolve_context_refs has replaced the
+    {"context": ...} reference with a flat list of ids, so b is always a list."""
+    # No overlap
+    assert expressions_are_equivalent(False, {"in_context": [["a", "b"], ["c", "d"]]},)
+    # Overlap on at least one element (has_any semantics)
+    assert expressions_are_equivalent(True, {"in_context": [["a", "b"], ["b", "c"]]},)
+    # Single-element list LHS — the common case after a single-target FK
+    assert expressions_are_equivalent(True, {"in_context": [["a"], ["a", "b"]]},)
+    # Empty LHS list
+    assert expressions_are_equivalent(False, {"in_context": [[], ["a", "b"]]},)
+    # Empty RHS list (e.g. inner context resolved to no matches)
+    assert expressions_are_equivalent(False, {"in_context": [["a", "b"], []]},)
+
+
+def test_operator__in_context_permissive_scalar_lhs():
+    """in_context accepts a scalar LHS as a 1-element membership check.
+    This matters because a {"var": ...} reference may resolve to either a
+    scalar (single-valued FK) or a list (list_strings column traversed via
+    reindex_through), and the UI authors the same expression in both cases."""
+    # Scalar in RHS list
+    assert expressions_are_equivalent(True, {"in_context": ["a", ["a", "b"]]},)
+    # Scalar not in RHS list
+    assert expressions_are_equivalent(False, {"in_context": ["z", ["a", "b"]]},)
+    # Scalar against empty RHS
+    assert expressions_are_equivalent(False, {"in_context": ["a", []]},)
+
+
+def test_operator__in_context_with_none():
+    """None LHS returns False, matching how has_any handles a None operand —
+    null entities are excluded from the positive group."""
+    assert expressions_are_equivalent(False, {"in_context": [None, ["a", "b"]]},)
+    assert expressions_are_equivalent(False, {"in_context": [None, []]},)
+
+
+def test_operator__in_context_with_malformed_rhs():
+    """Defensive: a non-list RHS returns False. In normal operation
+    _resolve_context_refs always produces a list, but the operator
+    shouldn't crash if something else slips through."""
+    assert expressions_are_equivalent(False, {"in_context": ["a", "a"]},)
+    assert expressions_are_equivalent(False, {"in_context": ["a", None]},)
+    assert expressions_are_equivalent(False, {"in_context": [["a"], "a"]},)
+
+
 def test_comparison_operators_with_none():
     """Standard comparison operators should handle None gracefully."""
     assert expressions_are_equivalent(True, {"!=": [None, "foo"]},)
@@ -741,3 +786,145 @@ def test_nested_context_ref_with_complement_in_inner():
     # preserved through the nested context reference. PAIR_X is excluded
     # because SOME_OTHER_GENE_NOT_IN_TABLE isn't a member of any gene group.
     assert result.ids == ["PAIR_N"]
+
+
+def test_in_context_with_list_valued_var():
+    """End-to-end: an outer context whose var resolves to a list (e.g. via a
+    list_strings FK column traversed through reindex_through) using in_context
+    to test overlap with an inner context's resolved id-list. This is the
+    motivating antibody → gene case: antibody_v2_metadata.target_entrez_id
+    holds a list of gene IDs per antibody, and the inner context filters genes
+    to a flat id-list. An antibody matches if any of its targets is in the
+    resolved set."""
+    context = {
+        "dimension_type": "antibody",
+        "expr": {"in_context": [{"var": "targets"}, {"context": "interesting_genes"}]},
+        "vars": {
+            "targets": {
+                "dataset_id": "antibody_meta",
+                "identifier": "target_gene_ids",
+                "identifier_type": "column",
+            }
+        },
+        "contexts": {
+            "interesting_genes": {
+                "dimension_type": "gene",
+                "expr": {"==": [{"var": "0"}, "interesting"]},
+                "vars": {
+                    "0": {
+                        "dataset_id": "gene_meta",
+                        "identifier": "annotation",
+                        "identifier_type": "column",
+                    }
+                },
+            }
+        },
+    }
+
+    # Antibody targets — list-shaped values, as produced by _chain_step when
+    # reindex_through traverses a list_strings column.
+    target_genes = pd.Series(
+        {
+            "AB_HIT_MULTI": ["GENE_X", "GENE_Y", "GENE_INT_1"],  # 1 of 3 matches
+            "AB_HIT_SINGLE": ["GENE_INT_2"],  # single-element matches
+            "AB_MISS": ["GENE_X", "GENE_Y"],  # no overlap
+            # AB_NULL has no entry: var resolves to None, excluded
+        }
+    )
+    gene_annotations = pd.Series(
+        {
+            "GENE_INT_1": "interesting",
+            "GENE_INT_2": "interesting",
+            "GENE_X": "boring",
+            "GENE_Y": "boring",
+        }
+    )
+
+    slice_data = {
+        ("antibody_meta", "target_gene_ids"): target_genes,
+        ("gene_meta", "annotation"): gene_annotations,
+    }
+
+    def get_slice_data(q):
+        return slice_data[(q.dataset_id, q.identifier)]
+
+    def get_labels(dim_type):
+        if dim_type == "antibody":
+            return {
+                "AB_HIT_MULTI": "Multi-target Hit",
+                "AB_HIT_SINGLE": "Single-target Hit",
+                "AB_MISS": "No Hit",
+                "AB_NULL": "No Targets",
+            }
+        if dim_type == "gene":
+            return {
+                "GENE_INT_1": "Gene Int 1",
+                "GENE_INT_2": "Gene Int 2",
+                "GENE_X": "Gene X",
+                "GENE_Y": "Gene Y",
+            }
+        raise ValueError(f"unexpected dim_type {dim_type!r}")
+
+    evaluator = ContextEvaluator(context, get_slice_data, get_labels)
+    result = evaluator.evaluate()
+
+    # AB_HIT_MULTI: targets overlap [GENE_INT_1, GENE_INT_2] on GENE_INT_1 -> match
+    # AB_HIT_SINGLE: targets overlap on GENE_INT_2 -> match
+    # AB_MISS: no overlap -> excluded
+    # AB_NULL: var is null -> excluded (the operator returns False on None LHS)
+    assert sorted(result.ids) == ["AB_HIT_MULTI", "AB_HIT_SINGLE"]
+
+
+def test_in_context_with_scalar_var():
+    """End-to-end with a scalar var — the legacy case where the FK column is
+    a single-valued reference (e.g. screen_metadata.ModelID). Same code path
+    as the list-var case but exercises the operator's permissive scalar LHS."""
+    context = {
+        "dimension_type": "screen",
+        "expr": {"in_context": [{"var": "model"}, {"context": "breast_models"}]},
+        "vars": {
+            "model": {
+                "dataset_id": "screen_meta",
+                "identifier": "ModelID",
+                "identifier_type": "column",
+            }
+        },
+        "contexts": {
+            "breast_models": {
+                "dimension_type": "model",
+                "expr": {"==": [{"var": "0"}, "Breast"]},
+                "vars": {
+                    "0": {
+                        "dataset_id": "model_meta",
+                        "identifier": "Lineage",
+                        "identifier_type": "column",
+                    }
+                },
+            }
+        },
+    }
+
+    screen_models = pd.Series(
+        {"SCREEN_BREAST": "MODEL_BREAST", "SCREEN_LUNG": "MODEL_LUNG"}
+    )
+    model_lineages = pd.Series({"MODEL_BREAST": "Breast", "MODEL_LUNG": "Lung"})
+
+    slice_data = {
+        ("screen_meta", "ModelID"): screen_models,
+        ("model_meta", "Lineage"): model_lineages,
+    }
+
+    def get_slice_data(q):
+        return slice_data[(q.dataset_id, q.identifier)]
+
+    def get_labels(dim_type):
+        if dim_type == "screen":
+            return {"SCREEN_BREAST": "Breast Screen", "SCREEN_LUNG": "Lung Screen"}
+        if dim_type == "model":
+            return {"MODEL_BREAST": "Breast Model", "MODEL_LUNG": "Lung Model"}
+        raise ValueError(f"unexpected dim_type {dim_type!r}")
+
+    evaluator = ContextEvaluator(context, get_slice_data, get_labels)
+    result = evaluator.evaluate()
+
+    assert result.ids == ["SCREEN_BREAST"]

--- a/breadbox/tests/service/test_slice.py
+++ b/breadbox/tests/service/test_slice.py
@@ -7,6 +7,7 @@ from breadbox.service.slice import (
     get_slice_data,
     _flatten_reindex_chain,
     _resolve_reindex_chain,
+    _chain_step,
 )
 from breadbox.models.dataset import AnnotationType
 from breadbox.schemas.dataset import ColumnMetadata
@@ -313,6 +314,104 @@ def test_resolve_allows_non_column_leaf():
             cast(SessionWithUser, None), cast(str, None), leaf,
         )
     assert "identifier_type 'column'" not in str(exc_info.value)
+
+
+# ============================================================
+# Unit tests for _chain_step
+# ============================================================
+
+
+def test_chain_step_scalar_chain():
+    """Fully scalar chain: output stays scalar (parity with the old .map() behavior)."""
+    current = pd.Series({"a": "x", "b": "y", "c": "z"})
+    nxt = pd.Series({"x": 1, "y": 2, "z": 3})
+
+    result = _chain_step(current, nxt)
+
+    assert result["a"] == 1
+    assert result["b"] == 2
+    assert result["c"] == 3
+    assert all(not isinstance(v, list) for v in result.dropna())
+
+
+def test_chain_step_list_valued_fk_dedupes_and_preserves_order():
+    """List-valued FK cells fan out, results dedup in first-occurrence order."""
+    current = pd.Series(
+        {
+            "Akt": [
+                "207",
+                "208",
+                "10000",
+            ],  # multi-element, two distinct arms after dedup
+            "ACC": ["31", "32"],  # multi-element, both map to the same arm
+            "single": ["7529"],  # single-element list — stays a list
+        }
+    )
+    nxt = pd.Series(
+        {
+            "207": "14q",
+            "208": "14q",  # same as 207, expect dedup
+            "10000": "10q",
+            "31": "1p",
+            "32": "1p",  # same as 31, expect dedup
+            "7529": "20p",
+        }
+    )
+
+    result = _chain_step(current, nxt)
+
+    # Order tracks input list order; duplicates collapse.
+    assert result["Akt"] == ["14q", "10q"]
+    assert result["ACC"] == ["1p"]
+    # Single-element lists stay lists (type stability across the column).
+    assert result["single"] == ["20p"]
+
+
+def test_chain_step_drops_empty_and_all_miss_lists():
+    """Empty list and all-elements-miss cells become None so dropna() removes them."""
+    current = pd.Series(
+        {
+            "empty": [],
+            "all_miss": ["nope1", "nope2"],
+            "partial": ["207", "nope"],  # one matching element, one missing
+        }
+    )
+    nxt = pd.Series({"207": "14q"})
+
+    result = _chain_step(current, nxt).dropna()
+
+    assert "empty" not in result.index
+    assert "all_miss" not in result.index
+    # Missing elements within an otherwise-matching list are silently skipped.
+    assert result["partial"] == ["14q"]
+
+
+def test_chain_step_list_valued_leaf_upgrades_scalar_input():
+    """Scalar input + list-valued lookup → list-valued output cell."""
+    current = pd.Series({"sp1": "g1", "sp2": "g2"})
+    nxt = pd.Series({"g1": ["AKT1", "PKB"], "g2": ["TP53"]})
+
+    result = _chain_step(current, nxt)
+
+    # Lookup-yielded list propagates; the output column is uniformly list-shaped.
+    assert result["sp1"] == ["AKT1", "PKB"]
+    assert result["sp2"] == ["TP53"]
+
+
+def test_chain_step_chained_list_propagation():
+    """Two consecutive _chain_step calls: list shape propagates through both hops."""
+    # Hop 1: list FK → scalar lookup yields a list of clusters.
+    antibody_fk = pd.Series(
+        {"Akt": ["207", "208", "10000"]}  # three targets across two clusters
+    )
+    gene_to_cluster = pd.Series({"207": "C1", "208": "C1", "10000": "C2"})
+    mid = _chain_step(antibody_fk, gene_to_cluster)
+    assert mid["Akt"] == ["C1", "C2"]  # dedup at hop 1
+
+    # Hop 2: list (from hop 1) → scalar lookup yields a list of cluster labels.
+    cluster_to_label = pd.Series({"C1": "PI3K_pathway", "C2": "AKT3_specific"})
+    final = _chain_step(mid, cluster_to_label)
+    assert final["Akt"] == ["PI3K_pathway", "AKT3_specific"]
 
 
 # ============================================================
@@ -630,3 +729,130 @@ def test_reindex_with_missing_fk_values(minimal_db: SessionWithUser, settings):
     assert set(result.index.tolist()) == {"S1", "S3"}
     assert result["S1"] == "val1"
     assert result["S3"] == "val2"
+
+
+def test_reindex_with_list_valued_fk(minimal_db: SessionWithUser, settings):
+    """
+    End-to-end: when a reindex_through hop uses a list_strings FK column
+    (e.g. antibody_v2_metadata.target_entrez_id storing a list of entrez
+    IDs per row), the chain fans out the lookup over each list element,
+    deduplicates the collected results, and yields a list_strings-shaped
+    output column. The cell values in `data_df` for a list_strings column
+    are JSON-encoded strings; they are decoded into Python lists by the
+    storage read path (see _convert_subsetted_tabular_df_dtypes).
+    """
+    user = settings.admin_users[0]
+
+    # Target dimension: gene-like, with a categorical "Arm" column that
+    # the chain will ultimately deliver indexed by antibodies.
+    factories.add_dimension_type(
+        minimal_db,
+        settings,
+        user=user,
+        name="gene-like",
+        display_name="Gene Like",
+        id_column="ID",
+        annotation_type_mapping={
+            "ID": AnnotationType.text,
+            "label": AnnotationType.text,
+            "Arm": AnnotationType.text,
+        },
+        axis="sample",
+        metadata_df=pd.DataFrame(
+            {
+                "ID": ["G1", "G2", "G3", "G4"],
+                "label": ["Gene 1", "Gene 2", "Gene 3", "Gene 4"],
+                "Arm": ["14q", "14q", "10q", "20p"],
+            }
+        ),
+    )
+
+    # Source dimension: antibody-like, with a list_strings FK column
+    # pointing at gene-like. JSON-encoded list cells emulate how
+    # list_strings columns are actually stored on disk.
+    factories.add_dimension_type(
+        minimal_db,
+        settings,
+        user=user,
+        name="antibody-like",
+        display_name="Antibody Like",
+        id_column="ID",
+        annotation_type_mapping={
+            "ID": AnnotationType.text,
+            "label": AnnotationType.text,
+            "TargetIDs": AnnotationType.list_strings,
+        },
+        axis="sample",
+        metadata_df=pd.DataFrame(
+            {
+                "ID": ["AB1", "AB2", "AB3"],
+                "label": ["Antibody 1", "Antibody 2", "Antibody 3"],
+                "TargetIDs": [
+                    '["G1", "G2", "G3"]',  # 3 targets → 2 distinct arms (14q, 10q)
+                    '["G1"]',  # single-element list — common case
+                    '["G3", "G4"]',  # 2 targets → 2 distinct arms (10q, 20p)
+                ],
+            }
+        ),
+    )
+
+    factories.tabular_dataset(
+        minimal_db,
+        settings,
+        given_id="gene-like-metadata",
+        index_type_name="gene-like",
+        columns_metadata={
+            "ID": ColumnMetadata(col_type=AnnotationType.text),
+            "label": ColumnMetadata(col_type=AnnotationType.text),
+            "Arm": ColumnMetadata(col_type=AnnotationType.text),
+        },
+        data_df=pd.DataFrame(
+            {
+                "ID": ["G1", "G2", "G3", "G4"],
+                "label": ["Gene 1", "Gene 2", "Gene 3", "Gene 4"],
+                "Arm": ["14q", "14q", "10q", "20p"],
+            }
+        ),
+    )
+
+    factories.tabular_dataset(
+        minimal_db,
+        settings,
+        given_id="antibody-like-metadata",
+        index_type_name="antibody-like",
+        columns_metadata={
+            "ID": ColumnMetadata(col_type=AnnotationType.text),
+            "label": ColumnMetadata(col_type=AnnotationType.text),
+            "TargetIDs": ColumnMetadata(
+                col_type=AnnotationType.list_strings, references="gene-like"
+            ),
+        },
+        data_df=pd.DataFrame(
+            {
+                "ID": ["AB1", "AB2", "AB3"],
+                "label": ["Antibody 1", "Antibody 2", "Antibody 3"],
+                "TargetIDs": ['["G1", "G2", "G3"]', '["G1"]', '["G3", "G4"]',],
+            }
+        ),
+    )
+
+    query = SliceQuery(
+        dataset_id="gene-like-metadata",
+        identifier="Arm",
+        identifier_type="column",
+        reindex_through=SliceQuery(
+            dataset_id="antibody-like-metadata",
+            identifier="TargetIDs",
+            identifier_type="column",
+        ),
+    )
+    result = get_slice_data(minimal_db, settings.filestore_location, query)
+
+    # Result is indexed by antibody IDs:
+    #   AB1: G1=14q, G2=14q, G3=10q → ["14q", "10q"]  (dedup, order-preserving)
+    #   AB2: G1=14q                 → ["14q"]         (single-element stays a list)
+    #   AB3: G3=10q, G4=20p         → ["10q", "20p"]
+    assert set(result.index.tolist()) == {"AB1", "AB2", "AB3"}
+    assert result["AB1"] == ["14q", "10q"]
+    assert result["AB2"] == ["14q"]
+    assert result["AB3"] == ["10q", "20p"]

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/DebugInfo.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/DebugInfo.tsx
@@ -7,8 +7,6 @@ import { dataExplorerAPI } from "../../../services/dataExplorerAPI";
 import { useContextBuilderState } from "../state/ContextBuilderState";
 import styles from "../../../styles/ContextBuilderV2.scss";
 
-const SHOW_DEBUG_INFO = false;
-
 type PartialDeep<T> = { [P in keyof T]?: PartialDeep<T[P]> };
 
 async function copyToClipboard(context: PartialDeep<DataExplorerContextV2>) {
@@ -25,6 +23,7 @@ async function copyToClipboard(context: PartialDeep<DataExplorerContextV2>) {
   }
 }
 
+// press Ctrl+Opt+D to bring up this debug panel
 const DebugInfo = () => {
   const {
     mainExpr,
@@ -123,4 +122,20 @@ const DebugInfo = () => {
   );
 };
 
-export default SHOW_DEBUG_INFO ? DebugInfo : () => null;
+const Wrapper = () => {
+  const [show, setShow] = useState(false);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.altKey && e.code === "KeyD") {
+        setShow((s) => !s);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
+
+  return show ? <DebugInfo /> : null;
+};
+
+export default Wrapper;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/Operator.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/ContextBuilderBody/Expression/RelationalExpression/Operator.tsx
@@ -33,10 +33,16 @@ const buildNextExpression = (
   lhs: RelationExpr[OperatorType][0],
   rhs: RelationExpr[OperatorType][1]
 ) => {
-  // "is in context" — pseudo-operator, emits standard "in"
+  // Membership against a resolved context's id-list. Was previously a
+  // pseudo-operator that flattened to `in` at emission time; in_context is
+  // now a first-class JsonLogic operator on the backend (see
+  // breadbox/depmap_compute_embed/context.py: _in_context).
   if (nextOp === "in_context") {
     return {
-      in: [lhs, isEmbeddedContextExpression(rhs) ? rhs : { context: null }],
+      in_context: [
+        lhs,
+        isEmbeddedContextExpression(rhs) ? rhs : { context: null },
+      ],
     };
   }
 
@@ -134,12 +140,6 @@ function Operator({
     );
   }, [isAllIntegers, isReference, value_type]);
 
-  let value = op as typeof op | "in_context";
-
-  if (op === "in" && isReference) {
-    value = "in_context";
-  }
-
   return (
     <PlotConfigSelect
       show
@@ -152,7 +152,7 @@ function Operator({
         [styles.context]: isReference,
       })}
       placeholder=""
-      value={isLoading ? null : value}
+      value={isLoading ? null : op}
       options={options}
       onChange={(nextOp) => {
         const innerExpr = expr[op];

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/utils/expressionUtils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/utils/expressionUtils.ts
@@ -20,6 +20,9 @@ export const opLabels = {
   has_any: "has any of",
   "!has_any": "has none of",
 
+  // membership against a resolved context's id-list (RHS is a {context} ref)
+  in_context: "is in context",
+
   // unary
   not_null: "has a value",
   is_null: "has no value",
@@ -186,7 +189,7 @@ export const makeCompatibleExpression = (
   }
 
   if (isReference) {
-    nextOp = "in";
+    nextOp = "in_context";
     nextValue = isContextValue ? value : { context: null };
   }
 

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/variables.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/variables.ts
@@ -81,6 +81,20 @@ export async function fetchVariableDomain(
     throw new Error("Error fetching data from slice query");
   }
 
+  // A reindex_through chain that traverses a list-valued column promotes
+  // scalar leaf values into lists per cell (see breadbox _chain_step). The
+  // leaf column's declared col_type doesn't reflect that promotion, so when
+  // we have the actual data in front of us, prefer the observed shape over
+  // the declared type. Only text/categorical leaves get upgraded to
+  // list_strings here — continuous leaves promoted to lists would also need
+  // a list-aware domain-stats branch, which is a larger change out of scope.
+  if (
+    (value_type === "text" || value_type === "categorical") &&
+    data.values.some((v) => Array.isArray(v))
+  ) {
+    value_type = "list_strings" as AnnotationType;
+  }
+
   if (value_type === "text" || value_type === "categorical") {
     const stringValues = data.values.filter(
       (val) => typeof val === "string"


### PR DESCRIPTION
Motivation
----------
Some FK columns store a list of references per row rather than a scalar. The motivating example is antibody_v2_metadata.target_entrez_id, where an antibody like "Akt" targets multiple genes ["207", "208", "10000"]. Before this change, a reindex_through chain that tried to traverse such a column silently dropped every antibody — pandas Series.map() can't use a list as a hashable lookup key — so the antibody → gene → arm chain returned no data, and context-membership filters against multi-target antibodies were impossible to express in the UI.

Backend: _chain_step
--------------------
Replaces the per-hop Series.map() in _resolve_reindex_chain with _chain_step(current, next), which fans out list-valued cells over their elements, deduplicates results in first-occurrence order (so SliceTable's join(", ") output is stable), and decides per cell whether the output should be a list (if the input or any lookup yielded one) or a scalar (the all-scalar fast path is preserved). Empty / all-miss results collapse to None so the existing dropna() removes them.

Backend: in_context operator
----------------------------
A list-valued LHS with standard json_logic `in` evaluates to False because Python's ["207"] in ["790", "207"] checks whether the whole list is an element of the right side, not whether they overlap. Rather than override the standard `in` operator (which would make a core operator behave conditionally on runtime types and introduce a latent crash hazard for unhashable list-of-list cells), this adds a new in_context operator with overlap semantics:

  - RHS is the resolved id-list of a {"context": ...} reference, flattened by _resolve_context_refs before the operator runs.
  - LHS is permissive: scalar (single-valued FK) and list (list_strings column traversed via reindex_through) are both accepted, with set-overlap semantics in the list case and membership in the scalar case.

No !in_context counterpart — null-safe negation has no clean meaning once the context is a flattened id-list. The operator can express "var doesn't overlap with the resolved set" but not "var is in the complement of the context within the dimension scope," and the asymmetry between those would surprise users.

Frontend: emit real in_context
------------------------------
The UI previously had "is in context" as a pseudo-operator that flattened to standard `in` at emission time. Now it emits in_context directly. Adding it to opLabels cascades through supportedOperators / isRelation / getVariableNames and incidentally fixes a var-stripping bug in useMatches where the LHS var was dropped from the request payload because no consumer recognized the new operator. The legacy pseudo-op display fallback is preserved so existing dev contexts saved as `in` still render correctly in the dropdown; no explicit migration pass.

Frontend: variables.ts list-shape detection
-------------------------------------------
fetchVariableDomain reads the leaf column's declared col_type to pick a domain-stats branch. After a reindex_through chain through a list-valued column, the actual cell shape diverges from that metadata: leaf says "text", cells are lists. Detect from the data, not the metadata: if any cell is a list and the declared type is text/categorical, treat as list_strings for the rest of the function. Per-consumer detection rather than backend response promotion preserves the invariant that col_type describes a column's declared type, not chain-output shape — promoting on the backend would silently break any consumer that derives shape from metadata elsewhere.

Tests
-----
test_slice.py: 5 new unit tests for _chain_step + 1 integration test through real list_strings columns via factories.
test_context.py: 4 operator-level tests + 2 end-to-end tests for in_context, covering the antibody (list var) and screen (scalar var) cases. All 30 tests pass; no regressions in the existing 24.

Out of scope
------------
== / != against list-valued vars: UI should steer users toward in_context / has_any.
Frontend test scaffolding for ContextBuilderV2 and services/dataExplorerAPI: those test suites don't exist yet, deferred.