### PR TITLE
Fix AnnotationSelect "Continue to table" for non-primary supplementals

### DIFF
--- a/frontend/packages/@depmap/selects/__mocks__/fileMock.js
+++ b/frontend/packages/@depmap/selects/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = "test-file-stub";

--- a/frontend/packages/@depmap/selects/__mocks__/styleMock.js
+++ b/frontend/packages/@depmap/selects/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/frontend/packages/@depmap/selects/jest-setup.ts
+++ b/frontend/packages/@depmap/selects/jest-setup.ts
@@ -1,0 +1,25 @@
+// https://jestjs.io/docs/en/configuration#setuptestframeworkscriptfile-string
+// according to the docs for setupFiles, this runs before each test file
+
+// https://jestjs.io/docs/en/jest-object.html#jestmockmodulename-factory-options
+// see example creating virtual mocks, to mock modules that don't exist. for us, these are libraries that we pull in via CDNs, e.g. plotly.
+declare const jest: any;
+declare const afterEach: any;
+
+import * as Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+jest.mock(
+  "plotly.js",
+  () => {
+    // virtual mocks modules that don't exist (plotly is pulled in via a CDN). see link to docs above
+  },
+  { virtual: true }
+);
+
+Enzyme.configure({
+  adapter: new Adapter(),
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});

--- a/frontend/packages/@depmap/selects/package.json
+++ b/frontend/packages/@depmap/selects/package.json
@@ -5,7 +5,7 @@
   "types": "index.d.ts",
   "license": "MIT",
   "scripts": {
-    "test": "echo 'no tests to run'"
+    "test": "jest"
   },
   "dependencies": {
     "@depmap/api": "1.0.0",
@@ -21,5 +21,38 @@
   "peerDependencies": {
     "react": "^16.9.35",
     "react-dom": "^16.9.8"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "ts",
+      "tsx"
+    ],
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "diagnostics": false
+        }
+      ]
+    },
+    "transformIgnorePatterns": [
+      "node_modules/(?!depmap-shared)"
+    ],
+    "testRegex": ".*/__tests__/.*test.*\\.(ts|tsx|js)$",
+    "testEnvironment": "jsdom",
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest-setup.ts"
+    ],
+    "setupFiles": [
+      "jest-localstorage-mock"
+    ],
+    "moduleNameMapper": {
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(css|less|scss)$": "<rootDir>/__mocks__/styleMock.js",
+      "@depmap/(.*)/src/(.*)": "<rootDir>/../$1/src/$2",
+      "@depmap/(.*)": "<rootDir>/../$1",
+      "^src/(.*)": "<rootDir>/src/$1"
+    }
   }
 }

--- a/frontend/packages/@depmap/selects/src/components/AnnotationSelect/ChainColumnPicker.tsx
+++ b/frontend/packages/@depmap/selects/src/components/AnnotationSelect/ChainColumnPicker.tsx
@@ -55,6 +55,7 @@ interface SelectedSupplementalTable {
   tableName: string;
   dimType: string;
   dimDisplayName: string;
+  autoPath: ChainHop[];
 }
 
 interface FocusableItem {
@@ -227,6 +228,7 @@ export default function ChainColumnPicker({
 
     return computeLevel(
       currentDimType,
+      index_type,
       tablesByDim,
       dimTypeMap,
       new Set(visited),
@@ -235,6 +237,7 @@ export default function ChainColumnPicker({
   }, [
     selectedSource,
     currentDimType,
+    index_type,
     tablesByDim,
     dimTypeMap,
     visited,
@@ -444,6 +447,7 @@ export default function ChainColumnPicker({
         tableName: st.table.name,
         dimType: st.dimType,
         dimDisplayName: st.dimDisplayName,
+        autoPath: st.autoPath,
       });
       refocusSearch();
     },
@@ -672,9 +676,9 @@ export default function ChainColumnPicker({
   }, []);
 
   const visibleSupplementalTables = useMemo(() => {
-    if (depth === 0 || isInSupplementalTable || !levelResult) return [];
+    if (isInSupplementalTable || !levelResult) return [];
     return levelResult.supplementalTables;
-  }, [depth, isInSupplementalTable, levelResult]);
+  }, [isInSupplementalTable, levelResult]);
 
   // ── Render helpers ──
 

--- a/frontend/packages/@depmap/selects/src/components/AnnotationSelect/__tests__/computeLevel.test.ts
+++ b/frontend/packages/@depmap/selects/src/components/AnnotationSelect/__tests__/computeLevel.test.ts
@@ -1,0 +1,265 @@
+import computeLevel from "../computeLevel";
+import type { DimensionTypeDescriptor, TableDescriptor } from "../types";
+
+const DIM_TYPES: Record<string, DimensionTypeDescriptor> = {
+  gene: {
+    name: "gene",
+    display_name: "Gene",
+    id_column: "entrez_id",
+    axis: "feature",
+    metadata_dataset_id: "gene_metadata_id",
+  },
+  protein: {
+    name: "protein",
+    display_name: "Protein",
+    id_column: "uniprot_id",
+    axis: "feature",
+    metadata_dataset_id: "protein_metadata_id",
+  },
+  antibody: {
+    name: "antibody",
+    display_name: "Antibody",
+    id_column: "antibody_id",
+    axis: "feature",
+    metadata_dataset_id: "antibody_metadata_id",
+  },
+  peptide: {
+    name: "peptide",
+    display_name: "Peptide",
+    id_column: "peptide_id",
+    axis: "feature",
+    metadata_dataset_id: "peptide_metadata_id",
+  },
+  screen: {
+    name: "screen",
+    display_name: "Screen",
+    id_column: "screen_id",
+    axis: "sample",
+    metadata_dataset_id: "screen_metadata_id",
+  },
+  screen_pair: {
+    name: "screen_pair",
+    display_name: "Screen Pair",
+    id_column: "pair_id",
+    axis: "sample",
+    metadata_dataset_id: "screen_pair_metadata_id",
+  },
+};
+
+// Schema:
+//   gene_metadata (primary on gene), uniprot_annotations (supplemental on gene)
+//   protein_metadata: gene_fk → gene
+//   antibody_metadata: target_gene_fk → gene
+//   peptide_metadata: protein_fk → protein
+//   screen_metadata: gene_fk → gene
+//   screen_pair_metadata: anchor_screen_id → screen, resistance_screen_id → screen
+const TABLES_BY_DIM: Record<string, TableDescriptor[]> = {
+  gene: [
+    {
+      id: "gene_metadata_id",
+      given_id: "gene_metadata",
+      name: "Gene Metadata",
+      columns: {
+        label: { col_type: "label" },
+        symbol: { col_type: "text" },
+      } as any,
+    },
+    {
+      id: "uniprot_id",
+      given_id: "uniprot_annotations",
+      name: "Uniprot Gene Annotations",
+      columns: {
+        label: { col_type: "label" },
+        keywords: { col_type: "list_strings" },
+        localization: { col_type: "list_strings" },
+      } as any,
+    },
+  ],
+  protein: [
+    {
+      id: "protein_metadata_id",
+      given_id: "protein_metadata",
+      name: "Protein Metadata",
+      columns: {
+        label: { col_type: "label" },
+        gene_fk: { col_type: "text", references: "gene" },
+      } as any,
+    },
+  ],
+  antibody: [
+    {
+      id: "antibody_metadata_id",
+      given_id: "antibody_metadata",
+      name: "Antibody Metadata",
+      columns: {
+        label: { col_type: "label" },
+        target_gene_fk: { col_type: "text", references: "gene" },
+      } as any,
+    },
+  ],
+  peptide: [
+    {
+      id: "peptide_metadata_id",
+      given_id: "peptide_metadata",
+      name: "Peptide Metadata",
+      columns: {
+        label: { col_type: "label" },
+        protein_fk: { col_type: "text", references: "protein" },
+      } as any,
+    },
+  ],
+  screen: [
+    {
+      id: "screen_metadata_id",
+      given_id: "screen_metadata",
+      name: "Screen Metadata",
+      columns: {
+        label: { col_type: "label" },
+        gene_fk: { col_type: "text", references: "gene" },
+      } as any,
+    },
+    {
+      id: "screen_extras_id",
+      given_id: "screen_extras",
+      name: "Screen Extras",
+      columns: {
+        label: { col_type: "label" },
+        annotation: { col_type: "text" },
+      } as any,
+    },
+  ],
+  screen_pair: [
+    {
+      id: "screen_pair_metadata_id",
+      given_id: "screen_pair_metadata",
+      name: "Screen Pair Metadata",
+      columns: {
+        label: { col_type: "label" },
+        anchor_screen_id: { col_type: "text", references: "screen" },
+        resistance_screen_id: { col_type: "text", references: "screen" },
+      } as any,
+    },
+  ],
+};
+
+describe("computeLevel", () => {
+  it("emits same-dim supplementals with empty autoPath when their dim is not index_type", () => {
+    // index_type = antibody (so gene's same-dim supplementals are not
+    // redundant with the source picker, which only lists antibody tables).
+    const result = computeLevel(
+      "gene",
+      "antibody",
+      TABLES_BY_DIM,
+      DIM_TYPES,
+      new Set()
+    );
+
+    expect(result.supplementalTables).toHaveLength(1);
+    expect(result.supplementalTables[0].table.given_id).toBe(
+      "uniprot_annotations"
+    );
+    expect(result.supplementalTables[0].autoPath).toEqual([]);
+  });
+
+  it("prepends the auto-traversal hop to a supplemental's autoPath", () => {
+    // antibody_metadata.target_gene_fk → gene is a single-FK auto-traversal;
+    // the supplemental lives at gene, so its autoPath should record the hop.
+    const result = computeLevel(
+      "antibody",
+      "antibody",
+      TABLES_BY_DIM,
+      DIM_TYPES,
+      new Set()
+    );
+
+    expect(result.supplementalTables).toHaveLength(1);
+    const supp = result.supplementalTables[0];
+    expect(supp.table.given_id).toBe("uniprot_annotations");
+    expect(supp.autoPath).toEqual([
+      { throughCol: "target_gene_fk", toDim: "gene" },
+    ]);
+  });
+
+  it("preserves outer-to-inner order across multi-hop auto-traversals", () => {
+    // peptide → protein → gene chain: the supplemental at gene should
+    // record both hops in the order they were traversed (peptide→protein
+    // first, protein→gene last).
+    const result = computeLevel(
+      "peptide",
+      "peptide",
+      TABLES_BY_DIM,
+      DIM_TYPES,
+      new Set()
+    );
+
+    expect(result.supplementalTables).toHaveLength(1);
+    expect(result.supplementalTables[0].autoPath).toEqual([
+      { throughCol: "protein_fk", toDim: "protein" },
+      { throughCol: "gene_fk", toDim: "gene" },
+    ]);
+  });
+
+  it("returns no supplementals when only door (many-to-one) FKs are reachable", () => {
+    // screen_pair has two FKs to screen (a door, not auto-traversed), so
+    // computeLevel does not recurse and no deeper supplementals surface.
+    // screen_pair has no same-dim extras either.
+    const result = computeLevel(
+      "screen_pair",
+      "screen_pair",
+      TABLES_BY_DIM,
+      DIM_TYPES,
+      new Set()
+    );
+
+    expect(result.supplementalTables).toEqual([]);
+    expect(result.doors).toHaveLength(2);
+  });
+
+  it("surfaces both same-dim and auto-traversed supplementals from a post-door dim", () => {
+    // After the user clicks a door from screen_pair → screen, the next call
+    // is computeLevel("screen", "screen_pair", ...). At this level:
+    //   - screen_extras is a same-dim supplemental at screen, NOT redundant
+    //     with the source picker (which is anchored at index_type=screen_pair),
+    //     so it should surface with empty autoPath.
+    //   - The screen → gene auto-traversal also surfaces uniprot with the
+    //     hop in autoPath.
+    const result = computeLevel(
+      "screen",
+      "screen_pair",
+      TABLES_BY_DIM,
+      DIM_TYPES,
+      new Set()
+    );
+
+    expect(result.supplementalTables).toHaveLength(2);
+
+    const sameDim = result.supplementalTables.find(
+      (s) => s.table.given_id === "screen_extras"
+    );
+    expect(sameDim).toBeDefined();
+    expect(sameDim!.autoPath).toEqual([]);
+
+    const autoTraversed = result.supplementalTables.find(
+      (s) => s.table.given_id === "uniprot_annotations"
+    );
+    expect(autoTraversed).toBeDefined();
+    expect(autoTraversed!.autoPath).toEqual([
+      { throughCol: "gene_fk", toDim: "gene" },
+    ]);
+  });
+
+  it("hides same-dim supplementals at index_type to avoid source-picker redundancy", () => {
+    // dimType === index_type === gene: gene's supplementals (uniprot) are
+    // already in the source picker, so "Continue to table" should not also
+    // offer them.
+    const result = computeLevel(
+      "gene",
+      "gene",
+      TABLES_BY_DIM,
+      DIM_TYPES,
+      new Set()
+    );
+
+    expect(result.supplementalTables).toEqual([]);
+  });
+});

--- a/frontend/packages/@depmap/selects/src/components/AnnotationSelect/__tests__/sliceQueryUtils.test.ts
+++ b/frontend/packages/@depmap/selects/src/components/AnnotationSelect/__tests__/sliceQueryUtils.test.ts
@@ -1,0 +1,315 @@
+import { SliceQuery } from "@depmap/types";
+import { buildSliceQuery, deriveNavStateFromValue } from "../sliceQueryUtils";
+import type { DimensionTypeDescriptor, TableDescriptor } from "../types";
+
+const DIM_TYPES: Record<string, DimensionTypeDescriptor> = {
+  gene: {
+    name: "gene",
+    display_name: "Gene",
+    id_column: "entrez_id",
+    axis: "feature",
+    metadata_dataset_id: "gene_metadata_id",
+  },
+  antibody: {
+    name: "antibody",
+    display_name: "Antibody",
+    id_column: "antibody_id",
+    axis: "feature",
+    metadata_dataset_id: "antibody_metadata_id",
+  },
+  screen: {
+    name: "screen",
+    display_name: "Screen",
+    id_column: "screen_id",
+    axis: "sample",
+    metadata_dataset_id: "screen_metadata_id",
+  },
+  screen_pair: {
+    name: "screen_pair",
+    display_name: "Screen Pair",
+    id_column: "pair_id",
+    axis: "sample",
+    metadata_dataset_id: "screen_pair_metadata_id",
+  },
+};
+
+// Schema:
+//   gene_metadata (primary on gene), uniprot_annotations (supplemental on gene)
+//   antibody_metadata: target_gene_fk → gene
+//   screen_metadata: gene_fk → gene
+//   screen_pair_metadata: anchor_screen_id → screen, resistance_screen_id → screen
+const TABLES_BY_DIM: Record<string, TableDescriptor[]> = {
+  gene: [
+    {
+      id: "gene_metadata_id",
+      given_id: "gene_metadata",
+      name: "Gene Metadata",
+      columns: {
+        label: { col_type: "label" },
+        symbol: { col_type: "text" },
+      } as any,
+    },
+    {
+      id: "uniprot_id",
+      given_id: "uniprot_annotations",
+      name: "Uniprot Gene Annotations",
+      columns: {
+        label: { col_type: "label" },
+        keywords: { col_type: "list_strings" },
+        localization: { col_type: "list_strings" },
+      } as any,
+    },
+  ],
+  antibody: [
+    {
+      id: "antibody_metadata_id",
+      given_id: "antibody_metadata",
+      name: "Antibody Metadata",
+      columns: {
+        label: { col_type: "label" },
+        target_gene_fk: { col_type: "text", references: "gene" },
+      } as any,
+    },
+  ],
+  screen: [
+    {
+      id: "screen_metadata_id",
+      given_id: "screen_metadata",
+      name: "Screen Metadata",
+      columns: {
+        label: { col_type: "label" },
+        gene_fk: { col_type: "text", references: "gene" },
+      } as any,
+    },
+  ],
+  screen_pair: [
+    {
+      id: "screen_pair_metadata_id",
+      given_id: "screen_pair_metadata",
+      name: "Screen Pair Metadata",
+      columns: {
+        label: { col_type: "label" },
+        anchor_screen_id: { col_type: "text", references: "screen" },
+        resistance_screen_id: { col_type: "text", references: "screen" },
+      } as any,
+    },
+  ],
+};
+
+const ANTIBODY_SOURCE = {
+  id: "antibody_metadata_id",
+  given_id: "antibody_metadata",
+};
+const GENE_SOURCE = {
+  id: "gene_metadata_id",
+  given_id: "gene_metadata",
+};
+const SCREEN_PAIR_SOURCE = {
+  id: "screen_pair_metadata_id",
+  given_id: "screen_pair_metadata",
+};
+
+describe("buildSliceQuery", () => {
+  it("produces a flat SliceQuery for a same-dim supplemental column", () => {
+    // index_type = gene, source = gene_metadata. User clicks "Continue to
+    // table" into uniprot_annotations and picks "keywords". No FKs traversed.
+    const result = buildSliceQuery(
+      "keywords",
+      null,
+      [],
+      {
+        tableId: "uniprot_id",
+        dimType: "gene",
+        autoPath: [],
+      },
+      GENE_SOURCE,
+      "gene",
+      TABLES_BY_DIM,
+      DIM_TYPES
+    );
+
+    expect(result).toEqual({
+      dataset_id: "uniprot_annotations",
+      identifier: "keywords",
+      identifier_type: "column",
+    });
+  });
+
+  it("wraps an auto-traversed supplemental column in reindex_through", () => {
+    // Regression case. index_type = antibody. Auto-traversal via
+    // target_gene_fk → gene reaches the uniprot supplemental.
+    const result = buildSliceQuery(
+      "keywords",
+      null,
+      [],
+      {
+        tableId: "uniprot_id",
+        dimType: "gene",
+        autoPath: [{ throughCol: "target_gene_fk", toDim: "gene" }],
+      },
+      ANTIBODY_SOURCE,
+      "antibody",
+      TABLES_BY_DIM,
+      DIM_TYPES
+    );
+
+    expect(result).toEqual({
+      dataset_id: "uniprot_annotations",
+      identifier: "keywords",
+      identifier_type: "column",
+      reindex_through: {
+        dataset_id: "antibody_metadata",
+        identifier: "target_gene_fk",
+        identifier_type: "column",
+      },
+    });
+  });
+
+  it("chains a door hop, an auto-traversal, and a supplemental into a 3-step nested query", () => {
+    // index_type = screen_pair. User clicks the anchor_screen_id door
+    // (screen_pair → screen), then auto-traverse via gene_fk → gene reaches
+    // the uniprot supplemental.
+    const result = buildSliceQuery(
+      "keywords",
+      null,
+      [{ throughCol: "anchor_screen_id", toDim: "screen" }],
+      {
+        tableId: "uniprot_id",
+        dimType: "gene",
+        autoPath: [{ throughCol: "gene_fk", toDim: "gene" }],
+      },
+      SCREEN_PAIR_SOURCE,
+      "screen_pair",
+      TABLES_BY_DIM,
+      DIM_TYPES
+    );
+
+    expect(result).toEqual({
+      dataset_id: "uniprot_annotations",
+      identifier: "keywords",
+      identifier_type: "column",
+      reindex_through: {
+        dataset_id: "screen_metadata",
+        identifier: "gene_fk",
+        identifier_type: "column",
+        reindex_through: {
+          dataset_id: "screen_pair_metadata",
+          identifier: "anchor_screen_id",
+          identifier_type: "column",
+        },
+      },
+    });
+  });
+});
+
+describe("deriveNavStateFromValue", () => {
+  it("reconstructs autoPath on the supplemental for an auto-traversed slice", () => {
+    const query: SliceQuery = {
+      dataset_id: "uniprot_annotations",
+      identifier: "keywords",
+      identifier_type: "column",
+      reindex_through: {
+        dataset_id: "antibody_metadata",
+        identifier: "target_gene_fk",
+        identifier_type: "column",
+      },
+    };
+
+    const nav = deriveNavStateFromValue(
+      query,
+      "antibody",
+      TABLES_BY_DIM,
+      DIM_TYPES
+    );
+
+    expect(nav.hops).toEqual([]);
+    expect(nav.supplementalTable).toEqual({
+      tableId: "uniprot_id",
+      tableName: "Uniprot Gene Annotations",
+      dimType: "gene",
+      dimDisplayName: "Gene",
+      autoPath: [{ throughCol: "target_gene_fk", toDim: "gene" }],
+    });
+  });
+
+  it("classifies door hops separately from supplemental autoPath", () => {
+    // 3-step chain: door (anchor_screen_id) + auto (gene_fk) + supplemental.
+    // anchor_screen_id should land in hops because screen_pair_metadata has
+    // two FKs to screen; gene_fk should land in autoPath because
+    // screen_metadata has only one FK to gene.
+    const query: SliceQuery = {
+      dataset_id: "uniprot_annotations",
+      identifier: "keywords",
+      identifier_type: "column",
+      reindex_through: {
+        dataset_id: "screen_metadata",
+        identifier: "gene_fk",
+        identifier_type: "column",
+        reindex_through: {
+          dataset_id: "screen_pair_metadata",
+          identifier: "anchor_screen_id",
+          identifier_type: "column",
+        },
+      },
+    };
+
+    const nav = deriveNavStateFromValue(
+      query,
+      "screen_pair",
+      TABLES_BY_DIM,
+      DIM_TYPES
+    );
+
+    expect(nav.hops).toEqual([
+      { throughCol: "anchor_screen_id", toDim: "screen" },
+    ]);
+    expect(nav.supplementalTable?.autoPath).toEqual([
+      { throughCol: "gene_fk", toDim: "gene" },
+    ]);
+  });
+});
+
+describe("buildSliceQuery + deriveNavStateFromValue round-trip", () => {
+  it("is idempotent for the auto-traversed supplemental case", () => {
+    const initial = buildSliceQuery(
+      "keywords",
+      null,
+      [],
+      {
+        tableId: "uniprot_id",
+        dimType: "gene",
+        autoPath: [{ throughCol: "target_gene_fk", toDim: "gene" }],
+      },
+      ANTIBODY_SOURCE,
+      "antibody",
+      TABLES_BY_DIM,
+      DIM_TYPES
+    );
+
+    const nav = deriveNavStateFromValue(
+      initial,
+      "antibody",
+      TABLES_BY_DIM,
+      DIM_TYPES
+    );
+
+    const rebuilt = buildSliceQuery(
+      "keywords",
+      null,
+      nav.hops,
+      nav.supplementalTable
+        ? {
+            tableId: nav.supplementalTable.tableId,
+            dimType: nav.supplementalTable.dimType,
+            autoPath: nav.supplementalTable.autoPath,
+          }
+        : null,
+      ANTIBODY_SOURCE,
+      "antibody",
+      TABLES_BY_DIM,
+      DIM_TYPES
+    );
+
+    expect(rebuilt).toEqual(initial);
+  });
+});

--- a/frontend/packages/@depmap/selects/src/components/AnnotationSelect/computeLevel.ts
+++ b/frontend/packages/@depmap/selects/src/components/AnnotationSelect/computeLevel.ts
@@ -26,6 +26,11 @@ export interface LevelResult {
  * relationships as "doors" the user clicks through.
  *
  * @param dimType        The dimension type name to start from.
+ * @param index_type     The picker's root dimension type. Used to suppress
+ *                       same-dim supplementals at this exact dim, since
+ *                       those tables are already offered in the source
+ *                       picker (Widget 1) and showing them again under
+ *                       "Continue to table" would be redundant.
  * @param tablesByDim    All tabular datasets grouped by index_type_name.
  * @param dimTypeMap     Dimension type name → descriptor (for display names,
  *                       metadata_dataset_id, etc.).
@@ -36,6 +41,7 @@ export interface LevelResult {
  */
 export default function computeLevel(
   dimType: string,
+  index_type: string,
   tablesByDim: Record<string, TableDescriptor[]>,
   dimTypeMap: Record<string, DimensionTypeDescriptor>,
   visited: Set<string>,
@@ -52,20 +58,27 @@ export default function computeLevel(
   const activeTable =
     startTable ?? tables.find((t) => t.id === metadataDatasetId) ?? null;
 
-  // Supplemental tables at this dim type (everything except the active table).
-  const supplementalTables: SupplementalTable[] = tables
-    .filter((t) => t.id !== (activeTable?.id ?? metadataDatasetId))
-    .map((t) => {
-      const colCount = Object.keys(t.columns).filter((name) => name !== "label")
-        .length;
+  // Supplemental tables at this dim type (everything except the active
+  // table). Skipped entirely when this dim is the picker's index_type,
+  // since those tables are already offered in the source picker.
+  const supplementalTables: SupplementalTable[] =
+    dimType === index_type
+      ? []
+      : tables
+          .filter((t) => t.id !== (activeTable?.id ?? metadataDatasetId))
+          .map((t) => {
+            const colCount = Object.keys(t.columns).filter(
+              (name) => name !== "label"
+            ).length;
 
-      return {
-        dimType,
-        dimDisplayName,
-        table: t,
-        columnCount: colCount,
-      };
-    });
+            return {
+              dimType,
+              dimDisplayName,
+              table: t,
+              columnCount: colCount,
+              autoPath: [],
+            };
+          });
 
   if (!activeTable) {
     return { doors: [], supplementalTables, columns: [] };
@@ -122,7 +135,13 @@ export default function computeLevel(
       // One-to-one: auto-traverse silently. The visited check here guards
       // against a dim type already claimed by an earlier sibling traversal.
       const throughCol = fkCols[0];
-      const deeper = computeLevel(targetDim, tablesByDim, dimTypeMap, visited);
+      const deeper = computeLevel(
+        targetDim,
+        index_type,
+        tablesByDim,
+        dimTypeMap,
+        visited
+      );
 
       // Prepend this hop to each deeper column's autoPath.
       for (const col of deeper.columns) {
@@ -136,8 +155,14 @@ export default function computeLevel(
       // since the user can't interact with auto-traversed hops).
       doors.push(...deeper.doors);
 
-      // Merge deeper supplemental tables.
-      supplementalTables.push(...deeper.supplementalTables);
+      // Merge deeper supplemental tables, prepending this hop to their
+      // autoPath so callers know how they were reached.
+      for (const st of deeper.supplementalTables) {
+        supplementalTables.push({
+          ...st,
+          autoPath: [{ throughCol, toDim: targetDim }, ...st.autoPath],
+        });
+      }
     }
   }
 

--- a/frontend/packages/@depmap/selects/src/components/AnnotationSelect/sliceQueryUtils.ts
+++ b/frontend/packages/@depmap/selects/src/components/AnnotationSelect/sliceQueryUtils.ts
@@ -105,7 +105,11 @@ export function buildSliceQuery(
   selectedColumn: string,
   columnEntry: ColumnEntry | null,
   hops: ChainHop[],
-  supplementalTable: { tableId: string; dimType: string } | null,
+  supplementalTable: {
+    tableId: string;
+    dimType: string;
+    autoPath: ChainHop[];
+  } | null,
   selectedSource: { id: string; given_id: string | null },
   index_type: string,
   tablesByDim: Record<string, TableDescriptor[]>,
@@ -132,27 +136,29 @@ export function buildSliceQuery(
     }
   }
 
-  // 2. Auto-path hops from the selected column (one-to-one traversals).
-  if (columnEntry && columnEntry.autoPath.length > 0) {
-    for (let j = 0; j < columnEntry.autoPath.length; j++) {
-      if (j === 0 && hops.length === 0) {
-        // First auto-path step with no preceding door hops:
-        // originates from the selected source table, not the primary table.
-        chain.push({
-          dataset_id: resolveDatasetId(selectedSource),
-          identifier: columnEntry.autoPath[j].throughCol,
-        });
-      } else {
-        const originDim =
-          j === 0
-            ? hops[hops.length - 1].toDim
-            : columnEntry.autoPath[j - 1].toDim;
-        const table = findPrimaryTable(originDim, tablesByDim, dimTypeMap);
-        chain.push({
-          dataset_id: table ? resolveDatasetId(table) : originDim,
-          identifier: columnEntry.autoPath[j].throughCol,
-        });
-      }
+  // 2. Trailing auto-path hops. These come from either the selected column
+  // (when picked from the properties list) or the supplemental table (when
+  // navigated into via "Continue to table"). The two cases are mutually
+  // exclusive and produce structurally identical chain steps.
+  const trailingAutoPath: ChainHop[] =
+    supplementalTable?.autoPath ?? columnEntry?.autoPath ?? [];
+
+  for (let j = 0; j < trailingAutoPath.length; j++) {
+    if (j === 0 && hops.length === 0) {
+      // First auto-path step with no preceding door hops:
+      // originates from the selected source table, not the primary table.
+      chain.push({
+        dataset_id: resolveDatasetId(selectedSource),
+        identifier: trailingAutoPath[j].throughCol,
+      });
+    } else {
+      const originDim =
+        j === 0 ? hops[hops.length - 1].toDim : trailingAutoPath[j - 1].toDim;
+      const table = findPrimaryTable(originDim, tablesByDim, dimTypeMap);
+      chain.push({
+        dataset_id: table ? resolveDatasetId(table) : originDim,
+        identifier: trailingAutoPath[j].throughCol,
+      });
     }
   }
 
@@ -313,6 +319,7 @@ export interface DerivedNavState {
     tableName: string;
     dimType: string;
     dimDisplayName: string;
+    autoPath: ChainHop[];
   } | null;
 }
 
@@ -342,8 +349,13 @@ export function deriveNavStateFromValue(
   const sourceTableId = rootMatch?.table.id ?? null;
 
   const hops: ChainHop[] = [];
+  let pendingAutoPath: ChainHop[] = [];
 
   // Walk intermediate steps (everything except the leaf) to find door hops.
+  // Auto-traversal hops (FKs with only one column to a given target) are
+  // accumulated in pendingAutoPath; the buffer resets each time a door hop
+  // is encountered, so what remains at the end is the trailing run of
+  // auto-traversals that lead from the last door (or the root) to the leaf.
   for (let i = 0; i < steps.length - 1; i++) {
     const step = steps[i];
 
@@ -370,8 +382,11 @@ export function deriveNavStateFromValue(
     if (fkCountToSameTarget >= 2) {
       // Many-to-one: this was a door hop.
       hops.push({ throughCol: col, toDim: targetDim });
+      pendingAutoPath = [];
+    } else {
+      // One-to-one: auto-traversed.
+      pendingAutoPath.push({ throughCol: col, toDim: targetDim });
     }
-    // Otherwise one-to-one: auto-traversed, not a user-visible hop.
   }
 
   // Leaf step: check if it's from a supplemental table.
@@ -389,6 +404,7 @@ export function deriveNavStateFromValue(
         tableName: leafTable.name,
         dimType: leafDimType,
         dimDisplayName: dimTypeMap[leafDimType]?.display_name ?? leafDimType,
+        autoPath: pendingAutoPath,
       };
     }
   }

--- a/frontend/packages/@depmap/selects/src/components/AnnotationSelect/types.ts
+++ b/frontend/packages/@depmap/selects/src/components/AnnotationSelect/types.ts
@@ -47,12 +47,17 @@ export interface Door {
 
 /**
  * A supplemental (non-primary) table reachable at some dimension type.
+ *
+ * `autoPath` records the one-to-one FK hops traversed to reach this table's
+ * dim type from the level computeLevel was invoked at. It mirrors
+ * ColumnEntry.autoPath and is empty for supplementals at the current level.
  */
 export interface SupplementalTable {
   dimType: string;
   dimDisplayName: string;
   table: TableDescriptor;
   columnCount: number;
+  autoPath: ChainHop[];
 }
 
 /**

--- a/frontend/packages/@depmap/slice-table/__mocks__/fileMock.js
+++ b/frontend/packages/@depmap/slice-table/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = "test-file-stub";

--- a/frontend/packages/@depmap/slice-table/__mocks__/styleMock.js
+++ b/frontend/packages/@depmap/slice-table/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/frontend/packages/@depmap/slice-table/jest-setup.ts
+++ b/frontend/packages/@depmap/slice-table/jest-setup.ts
@@ -1,0 +1,25 @@
+// https://jestjs.io/docs/en/configuration#setuptestframeworkscriptfile-string
+// according to the docs for setupFiles, this runs before each test file
+
+// https://jestjs.io/docs/en/jest-object.html#jestmockmodulename-factory-options
+// see example creating virtual mocks, to mock modules that don't exist. for us, these are libraries that we pull in via CDNs, e.g. plotly.
+declare const jest: any;
+declare const afterEach: any;
+
+import * as Enzyme from "enzyme";
+import Adapter from "enzyme-adapter-react-16";
+jest.mock(
+  "plotly.js",
+  () => {
+    // virtual mocks modules that don't exist (plotly is pulled in via a CDN). see link to docs above
+  },
+  { virtual: true }
+);
+
+Enzyme.configure({
+  adapter: new Adapter(),
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});

--- a/frontend/packages/@depmap/slice-table/package.json
+++ b/frontend/packages/@depmap/slice-table/package.json
@@ -4,7 +4,7 @@
   "main": "index.ts",
   "license": "MIT",
   "scripts": {
-    "test": "echo 'no tests to run'"
+    "test": "jest"
   },
   "dependencies": {
     "@depmap/api": "1.0.0",
@@ -25,5 +25,38 @@
   "peerDependencies": {
     "react": "^16.9.35",
     "react-dom": "^16.9.8"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "ts",
+      "tsx"
+    ],
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "diagnostics": false
+        }
+      ]
+    },
+    "transformIgnorePatterns": [
+      "node_modules/(?!depmap-shared)"
+    ],
+    "testRegex": ".*/__tests__/.*test.*\\.(ts|tsx|js)$",
+    "testEnvironment": "jsdom",
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest-setup.ts"
+    ],
+    "setupFiles": [
+      "jest-localstorage-mock"
+    ],
+    "moduleNameMapper": {
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(css|less|scss)$": "<rootDir>/__mocks__/styleMock.js",
+      "@depmap/(.*)/src/(.*)": "<rootDir>/../$1/src/$2",
+      "@depmap/(.*)": "<rootDir>/../$1",
+      "^src/(.*)": "<rootDir>/src/$1"
+    }
   }
 }

--- a/frontend/packages/@depmap/slice-table/src/__tests__/transformToTableData.test.ts
+++ b/frontend/packages/@depmap/slice-table/src/__tests__/transformToTableData.test.ts
@@ -1,0 +1,163 @@
+import { Dataset, DimensionType, SliceQuery } from "@depmap/types";
+import { SliceResponse, transformToTableData } from "../components/useData";
+
+// Minimal valid dataset for the function's lookups (id/given_id matching,
+// `format`, `columns_metadata` field reads). Cast to `any` because the
+// real `Dataset` type has many more fields that aren't relevant here.
+const makeDataset = (id: string, name: string): Dataset =>
+  ({
+    id,
+    given_id: id,
+    name,
+    format: "tabular_dataset",
+    columns_metadata: {},
+  } as any);
+
+const indexType = {
+  name: "antibody_v2",
+  display_name: "Antibody",
+  id_column: "antibody_id",
+  metadata_dataset_id: "metadata_ds",
+} as DimensionType;
+
+const labelSlice: SliceQuery = {
+  dataset_id: "metadata_ds",
+  identifier_type: "column",
+  identifier: "label",
+};
+
+const dataSlice: SliceQuery = {
+  dataset_id: "data_ds",
+  identifier_type: "column",
+  identifier: "score",
+};
+
+const datasets = [
+  makeDataset("metadata_ds", "Metadata"),
+  makeDataset("data_ds", "Data"),
+];
+
+describe("transformToTableData", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("anchors row assembly on the label response when data is clean", () => {
+    const labelResponse: SliceResponse = {
+      ids: ["A", "B", "C"],
+      labels: ["A", "B", "C"],
+      values: ["alpha", "beta", "gamma"],
+    };
+    const dataResponse: SliceResponse = {
+      ids: ["A", "B", "C"],
+      labels: ["A", "B", "C"],
+      values: [1, 2, 3],
+    };
+
+    const { data } = transformToTableData(
+      [labelResponse, dataResponse],
+      ["label", "Score"],
+      [labelSlice, dataSlice],
+      undefined,
+      datasets,
+      indexType,
+      "antibody_id",
+      "label",
+      {}
+    );
+
+    expect(data).toHaveLength(3);
+    expect(data.map((r) => r.id)).toEqual(["A", "B", "C"]);
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it("drops foreign IDs from a data response and logs the violation", () => {
+    const labelResponse: SliceResponse = {
+      ids: ["A", "B", "C"],
+      labels: ["A", "B", "C"],
+      values: ["alpha", "beta", "gamma"],
+    };
+    // X and Y are foreign — they aren't in the index type's entity set.
+    const dataResponse: SliceResponse = {
+      ids: ["A", "B", "X", "Y"],
+      labels: ["A", "B", "X", "Y"],
+      values: [1, 2, 3, 4],
+    };
+
+    const { data, columns } = transformToTableData(
+      [labelResponse, dataResponse],
+      ["label", "Score"],
+      [labelSlice, dataSlice],
+      undefined,
+      datasets,
+      indexType,
+      "antibody_id",
+      "label",
+      {}
+    );
+
+    // Row set is anchored to the canonical entities — X and Y are gone.
+    expect(data).toHaveLength(3);
+    expect(data.map((r) => r.id)).toEqual(["A", "B", "C"]);
+
+    // A and B keep their score values; C is a coverage hole (undefined).
+    const scoreColumn = columns.find((c) => c.meta.idLabel === "Score")!;
+    const scoreKey = scoreColumn.id;
+    expect(data[0][scoreKey]).toBe(1);
+    expect(data[1][scoreKey]).toBe(2);
+    expect(data[2][scoreKey]).toBeUndefined();
+
+    // Should have warned with enough detail to diagnose the upstream bug.
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    const message = consoleErrorSpy.mock.calls[0][0] as string;
+    expect(message).toContain("Score");
+    expect(message).toContain("data_ds");
+    expect(message).toContain("score");
+    expect(message).toContain("antibody_v2");
+    expect(message).toContain("2 of 4");
+    expect(message).toContain("X");
+    expect(message).toContain("Y");
+  });
+
+  it("does not warn for a sparse data response with no foreign IDs", () => {
+    const labelResponse: SliceResponse = {
+      ids: ["A", "B", "C"],
+      labels: ["A", "B", "C"],
+      values: ["alpha", "beta", "gamma"],
+    };
+    // Coverage hole (B and C have no data) is normal and should not warn.
+    const dataResponse: SliceResponse = {
+      ids: ["A"],
+      labels: ["A"],
+      values: [1],
+    };
+
+    const { data, columns } = transformToTableData(
+      [labelResponse, dataResponse],
+      ["label", "Score"],
+      [labelSlice, dataSlice],
+      undefined,
+      datasets,
+      indexType,
+      "antibody_id",
+      "label",
+      {}
+    );
+
+    expect(data).toHaveLength(3);
+
+    const scoreColumn = columns.find((c) => c.meta.idLabel === "Score")!;
+    const scoreKey = scoreColumn.id;
+    expect(data[0][scoreKey]).toBe(1);
+    expect(data[1][scoreKey]).toBeUndefined();
+    expect(data[2][scoreKey]).toBeUndefined();
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/packages/@depmap/slice-table/src/components/useData.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/useData.tsx
@@ -29,7 +29,7 @@ interface Parameters {
 }
 
 // Types for better code clarity
-type SliceResponse = {
+export type SliceResponse = {
   ids: string[];
   labels: string[];
   values: (string | number | null)[];
@@ -316,7 +316,7 @@ const truncateMiddle = (str: string, maxLength = 45): string => {
  * 2. Creates rows where each ID gets values from all slices (with null for missing data)
  * 3. Generates table column definitions with proper headers and metadata
  */
-function transformToTableData(
+export function transformToTableData(
   dataResponses: SliceResponse[],
   displayLabels: string[],
   slices: SliceQuery[],
@@ -328,26 +328,55 @@ function transformToTableData(
   idToLabelMappings: Record<string, Record<string, string>>,
   getColumnDisplayOptions?: Parameters["getColumnDisplayOptions"]
 ) {
-  // Step 1: Create unique column keys and collect all row IDs
+  // Step 1: Create unique column keys, validate IDs, and key data by ID.
+  //
+  // The label response (always at index 0 — `buildSlicesToFetch` prepends
+  // it) is keyed by the index type's canonical entity IDs. Every other
+  // response should be keyed by a subset of those: a data slice can have
+  // coverage holes, but should never include IDs that aren't part of the
+  // index type. If it does, drop the offending IDs (so the table stays
+  // coherent) and log loudly so the bug isn't invisible. This usually
+  // means a slice that should have been wrapped in `reindex_through`
+  // wasn't, or the backend returned IDs in the wrong space.
   const columnKeys = slices.map(createUniqueColumnKey);
-  const allRowIds = new Set<string>();
+  const labelIds = new Set(dataResponses[0].ids);
   const columnData: Record<string, Record<string, string | number | null>> = {};
 
-  // Process each data response and collect row IDs
+  // Process each data response, dropping foreign IDs.
   dataResponses.forEach((response, index) => {
     const uniqueKey = columnKeys[index];
     const keyed: Record<string, string | number | null> = {};
 
+    if (index > 0) {
+      const foreign = response.ids.filter((id) => !labelIds.has(id));
+      if (foreign.length > 0) {
+        const slice = slices[index];
+        // eslint-disable-next-line no-console
+        console.error(
+          `[SliceTable] Slice "${displayLabels[index]}" (dataset_id=` +
+            `"${slice.dataset_id}", identifier="${slice.identifier}") ` +
+            `returned ${foreign.length} of ${response.ids.length} IDs that ` +
+            `aren't part of the "${indexType.name}" index. These rows are ` +
+            `being dropped from the table. This usually means the slice ` +
+            `should have been wrapped in reindex_through but wasn't. ` +
+            `Foreign ID sample: ${JSON.stringify(foreign.slice(0, 5))}`
+        );
+      }
+    }
+
     for (let i = 0; i < response.ids.length; i++) {
+      if (index > 0 && !labelIds.has(response.ids[i])) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
       keyed[response.ids[i]] = response.values[i];
-      allRowIds.add(response.ids[i]);
     }
 
     columnData[uniqueKey] = keyed;
   });
 
-  // Step 2: Build data rows
-  const data = Array.from(allRowIds).map((rowId) => {
+  // Step 2: Build data rows from the canonical entity set.
+  const data = Array.from(labelIds).map((rowId) => {
     const row: Record<string, string | number | undefined> = { id: rowId };
 
     columnKeys.forEach((columnKey) => {

--- a/frontend/packages/@depmap/slice-table/src/styles/AddColumnModal.scss
+++ b/frontend/packages/@depmap/slice-table/src/styles/AddColumnModal.scss
@@ -89,6 +89,11 @@
 
   & > div:first-child {
     @extend .fadein;
+
+    &.showNulls {
+      display: flex;
+      align-items: flex-end;
+    }
   }
 }
 


### PR DESCRIPTION
Two bugs prevented supplemental (non-primary) tables from being selectable when reached via FK auto-traversal:

- Auto-traversal-reached supplementals were dropped at render time by an overly broad depth === 0 guard in visibleSupplementalTables.
- After removing the guard, selecting such a supplemental produced a flat SliceQuery with no reindex_through, because the traversed hops were never attached to the SupplementalTable record and buildSliceQuery only emitted intermediate chain steps for ColumnEntry picks. The result was a slice indexed by the wrong dim type, which produced wonky downstream behavior in SliceTable.

SupplementalTable now carries an autoPath field that mirrors ColumnEntry.autoPath. buildSliceQuery and deriveNavStateFromValue are updated to read/write it so the picker round-trips correctly.

Separately, computeLevel now hides same-dim supplementals when their dimType equals the picker's index_type, eliminating redundancy with the source picker (which already lists them).

Unit tests added for computeLevel autoPath plumbing, buildSliceQuery output shapes, deriveNavStateFromValue round-trip, and the same-dim suppression rule.