### PR TITLE
Make ids the source of truth for identity in Data Explorer

### DIFF
--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -50,6 +50,7 @@ module.exports = {
     "jsx-a11y/label-has-associated-control": ["warn", { assert: "either" }],
     "max-len": "off",
     "no-confusing-arrow": "off",
+    "no-continue": "off",
     "no-plusplus": "off",
     "no-restricted-syntax": "off",
     "no-tabs": "off",

--- a/frontend/packages/@depmap/data-explorer-2/jest-setup.ts
+++ b/frontend/packages/@depmap/data-explorer-2/jest-setup.ts
@@ -20,6 +20,66 @@ Enzyme.configure({
   adapter: new Adapter(),
 });
 
+const portalApiProxyTarget: Record<string | symbol, unknown> = {};
+const breadboxApiProxyTarget: Record<string | symbol, unknown> = {};
+
+const createApiMock = (
+  label: string,
+  importName: string,
+  target: Record<string | symbol, unknown>
+) => {
+  return new Proxy(target, {
+    get(t, prop) {
+      if (prop in t) {
+        return t[prop];
+      }
+
+      const message = [
+        "-".repeat(80),
+        `Some application code is trying to access the ${label} from this test.`,
+        "You'll need to provide a mock response. Please add this to your test:\n",
+        `  ${importName}.${String(prop)} = jest`,
+        `    .fn<ReturnType<typeof ${importName}.${String(prop)}>, []>()`,
+        "    .mockResolvedValue(/* some value */);",
+        "",
+        "(You don't need to reset the mock after the test runs. All mocks are",
+        "automatically reset after each test.)",
+        "-".repeat(80),
+      ].join("\n");
+
+      throw new Error(message);
+    },
+    set(t, prop, value) {
+      t[prop] = value;
+      return true;
+    },
+  });
+};
+
+jest.mock("@depmap/api", () => ({
+  cached: (api: unknown) => api,
+
+  legacyPortalAPI: createApiMock(
+    "Portal API",
+    "legacyPortalAPI",
+    portalApiProxyTarget
+  ),
+
+  breadboxAPI: createApiMock(
+    "Breadbox API",
+    "breadboxAPI",
+    breadboxApiProxyTarget
+  ),
+}));
+
 afterEach(() => {
+  for (const key of Object.keys(portalApiProxyTarget)) {
+    delete portalApiProxyTarget[key];
+  }
+
+  for (const key of Object.keys(breadboxApiProxyTarget)) {
+    delete breadboxApiProxyTarget[key];
+  }
+
   jest.resetAllMocks();
 });

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/__tests__/utils.test.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/__tests__/utils.test.ts
@@ -1,0 +1,185 @@
+import { DataExplorerPlotConfig } from "@depmap/types";
+import { toRelatedPlot } from "../utils";
+
+// `toRelatedPlot` pins the selection-to-context translation: given a plot
+// the user is looking at and a set of selected IDs, return the plot that
+// "drills into" those selections. The tests below assert the post-refactor
+// contract: the input selection set is always real Breadbox IDs and the
+// emitted context expressions reference them directly via `given_id` — no
+// label↔id translation, no per-dimension-type special cases.
+//
+// Tests against the gene-index-type cases (3 and 6) fail against the
+// current implementation, because today `toRelatedPlot` routes non-
+// depmap_model dimensions through a label→id lookup and the input set is
+// labels, not IDs.
+
+// Shared identifiers fixture: a mix of feature-type (gene) and
+// sample-type (depmap_model) rows so every case below can pull from one
+// array. `toRelatedPlot` takes `identifiers` as an explicit argument
+// (no I/O), which makes these tests pure-function with no mocks.
+const identifiers = [
+  { id: "ENSG00000164687", label: "FABP5" },
+  { id: "ENSG00000181449", label: "SOX2" },
+  { id: "ENSG00000176697", label: "BDNF" },
+  { id: "ACH-000425", label: "NIHOVCAR3" },
+  { id: "ACH-000552", label: "HT29" },
+  { id: "ACH-000001", label: "MCF7" },
+];
+
+// Helper: build the minimal scatter plot the tests need as input.
+const scatterPlot = (
+  indexType: string,
+  sliceType: string
+): DataExplorerPlotConfig =>
+  (({
+    plot_type: "scatter",
+    index_type: indexType,
+    dimensions: {
+      x: {
+        axis_type: "raw_slice",
+        aggregation: "first",
+        slice_type: sliceType,
+        dataset_id: "Chronos_Combined",
+        context: {
+          name: "FABP5",
+          context_type: sliceType,
+          expr: { "==": [{ var: "entity_label" }, "FABP5"] },
+        },
+      },
+    },
+  } as unknown) as DataExplorerPlotConfig);
+
+// Helper: build the minimal correlation-heatmap plot the tests need as
+// input. The heatmap branch reads slice_type off the X dimension; the
+// index_type is preserved through the transform (no flip).
+const heatmapPlot = (
+  indexType: string,
+  sliceType: string
+): DataExplorerPlotConfig =>
+  (({
+    plot_type: "correlation_heatmap",
+    index_type: indexType,
+    dimensions: {
+      x: {
+        axis_type: "aggregated_slice",
+        aggregation: "correlation",
+        slice_type: sliceType,
+        dataset_id: "Chronos_Combined",
+        context: {
+          name: "All",
+          context_type: sliceType,
+          expr: true,
+        },
+      },
+    },
+  } as unknown) as DataExplorerPlotConfig);
+
+// Pull the `given_id` value out of an `==` expression so tests can
+// assert against it without caring about expression shape.
+const givenIdOf = (context: unknown): unknown => {
+  const expr = (context as { expr: unknown }).expr as {
+    "=="?: [{ var: string }, unknown];
+  };
+  return expr["=="]?.[1];
+};
+
+// Pull the array of ids out of an `in` expression.
+const inIdsOf = (context: unknown): unknown => {
+  const expr = (context as { expr: unknown }).expr as {
+    in?: [{ var: string }, unknown[]];
+  };
+  return expr.in?.[1];
+};
+
+describe("toRelatedPlot", () => {
+  describe("scatter plot (non-heatmap path)", () => {
+    test("model index + 1 selected model id → density_1d with given_id of the id", () => {
+      const plot = scatterPlot("depmap_model", "gene");
+      const selected = new Set(["ACH-000425"]);
+
+      const next = toRelatedPlot(plot, selected, identifiers);
+
+      expect(next.plot_type).toBe("density_1d");
+      // Index/slice flip: the new index_type is what was the X slice_type.
+      expect(next.index_type).toBe("gene");
+      expect(next.dimensions.x?.slice_type).toBe("depmap_model");
+      expect(givenIdOf(next.dimensions.x?.context)).toBe("ACH-000425");
+    });
+
+    test("model index + 2 selected model ids → scatter with two single-slice contexts", () => {
+      const plot = scatterPlot("depmap_model", "gene");
+      const selected = new Set(["ACH-000425", "ACH-000552"]);
+
+      const next = toRelatedPlot(plot, selected, identifiers);
+
+      expect(next.plot_type).toBe("scatter");
+      expect(next.index_type).toBe("gene");
+      // The order of iteration over a Set is insertion order in JS.
+      expect(givenIdOf(next.dimensions.x?.context)).toBe("ACH-000425");
+      expect(givenIdOf(next.dimensions.y?.context)).toBe("ACH-000552");
+    });
+
+    test("gene index + 1 selected gene id → density_1d with given_id of the id", () => {
+      const plot = scatterPlot("gene", "depmap_model");
+      const selected = new Set(["ENSG00000181449"]);
+
+      const next = toRelatedPlot(plot, selected, identifiers);
+
+      expect(next.plot_type).toBe("density_1d");
+      expect(next.index_type).toBe("depmap_model");
+      expect(next.dimensions.x?.slice_type).toBe("gene");
+      // This is the case that fails pre-refactor: today the impl does
+      // labelToIdMap["ENSG00000181449"] which is undefined, because the
+      // input is an id, not a label, and the map is keyed by label.
+      expect(givenIdOf(next.dimensions.x?.context)).toBe("ENSG00000181449");
+    });
+
+    test("model index + 3 selected model ids → correlation_heatmap with `in` listing all ids", () => {
+      const plot = scatterPlot("depmap_model", "gene");
+      const selected = new Set(["ACH-000425", "ACH-000552", "ACH-000001"]);
+
+      const next = toRelatedPlot(plot, selected, identifiers);
+
+      expect(next.plot_type).toBe("correlation_heatmap");
+      expect(next.index_type).toBe("gene");
+      expect(next.dimensions.x?.slice_type).toBe("depmap_model");
+      expect(inIdsOf(next.dimensions.x?.context)).toEqual([
+        "ACH-000425",
+        "ACH-000552",
+        "ACH-000001",
+      ]);
+    });
+  });
+
+  describe("correlation heatmap (heatmap path)", () => {
+    test("model slice + 1 selected model id → density_1d, index_type preserved (no flip)", () => {
+      const plot = heatmapPlot("depmap_model", "depmap_model");
+      const selected = new Set(["ACH-000425"]);
+
+      const next = toRelatedPlot(plot, selected, identifiers);
+
+      expect(next.plot_type).toBe("density_1d");
+      // Heatmap branch does NOT flip index_type; it stays the same as input.
+      expect(next.index_type).toBe("depmap_model");
+      expect(next.dimensions.x?.slice_type).toBe("depmap_model");
+      expect(givenIdOf(next.dimensions.x?.context)).toBe("ACH-000425");
+    });
+
+    test("gene slice + 1 selected gene id → density_1d, index_type preserved (no flip)", () => {
+      // Note: this exercises a less-common shape — a gene-by-gene heatmap.
+      // The index_type and slice_type both being non-model lets us see the
+      // "non-inverted, non-model" path explicitly, which is the case that
+      // pre-refactor would have routed through labelToIdMap and failed.
+      const plot = heatmapPlot("gene", "gene");
+      const selected = new Set(["ENSG00000181449"]);
+
+      const next = toRelatedPlot(plot, selected, identifiers);
+
+      expect(next.plot_type).toBe("density_1d");
+      expect(next.index_type).toBe("gene");
+      expect(next.dimensions.x?.slice_type).toBe("gene");
+      // Pre-refactor: labelToIdMap["ENSG00000181449"] === undefined.
+      expect(givenIdOf(next.dimensions.x?.context)).toBe("ENSG00000181449");
+    });
+  });
+});

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/PrecomputedAssociations/PrecomputedAssociations.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/PrecomputedAssociations/PrecomputedAssociations.tsx
@@ -71,8 +71,15 @@ function PrecomputedAssociations({ plot, onSelectY, sectionRef }: Props) {
       const valueExpr = (expr["=="]![1] as unknown) as string;
 
       if (varExpr?.var === "entity_label") {
-        // edge case
-        yDimensionId = labelToIdMap[valueExpr];
+        // Legacy V1 contexts use `entity_label`. For depmap_model the
+        // legacy backend stored a depmap id as the "label", so the value
+        // is already an id and needs no resolution. For other types we
+        // resolve label → id via Breadbox.
+        if (plot.dimensions?.y?.slice_type === "depmap_model") {
+          yDimensionId = valueExpr;
+        } else {
+          yDimensionId = labelToIdMap[valueExpr];
+        }
       } else {
         yDimensionId = valueExpr;
       }

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/PrecomputedAssociations/useLabelToIdMap.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/PrecomputedAssociations/useLabelToIdMap.ts
@@ -1,6 +1,13 @@
 import { useEffect, useState } from "react";
 import { breadboxAPI, cached } from "@depmap/api";
 
+// Builds a label → id map for a given dimension type. Used by
+// `PrecomputedAssociations` to resolve a legacy `entity_label`-style
+// context expression to an id for downstream comparison. Callers that
+// pass `dimension_type === "depmap_model"` should NOT use this hook —
+// for that legacy edge case the "entity_label" value is already a
+// depmap id and no lookup is needed. See the consumer for the inline
+// check.
 function useLabelToIdMap(dimension_type: string | undefined) {
   const [mapping, setMapping] = useState<Record<string, string>>({});
 
@@ -16,11 +23,7 @@ function useLabelToIdMap(dimension_type: string | undefined) {
         const map: Record<string, string> = {};
 
         identifiers.forEach(({ id, label }) => {
-          if (dimension_type === "depmap_model") {
-            map[id] = label;
-          } else {
-            map[label] = id;
-          }
+          map[label] = id;
         });
 
         setMapping(map);

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerCorrelationHeatmap.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerCorrelationHeatmap.tsx
@@ -21,11 +21,11 @@ interface Props {
   isLoading: boolean;
   onClickVisualizeSelected: (
     e: React.MouseEvent,
-    selectedLabels: Set<string>
+    selectedIds: Set<string>
   ) => void;
   onClickSaveSelectionAsContext: (
     dimension_type: string,
-    selectedLabels: Set<string>
+    selectedIds: Set<string>
   ) => void;
   onClickShowDensityFallback: () => void;
 }
@@ -79,9 +79,7 @@ function DataExplorerCorrelationHeatmap({
   onClickShowDensityFallback,
 }: Props) {
   const [plotElement, setPlotElement] = useState<ExtendedPlotType | null>(null);
-  const [selectedLabels, setSelectedLabels] = useState<Set<string> | null>(
-    null
-  );
+  const [selectedIds, setSelectedIds] = useState<Set<string> | null>(null);
   const { plotStyles } = useDataExplorerSettings();
   const { palette, xAxisFontSize } = plotStyles;
 
@@ -93,7 +91,7 @@ function DataExplorerCorrelationHeatmap({
   } = useCorrelationHeatmapData(data, isLoading);
 
   const handleSelectLabels = (labels: string[]) => {
-    setSelectedLabels(new Set(labels));
+    setSelectedIds(new Set(labels));
   };
 
   return (
@@ -105,7 +103,7 @@ function DataExplorerCorrelationHeatmap({
             isLoading={isLoading}
             plotConfig={plotConfig}
             plotElement={plotElement}
-            onClickUnselectAll={() => setSelectedLabels(null)}
+            onClickUnselectAll={() => setSelectedIds(null)}
             hideSelectionTools
           />
         </div>
@@ -131,7 +129,7 @@ function DataExplorerCorrelationHeatmap({
               height="auto"
               onLoad={setPlotElement}
               onSelectLabels={handleSelectLabels}
-              selectedLabels={selectedLabels || undefined}
+              selectedLabels={selectedIds || undefined}
               palette={palette}
               xAxisFontSize={xAxisFontSize}
               distinguish1Label={plotConfig.filters?.distinguish1?.name}
@@ -145,16 +143,16 @@ function DataExplorerCorrelationHeatmap({
           <PlotSelections
             data={data}
             plot_type={plotConfig?.plot_type || null}
-            selectedLabels={selectedLabels}
+            selectedIds={selectedIds}
             onClickVisualizeSelected={(e) => {
-              if (selectedLabels) {
-                onClickVisualizeSelected(e, selectedLabels);
+              if (selectedIds) {
+                onClickVisualizeSelected(e, selectedIds);
               }
             }}
             onClickSaveSelectionAsContext={() => {
               onClickSaveSelectionAsContext(
                 plotConfig.dimensions.x!.slice_type,
-                selectedLabels as Set<string>
+                selectedIds as Set<string>
               );
             }}
           />

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerDensity1DPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerDensity1DPlot.tsx
@@ -25,11 +25,11 @@ interface Props {
   plotConfig: DataExplorerPlotConfig;
   onClickVisualizeSelected: (
     e: React.MouseEvent,
-    selectedLabels: Set<string>
+    selectedIds: Set<string>
   ) => void;
   onClickSaveSelectionAsContext: (
     dimension_type: string,
-    selectedLabels: Set<string>
+    selectedIds: Set<string>
   ) => void;
   onClickColorByContext: (context: DataExplorerContextV2) => void;
 }
@@ -43,7 +43,7 @@ function DataExplorerDensity1DPlot({
   onClickColorByContext,
 }: Props) {
   const [plotElement, setPlotElement] = useState<ExtendedPlotType | null>(null);
-  const [selectedLabels, setSelectedLabels] = useState<Set<string> | null>(
+  const [selectedIds, setSelectedIds] = useState<Set<string> | null>(
     null
   );
   const [showSpinner, setShowSpinner] = useState(isLoading);
@@ -92,28 +92,28 @@ function DataExplorerDensity1DPlot({
     .x as DataExplorerPlotConfigDimension;
 
   useEffect(() => {
-    setSelectedLabels(null);
+    setSelectedIds(null);
   }, [slice_type]);
 
   useEffect(() => {
-    if (!data?.index_labels) {
+    if (!data?.index_ids) {
       return;
     }
 
-    const validSelections = new Set(data.index_labels || []);
+    const validSelections = new Set(data.index_ids || []);
 
-    setSelectedLabels((xs) => {
+    setSelectedIds((xs) => {
       if (!xs) {
         return null;
       }
 
       const ys = new Set<string>();
-      const labels = [...xs];
+      const ids = [...xs];
 
-      for (let i = 0; i < labels.length; i += 1) {
-        const label = labels[i];
-        if (validSelections.has(label)) {
-          ys.add(label);
+      for (let i = 0; i < ids.length; i += 1) {
+        const id = ids[i];
+        if (validSelections.has(id)) {
+          ys.add(id);
         }
       }
 
@@ -124,27 +124,27 @@ function DataExplorerDensity1DPlot({
   const selectedPoints = useMemo(() => {
     const out: Set<number> = new Set();
 
-    if (!data?.index_labels) {
+    if (!data?.index_ids) {
       return out;
     }
 
-    for (let i = 0; i < data.index_labels.length; i += 1) {
-      if (selectedLabels?.has(data.index_labels[i])) {
+    for (let i = 0; i < data.index_ids.length; i += 1) {
+      if (selectedIds?.has(data.index_ids[i])) {
         out.add(i);
       }
     }
 
     return out;
-  }, [data, selectedLabels]);
+  }, [data, selectedIds]);
 
   const handleMultiselect = useCallback(
     (pointIndices: number[]) => {
       if (pointIndices.length > 0) {
         const s = new Set<string>();
         pointIndices.forEach((i: number) => {
-          s.add(data!.index_labels[i]);
+          s.add(data!.index_ids[i]);
         });
-        setSelectedLabels(s);
+        setSelectedIds(s);
       }
     },
     [data]
@@ -152,26 +152,48 @@ function DataExplorerDensity1DPlot({
 
   const handleClickPoint = useCallback(
     (pointIndex: number, ctrlKey: boolean) => {
-      const label = data!.index_labels[pointIndex];
+      const id = data!.index_ids[pointIndex];
 
       if (ctrlKey) {
-        setSelectedLabels((xs) => {
+        setSelectedIds((xs) => {
           const ys = new Set(xs);
 
-          if (xs?.has(label)) {
-            ys.delete(label);
+          if (xs?.has(id)) {
+            ys.delete(id);
           } else {
-            ys.add(label);
+            ys.add(id);
           }
 
           return ys;
         });
       } else {
-        setSelectedLabels(new Set([label]));
+        setSelectedIds(new Set([id]));
       }
     },
-    [data, setSelectedLabels]
+    [data, setSelectedIds]
   );
+
+  // GeneTea consumes display labels (gene symbols), not IDs. Convert at
+  // the boundary by indexing the data's parallel id/label arrays.
+  const selectedLabels = useMemo(() => {
+    if (!data?.index_ids || !selectedIds) {
+      return selectedIds;
+    }
+
+    const idToLabel: Record<string, string> = {};
+    for (let i = 0; i < data.index_ids.length; i += 1) {
+      idToLabel[data.index_ids[i]] = data.index_labels[i];
+    }
+
+    const out = new Set<string>();
+    selectedIds.forEach((id) => {
+      const label = idToLabel[id];
+      if (label !== undefined) {
+        out.add(label);
+      }
+    });
+    return out;
+  }, [data, selectedIds]);
 
   return (
     <div className={styles.DataExplorerDensity1DPlot}>
@@ -184,7 +206,7 @@ function DataExplorerDensity1DPlot({
             plotElement={plotElement}
             handleClickPoint={handleClickPoint}
             onClickUnselectAll={() => {
-              setSelectedLabels(null);
+              setSelectedIds(null);
             }}
           />
         </div>
@@ -209,7 +231,7 @@ function DataExplorerDensity1DPlot({
               onMultiselect={handleMultiselect}
               selectedPoints={selectedPoints}
               onClickResetSelection={() => {
-                setSelectedLabels(null);
+                setSelectedIds(null);
               }}
               hiddenLegendValues={hiddenLegendValues}
               pointSize={pointSize}
@@ -240,27 +262,27 @@ function DataExplorerDensity1DPlot({
             <PlotSelections
               data={data}
               plot_type={plotConfig?.plot_type || null}
-              selectedLabels={selectedLabels}
+              selectedIds={selectedIds}
               onClickVisualizeSelected={(e) =>
-                onClickVisualizeSelected(e, selectedLabels as Set<string>)
+                onClickVisualizeSelected(e, selectedIds as Set<string>)
               }
               onClickSaveSelectionAsContext={() => {
                 onClickSaveSelectionAsContext(
                   plotConfig.index_type,
-                  selectedLabels as Set<string>
+                  selectedIds as Set<string>
                 );
               }}
               onClickClearSelection={() => {
-                setSelectedLabels(null);
+                setSelectedIds(null);
               }}
               onClickSetSelectionFromContext={async () => {
-                const labels = await promptForSelectionFromContext(data!);
+                const newSelectedIds = await promptForSelectionFromContext(data!);
 
-                if (labels === null) {
+                if (newSelectedIds === null) {
                   return;
                 }
 
-                setSelectedLabels(labels);
+                setSelectedIds(newSelectedIds);
                 plotElement?.annotateSelected();
               }}
             />

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerPlotControls.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerPlotControls.tsx
@@ -27,6 +27,13 @@ function DataExplorerPlotControls({
       return [];
     }
 
+    // Search options show what a user can type to pick a point. The
+    // `value` prefix is unused by `handleSearch` (which parses only the
+    // index after the colon); the labels in the dropdown are what the
+    // user sees and matches against. For `depmap_model` we historically
+    // provide two parallel lists so users can search either by depmap ID
+    // or by cell line name — that dual list is preserved here, now
+    // sourced from `index_ids` and `index_labels` directly.
     let options: {
       value: string;
       label: string;
@@ -36,14 +43,14 @@ function DataExplorerPlotControls({
     }));
 
     if (data.index_type === "depmap_model") {
-      const cellLineNameOptions = data.index_display_labels.map(
-        (label: string, index: number) => ({
-          label,
-          value: `index_display_labels:${index}`,
-        })
-      );
+      const idOptions = data.index_ids.map((id: string, index: number) => ({
+        label: id,
+        value: `index_ids:${index}`,
+      }));
 
-      options = [...cellLineNameOptions, ...options];
+      // Names first (the human-friendly default), then IDs as a secondary
+      // search path — matches the pre-refactor option ordering.
+      options = [...options, ...idOptions];
     }
 
     return options.filter((option) => {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerScatterPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerScatterPlot.tsx
@@ -26,11 +26,11 @@ interface Props {
   onClickColorByContext: (context: DataExplorerContextV2) => void;
   onClickSaveSelectionAsContext: (
     dimension_type: string,
-    selectedLabels: Set<string>
+    selectedIds: Set<string>
   ) => void;
   onClickVisualizeSelected: (
     e: React.MouseEvent,
-    selectedLabels: Set<string>
+    selectedIds: Set<string>
   ) => void;
   plotConfig: DataExplorerPlotConfig;
 }
@@ -45,9 +45,7 @@ function DataExplorerScatterPlot({
   plotConfig,
 }: Props) {
   const [plotElement, setPlotElement] = useState<ExtendedPlotType | null>(null);
-  const [selectedLabels, setSelectedLabels] = useState<Set<string> | null>(
-    null
-  );
+  const [selectedIds, setSelectedIds] = useState<Set<string> | null>(null);
   const [showSpinner, setShowSpinner] = useState(isLoading);
   const { plotStyles } = useDataExplorerSettings();
   const {
@@ -95,28 +93,28 @@ function DataExplorerScatterPlot({
   const slice_type1 = plotConfig.dimensions.y?.slice_type;
 
   useEffect(() => {
-    setSelectedLabels(null);
+    setSelectedIds(null);
   }, [slice_type0, slice_type1]);
 
   useEffect(() => {
-    if (!data?.index_labels) {
+    if (!data?.index_ids) {
       return;
     }
 
-    const validSelections = new Set(data.index_labels || []);
+    const validSelections = new Set(data.index_ids || []);
 
-    setSelectedLabels((xs) => {
+    setSelectedIds((xs) => {
       if (!xs) {
         return null;
       }
 
       const ys = new Set<string>();
-      const labels = [...xs];
+      const ids = [...xs];
 
-      for (let i = 0; i < labels.length; i += 1) {
-        const label = labels[i];
-        if (validSelections.has(label)) {
-          ys.add(label);
+      for (let i = 0; i < ids.length; i += 1) {
+        const id = ids[i];
+        if (validSelections.has(id)) {
+          ys.add(id);
         }
       }
 
@@ -127,27 +125,27 @@ function DataExplorerScatterPlot({
   const selectedPoints = useMemo(() => {
     const out: Set<number> = new Set();
 
-    if (!data?.index_labels) {
+    if (!data?.index_ids) {
       return out;
     }
 
-    for (let i = 0; i < data.index_labels.length; i += 1) {
-      if (selectedLabels?.has(data.index_labels[i])) {
+    for (let i = 0; i < data.index_ids.length; i += 1) {
+      if (selectedIds?.has(data.index_ids[i])) {
         out.add(i);
       }
     }
 
     return out;
-  }, [data, selectedLabels]);
+  }, [data, selectedIds]);
 
   const handleMultiselect = useCallback(
     (pointIndices: number[]) => {
       if (data && pointIndices.length > 0) {
         const s = new Set<string>();
         pointIndices.forEach((i: number) => {
-          s.add(data.index_labels[i]);
+          s.add(data.index_ids[i]);
         });
-        setSelectedLabels(s);
+        setSelectedIds(s);
       }
     },
     [data]
@@ -159,26 +157,48 @@ function DataExplorerScatterPlot({
         return;
       }
 
-      const label = data.index_labels[pointIndex];
+      const id = data.index_ids[pointIndex];
 
       if (ctrlKey) {
-        setSelectedLabels((xs) => {
+        setSelectedIds((xs) => {
           const ys = new Set(xs);
 
-          if (xs?.has(label)) {
-            ys.delete(label);
+          if (xs?.has(id)) {
+            ys.delete(id);
           } else {
-            ys.add(label);
+            ys.add(id);
           }
 
           return ys;
         });
       } else {
-        setSelectedLabels(new Set([label]));
+        setSelectedIds(new Set([id]));
       }
     },
-    [data, setSelectedLabels]
+    [data, setSelectedIds]
   );
+
+  // GeneTea consumes display labels (gene symbols), not IDs. Convert at
+  // the boundary by indexing the data's parallel id/label arrays.
+  const selectedLabels = useMemo(() => {
+    if (!data?.index_ids || !selectedIds) {
+      return selectedIds;
+    }
+
+    const idToLabel: Record<string, string> = {};
+    for (let i = 0; i < data.index_ids.length; i += 1) {
+      idToLabel[data.index_ids[i]] = data.index_labels[i];
+    }
+
+    const out = new Set<string>();
+    selectedIds.forEach((id) => {
+      const label = idToLabel[id];
+      if (label !== undefined) {
+        out.add(label);
+      }
+    });
+    return out;
+  }, [data, selectedIds]);
 
   return (
     <div className={styles.DataExplorerScatterPlot}>
@@ -190,7 +210,7 @@ function DataExplorerScatterPlot({
             isLoading={showSpinner}
             plotElement={plotElement}
             handleClickPoint={handleClickPoint}
-            onClickUnselectAll={() => setSelectedLabels(null)}
+            onClickUnselectAll={() => setSelectedIds(null)}
           />
         </div>
         <div className={styles.plot}>
@@ -218,7 +238,7 @@ function DataExplorerScatterPlot({
               selectedPoints={selectedPoints}
               showIdentityLine={showIdentityLine}
               regressionLines={regressionLines}
-              onClickResetSelection={() => setSelectedLabels(null)}
+              onClickResetSelection={() => setSelectedIds(null)}
               legendForDownload={legendForDownload}
               pointSize={pointSize}
               pointOpacity={pointOpacity}
@@ -248,27 +268,29 @@ function DataExplorerScatterPlot({
             <PlotSelections
               data={data}
               plot_type={plotConfig?.plot_type || null}
-              selectedLabels={selectedLabels}
+              selectedIds={selectedIds}
               onClickVisualizeSelected={(e) =>
-                onClickVisualizeSelected(e, selectedLabels as Set<string>)
+                onClickVisualizeSelected(e, selectedIds as Set<string>)
               }
               onClickSaveSelectionAsContext={() => {
                 onClickSaveSelectionAsContext(
                   plotConfig.index_type,
-                  selectedLabels as Set<string>
+                  selectedIds as Set<string>
                 );
               }}
               onClickClearSelection={() => {
-                setSelectedLabels(null);
+                setSelectedIds(null);
               }}
               onClickSetSelectionFromContext={async () => {
-                const labels = await promptForSelectionFromContext(data!);
+                const newSelectedIds = await promptForSelectionFromContext(
+                  data!
+                );
 
-                if (labels === null) {
+                if (newSelectedIds === null) {
                   return;
                 }
 
-                setSelectedLabels(labels);
+                setSelectedIds(newSelectedIds);
                 plotElement?.annotateSelected();
               }}
             />

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerWaterfallPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerWaterfallPlot.tsx
@@ -25,11 +25,11 @@ interface Props {
   onClickColorByContext: (context: DataExplorerContextV2) => void;
   onClickSaveSelectionAsContext: (
     dimension_type: string,
-    selectedLabels: Set<string>
+    selectedIds: Set<string>
   ) => void;
   onClickVisualizeSelected: (
     e: React.MouseEvent,
-    selectedLabels: Set<string>
+    selectedIds: Set<string>
   ) => void;
 }
 
@@ -42,9 +42,7 @@ function DataExplorerWaterfallPlot({
   onClickVisualizeSelected,
 }: Props) {
   const [plotElement, setPlotElement] = useState<ExtendedPlotType | null>(null);
-  const [selectedLabels, setSelectedLabels] = useState<Set<string> | null>(
-    null
-  );
+  const [selectedIds, setSelectedIds] = useState<Set<string> | null>(null);
   const [showSpinner, setShowSpinner] = useState(isLoading);
   const { plotStyles } = useDataExplorerSettings();
   const {
@@ -91,28 +89,28 @@ function DataExplorerWaterfallPlot({
   const slice_type1 = plotConfig.dimensions.y?.slice_type;
 
   useEffect(() => {
-    setSelectedLabels(null);
+    setSelectedIds(null);
   }, [slice_type0, slice_type1]);
 
   useEffect(() => {
-    if (!data?.index_labels) {
+    if (!data?.index_ids) {
       return;
     }
 
-    const validSelections = new Set(data.index_labels || []);
+    const validSelections = new Set(data.index_ids || []);
 
-    setSelectedLabels((xs) => {
+    setSelectedIds((xs) => {
       if (!xs) {
         return null;
       }
 
       const ys = new Set<string>();
-      const labels = [...xs];
+      const ids = [...xs];
 
-      for (let i = 0; i < labels.length; i += 1) {
-        const label = labels[i];
-        if (validSelections.has(label)) {
-          ys.add(label);
+      for (let i = 0; i < ids.length; i += 1) {
+        const id = ids[i];
+        if (validSelections.has(id)) {
+          ys.add(id);
         }
       }
 
@@ -123,27 +121,27 @@ function DataExplorerWaterfallPlot({
   const selectedPoints = useMemo(() => {
     const out: Set<number> = new Set();
 
-    if (!data?.index_labels) {
+    if (!data?.index_ids) {
       return out;
     }
 
-    for (let i = 0; i < data.index_labels.length; i += 1) {
-      if (selectedLabels?.has(data.index_labels[i])) {
+    for (let i = 0; i < data.index_ids.length; i += 1) {
+      if (selectedIds?.has(data.index_ids[i])) {
         out.add(i);
       }
     }
 
     return out;
-  }, [data, selectedLabels]);
+  }, [data, selectedIds]);
 
   const handleMultiselect = useCallback(
     (pointIndices: number[]) => {
       if (data && pointIndices.length > 0) {
         const s = new Set<string>();
         pointIndices.forEach((i: number) => {
-          s.add(data.index_labels[i]);
+          s.add(data.index_ids[i]);
         });
-        setSelectedLabels(s);
+        setSelectedIds(s);
       }
     },
     [data]
@@ -155,26 +153,48 @@ function DataExplorerWaterfallPlot({
         return;
       }
 
-      const label = data.index_labels[pointIndex];
+      const id = data.index_ids[pointIndex];
 
       if (ctrlKey) {
-        setSelectedLabels((xs) => {
+        setSelectedIds((xs) => {
           const ys = new Set(xs);
 
-          if (xs?.has(label)) {
-            ys.delete(label);
+          if (xs?.has(id)) {
+            ys.delete(id);
           } else {
-            ys.add(label);
+            ys.add(id);
           }
 
           return ys;
         });
       } else {
-        setSelectedLabels(new Set([label]));
+        setSelectedIds(new Set([id]));
       }
     },
-    [data, setSelectedLabels]
+    [data, setSelectedIds]
   );
+
+  // GeneTea consumes display labels (gene symbols), not IDs. Convert at
+  // the boundary by indexing the data's parallel id/label arrays.
+  const selectedLabels = useMemo(() => {
+    if (!data?.index_ids || !selectedIds) {
+      return selectedIds;
+    }
+
+    const idToLabel: Record<string, string> = {};
+    for (let i = 0; i < data.index_ids.length; i += 1) {
+      idToLabel[data.index_ids[i]] = data.index_labels[i];
+    }
+
+    const out = new Set<string>();
+    selectedIds.forEach((id) => {
+      const label = idToLabel[id];
+      if (label !== undefined) {
+        out.add(label);
+      }
+    });
+    return out;
+  }, [data, selectedIds]);
 
   return (
     <div className={styles.DataExplorerScatterPlot}>
@@ -186,7 +206,7 @@ function DataExplorerWaterfallPlot({
             isLoading={showSpinner}
             plotElement={plotElement}
             handleClickPoint={handleClickPoint}
-            onClickUnselectAll={() => setSelectedLabels(null)}
+            onClickUnselectAll={() => setSelectedIds(null)}
           />
         </div>
         <div className={styles.plot}>
@@ -213,7 +233,7 @@ function DataExplorerWaterfallPlot({
               onMultiselect={handleMultiselect}
               selectedPoints={selectedPoints}
               showIdentityLine={false}
-              onClickResetSelection={() => setSelectedLabels(null)}
+              onClickResetSelection={() => setSelectedIds(null)}
               legendForDownload={legendForDownload}
               pointSize={pointSize}
               pointOpacity={pointOpacity}
@@ -247,27 +267,29 @@ function DataExplorerWaterfallPlot({
             <PlotSelections
               data={data}
               plot_type={plotConfig?.plot_type || null}
-              selectedLabels={selectedLabels}
+              selectedIds={selectedIds}
               onClickVisualizeSelected={(e) =>
-                onClickVisualizeSelected(e, selectedLabels as Set<string>)
+                onClickVisualizeSelected(e, selectedIds as Set<string>)
               }
               onClickSaveSelectionAsContext={() => {
                 onClickSaveSelectionAsContext(
                   plotConfig.index_type,
-                  selectedLabels as Set<string>
+                  selectedIds as Set<string>
                 );
               }}
               onClickClearSelection={() => {
-                setSelectedLabels(null);
+                setSelectedIds(null);
               }}
               onClickSetSelectionFromContext={async () => {
-                const labels = await promptForSelectionFromContext(data!);
+                const newSelectedIds = await promptForSelectionFromContext(
+                  data!
+                );
 
-                if (labels === null) {
+                if (newSelectedIds === null) {
                   return;
                 }
 
-                setSelectedLabels(labels);
+                setSelectedIds(newSelectedIds);
                 plotElement?.annotateSelected();
               }}
             />

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DummyPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DummyPlot.tsx
@@ -125,7 +125,7 @@ function DummyPlot({
           <PlotSelections
             data={null}
             plot_type={null}
-            selectedLabels={null}
+            selectedIds={null}
             onClickVisualizeSelected={() => {}}
             onClickSaveSelectionAsContext={() => {}}
           />

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/PlotSelections/LabelsVirtualList.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/PlotSelections/LabelsVirtualList.tsx
@@ -3,21 +3,10 @@ import VirtualList from "react-tiny-virtual-list";
 import styles from "../../../styles/DataExplorer2.scss";
 
 const toHyperlink = (dimensionType: string, id: string, label: string) => {
-  if (dimensionType === "compound_experiment") {
-    const compound = label.replace(/\s*\(BRD:.*\)/, "");
-
-    return (
-      <span>
-        <a href={`../compound/${compound}`} target="_blank" rel="noreferrer">
-          {compound}
-        </a>
-      </span>
-    );
-  }
-
   const urlFor: Record<string, string | undefined> = {
     gene: `../gene/${label}`,
     depmap_model: `../cell_line/${id}`,
+    compound_v2: `../compound/${label}`,
   };
 
   if (!urlFor[dimensionType]) {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/PlotSelections/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/PlotSelections/index.tsx
@@ -11,7 +11,7 @@ import styles from "../../../styles/DataExplorer2.scss";
 interface Props {
   data: DataExplorerPlotResponse | null;
   plot_type: DataExplorerPlotType | null;
-  selectedLabels: Set<string> | null;
+  selectedIds: Set<string> | null;
   onClickVisualizeSelected: (e: React.MouseEvent) => void;
   onClickSaveSelectionAsContext: () => void;
   onClickClearSelection?: () => void;
@@ -23,7 +23,7 @@ const SECTION_HEIGHT_WITHOUT_LIST = 194;
 function PlotSelections({
   data,
   plot_type,
-  selectedLabels,
+  selectedIds,
   onClickVisualizeSelected,
   onClickSaveSelectionAsContext,
   onClickClearSelection = undefined,
@@ -33,8 +33,8 @@ function PlotSelections({
   const { sectionHeights } = useContext(SectionStackContext);
 
   const maxHeightOfList =
-    selectedLabels &&
-    selectedLabels.size > 0 &&
+    selectedIds &&
+    selectedIds.size > 0 &&
     plot_type !== "correlation_heatmap"
       ? sectionHeights[1] - SECTION_HEIGHT_WITHOUT_LIST
       : Infinity;
@@ -43,18 +43,18 @@ function PlotSelections({
     if (!data) {
       return [[], []];
     }
-    const indexLabels: string[] = [];
+    const selectedIndexIds: string[] = [];
     const displayLabels: string[] = [];
 
-    for (let i = 0; i < data.index_labels.length; i += 1) {
-      if (selectedLabels?.has(data.index_labels[i])) {
-        indexLabels.push(data.index_labels[i]);
-        displayLabels.push((data.index_display_labels || data.index_labels)[i]);
+    for (let i = 0; i < data.index_ids.length; i += 1) {
+      if (selectedIds?.has(data.index_ids[i])) {
+        selectedIndexIds.push(data.index_ids[i]);
+        displayLabels.push(data.index_labels[i]);
       }
     }
 
-    return [indexLabels, displayLabels];
-  }, [data, selectedLabels]);
+    return [selectedIndexIds, displayLabels];
+  }, [data, selectedIds]);
 
   const handleCopy = useCallback(() => {
     const w = window.open("");
@@ -71,19 +71,19 @@ function PlotSelections({
           Select points to populate list
           <HelpTip id="select-points-help" />
         </div>
-        {onClickClearSelection && selectedLabels && selectedLabels.size > 0 && (
+        {onClickClearSelection && selectedIds && selectedIds.size > 0 && (
           <div>
             <button
               className={styles.setSelectionButton}
               type="button"
               onClick={onClickClearSelection}
             >
-              clear {selectedLabels.size.toLocaleString()} selected{" "}
-              {selectedLabels.size === 1 ? "point" : "points"}
+              clear {selectedIds.size.toLocaleString()} selected{" "}
+              {selectedIds.size === 1 ? "point" : "points"}
             </button>
           </div>
         )}
-        {onClickSetSelectionFromContext && !selectedLabels && (
+        {onClickSetSelectionFromContext && !selectedIds && (
           <div>
             or{" "}
             <button

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/promptForSelectionFromContext.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/promptForSelectionFromContext.tsx
@@ -9,10 +9,9 @@ import ContextSelectorV2 from "../../../ContextSelectorV2";
 import { DepMap } from "@depmap/globals";
 import { DataExplorerContextV2, DataExplorerPlotResponse } from "@depmap/types";
 
-const resolveToLabels = async (context: DataExplorerContextV2) => {
+const resolveToIds = async (context: DataExplorerContextV2) => {
   const result = await cached(breadboxAPI).evaluateContext(context);
-
-  return context.dimension_type === "depmap_model" ? result.ids : result.labels;
+  return result.ids;
 };
 
 export default async function promptForSelectionFromContext(
@@ -20,8 +19,12 @@ export default async function promptForSelectionFromContext(
 ) {
   const filter = data!.filters?.visible;
 
-  const datasetLabels = new Set(
-    data.index_labels.filter((_, i) => {
+  // Identity comparisons in this function use Breadbox IDs throughout —
+  // resolved from contexts via `resolveToIds`, sourced from plot responses
+  // via `data.index_ids`. The returned `Set<string>` is consumed by plot
+  // components as `selectedIds` state.
+  const datasetIds = new Set(
+    data.index_ids.filter((_, i) => {
       return (
         data!.dimensions.x.values[i] !== null &&
         data!.dimensions.y?.values[i] !== null
@@ -61,32 +64,32 @@ export default async function promptForSelectionFromContext(
           return;
         }
 
-        const labels = await resolveToLabels(nextContext);
-        const contextLabels = new Set(labels);
+        const ids = await resolveToIds(nextContext);
+        const contextIds = new Set(ids);
 
-        const found = [...datasetLabels].filter((label) => {
-          return contextLabels.has(label);
+        const found = [...datasetIds].filter((id) => {
+          return contextIds.has(id);
         }).length;
 
-        const notFound = contextLabels.size - found;
+        const notFound = contextIds.size - found;
 
-        const hiddenByFilters = data.index_labels
-          .map((label, i) => {
+        const hiddenByFilters = data.index_ids
+          .map((id, i) => {
             return [
-              label,
-              datasetLabels.has(label) && filter ? filter.values[i] : true,
+              id,
+              datasetIds.has(id) && filter ? filter.values[i] : true,
             ];
           })
-          .filter(([label]) => contextLabels.has(label as string))
+          .filter(([id]) => contextIds.has(id as string))
           .filter(([, visible]) => !visible).length;
 
         setStats({
-          total: contextLabels.size,
+          total: contextIds.size,
           notFound,
           hiddenByFilters,
         });
 
-        const selectionLength = contextLabels.size - notFound - hiddenByFilters;
+        const selectionLength = contextIds.size - notFound - hiddenByFilters;
 
         if (selectionLength === 0) {
           updateAcceptText("OK");
@@ -146,15 +149,15 @@ export default async function promptForSelectionFromContext(
     return null;
   }
 
-  const labels = await resolveToLabels(context);
-  const contextLabels = new Set(labels);
-  const matchingLabels = data.index_labels.filter((label, i) => {
+  const ids = await resolveToIds(context);
+  const contextIds = new Set(ids);
+  const matchingIds = data.index_ids.filter((id, i) => {
     return (
-      datasetLabels.has(label) &&
-      contextLabels.has(label) &&
+      datasetIds.has(id) &&
+      contextIds.has(id) &&
       (filter ? filter.values[i] : true)
     );
   });
 
-  return matchingLabels.length ? new Set(matchingLabels) : null;
+  return matchingIds.length ? new Set(matchingIds) : null;
 }

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/PrototypeCorrelationHeatmap.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/PrototypeCorrelationHeatmap.tsx
@@ -237,6 +237,7 @@ function PrototypeCorrelationHeatmap({
     }
 
     const yaxis = axes.current.yaxis || {
+      type: "category" as const,
       automargin: true,
       autorange: true,
       tickvals: y,
@@ -251,6 +252,7 @@ function PrototypeCorrelationHeatmap({
       hoverlabel: { namelength: -1 },
 
       xaxis: {
+        type: "category",
         tickvals: x,
         ticktext: xLabels ? xLabels.map(truncate) : x.map(truncate),
         domain: [0, z2Key ? doubleHeatMapRatio : 1],
@@ -261,6 +263,7 @@ function PrototypeCorrelationHeatmap({
 
       ...(z2Key && {
         xaxis2: {
+          type: "category",
           tickvals: x,
           ticktext: xLabels ? xLabels.map(truncate) : x.map(truncate),
           domain: [1 - doubleHeatMapRatio, 1],

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/__tests__/plotToLookupTable.test.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/__tests__/plotToLookupTable.test.ts
@@ -3,8 +3,8 @@ import { DataExplorerPlotResponse } from "@depmap/types";
 
 const data: DataExplorerPlotResponse = {
   index_type: "depmap_model",
-  index_labels: ["ACH-000001", "ACH-000147", "ACH-000535", "ACH-000552"],
-  index_display_labels: ["NIHOVCAR3", "T47D", "BXPC3", "HT29"],
+  index_ids: ["ACH-000001", "ACH-000147", "ACH-000535", "ACH-000552"],
+  index_labels: ["NIHOVCAR3", "T47D", "BXPC3", "HT29"],
   dimensions: {
     x: {
       axis_label: "SOX10 Gene Effect (Chronos)",

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/plotToLookupTable.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/plotToLookupTable.ts
@@ -23,10 +23,19 @@ const applyFilter = (
 export default function plotToLookupTable(data: DataExplorerPlotResponse) {
   const indexColumn = getDimensionTypeLabel(data.index_type);
 
-  let formattedData: FormattedData = { [indexColumn]: data.index_labels };
+  // For depmap_model, the legacy CSV layout has two columns: depmap IDs
+  // in "Cell Line" and cell line names in "Cell Line Name". Preserve
+  // that exact shape, now reading IDs from `index_ids` and names from
+  // `index_labels` (which post-refactor carries real labels for all
+  // types, including depmap_model). For other dimension types, the
+  // single primary column continues to carry labels.
+  const primaryColumnValues =
+    data.index_type === "depmap_model" ? data.index_ids : data.index_labels;
+
+  let formattedData: FormattedData = { [indexColumn]: primaryColumnValues };
 
   if (data.index_type === "depmap_model") {
-    formattedData["Cell Line Name"] = data.index_display_labels as string[];
+    formattedData["Cell Line Name"] = data.index_labels;
   }
 
   Object.values(data.dimensions).forEach((dimension) => {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/plotUtils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/plotUtils.ts
@@ -303,14 +303,16 @@ export function formatDataForScatterPlot(
     catColorData: catValues || null,
     contColorData: contValues || null,
 
-    hoverText: data.index_labels.map((label: string, i: number) => {
+    hoverText: data.index_ids.map((id: string, i: number) => {
+      const label = data.index_labels[i];
       const aliases: string[] = [];
       const colorInfo = [];
 
-      // FIXME: We shouldn't have a special case for models.
-      // We should just show both id and label.
-      if (data.index_type === "depmap_model") {
-        aliases.push(`<b>${data.index_display_labels[i]}</b>`);
+      // Show the label prominently and the id as a secondary line when
+      // they differ. This is the desired behavior for every type where
+      // ids and labels are distinct (depmap_model, gene, compound_v2, etc).
+      if (id !== label) {
+        aliases.push(`<b>${label}</b>`);
       }
 
       if (c1Values && c1Values[i] && color_by === "aggregated_slice") {
@@ -333,15 +335,18 @@ export function formatDataForScatterPlot(
         );
       }
 
-      const formattedLabel =
-        data.index_type === "compound_experiment"
-          ? label.replace(/\s+\(BRD:.*\)/, "")
-          : label;
+      let primaryLine = label;
+
+      if (id !== label) {
+        primaryLine = data.index_id_column
+          ? `${data.index_id_column}: ${id}`
+          : id;
+      }
 
       const formattedLines =
         aliases.length > 0
-          ? [...aliases, `${formattedLabel}`, ...colorInfo]
-          : [`<b>${formattedLabel}</b>`, ...colorInfo];
+          ? [...aliases, primaryLine, ...colorInfo]
+          : [`<b>${primaryLine}</b>`, ...colorInfo];
 
       Object.keys(data.metadata || {}).forEach((key) => {
         let { label: hoverLabel } = data.metadata[key]!;
@@ -363,23 +368,14 @@ export function formatDataForScatterPlot(
       return formattedLines.join("<br>");
     }),
 
-    annotationText: data.index_labels.map((label: string, i: number) => {
-      const aliases: string[] = [];
+    annotationText: data.index_ids.map((id: string, i: number) => {
+      const label = data.index_labels[i];
 
-      // FIXME: We shouldn't have a special case for models.
-      // We should just show both id and label.
-      if (data.index_type === "depmap_model") {
-        aliases.push(`<b>${data.index_display_labels[i]}</b>`);
+      if (id !== label) {
+        return `<b>${label}</b>`;
       }
 
-      const formattedLabel =
-        data.index_type === "compound_experiment"
-          ? label.replace(/\s+\(BRD:.*\)/, "")
-          : label;
-
-      return aliases.length > 0
-        ? [...aliases].join("<br>")
-        : `<b>${formattedLabel}</b>`;
+      return `<b>${id}</b>`;
     }),
   };
 }

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/useCorrelationHeatmapData.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/useCorrelationHeatmapData.ts
@@ -57,8 +57,8 @@ export default function useCorrelationHeatmapData(
     () =>
       data && !isLoading
         ? {
-            x: data.index_labels.slice().reverse(),
-            y: data.index_labels,
+            x: data.index_ids.slice().reverse(),
+            y: data.index_ids,
             z: assert2d(data.dimensions.x.values).map(formatDimension),
             z2: data.dimensions.x2
               ? assert2d(data.dimensions.x2.values).map(formatDimension)
@@ -72,21 +72,17 @@ export default function useCorrelationHeatmapData(
     [data, isLoading]
   );
 
-  // If there are index_display_labels, use these for graphing
-  // so that we can prioritize cell line name over model id.
+  // Heatmap axis ticks show real labels (cell line names for depmap_model,
+  // gene symbols for genes, etc). Identity is carried separately by
+  // `heatmapData.x`/`.y` above. No legacy fallback needed — post-patch-1,
+  // `index_labels` is always real display labels.
   const xLabels = useMemo(
-    () =>
-      data && !isLoading
-        ? (data.index_display_labels || data.index_labels).slice().reverse()
-        : null,
+    () => (data && !isLoading ? data.index_labels.slice().reverse() : null),
     [data, isLoading]
   );
 
   const yLabels = useMemo(
-    () =>
-      data && !isLoading
-        ? data.index_display_labels || data.index_labels
-        : null,
+    () => (data && !isLoading ? data.index_labels : null),
     [data, isLoading]
   );
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/hooks/useClickHandlers.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/hooks/useClickHandlers.ts
@@ -27,33 +27,12 @@ export default function useClickHandlers(
 ) {
   const handleClickSaveSelectionAsContext = async (
     dimension_type: string,
-    selectedLabels: Set<string>
+    selectedIds: Set<string>
   ) => {
-    const labels = [...selectedLabels];
-
-    const identifiers = await dataExplorerAPI.fetchDimensionIdentifiers(
-      dimension_type
-    );
-    const labelToIdMap = Object.fromEntries(
-      identifiers.map(({ label, id }) => [label, id])
-    );
-
-    // "depmap_model" is a confusing type because its IDs were considered
-    // labels by the legacy portal.
-    let labelsAreDemapIds = plot.index_type === "depmap_model";
-
-    // To add an extra layer of confusion, this plot type's index isn't
-    // really a proper index.
-    if (plot.plot_type === "correlation_heatmap") {
-      labelsAreDemapIds = !labelsAreDemapIds;
-    }
-
-    const ids = labelsAreDemapIds
-      ? labels
-      : labels.map((label) => labelToIdMap[label]);
+    const ids = [...selectedIds];
 
     const context = {
-      name: defaultContextName(selectedLabels.size),
+      name: defaultContextName(selectedIds.size),
       dimension_type,
       expr: { in: [{ var: "given_id" }, ids] },
       vars: {},
@@ -63,7 +42,7 @@ export default function useClickHandlers(
   };
 
   const handleClickVisualizeSelected = useCallback(
-    async (e: React.MouseEvent, selectedLabels: Set<string>) => {
+    async (e: React.MouseEvent, selectedIds: Set<string>) => {
       if (!isCompletePlot(plot)) {
         throw new Error("Cannot visualize an incomplete plot!");
       }
@@ -79,7 +58,7 @@ export default function useClickHandlers(
         dimensionType
       );
 
-      const nextPlot = toRelatedPlot(plot, selectedLabels, identifiers);
+      const nextPlot = toRelatedPlot(plot, selectedIds, identifiers);
       const queryString = await plotToQueryString(nextPlot, ["task"]);
 
       if (isModifierPressed) {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/utils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/utils.ts
@@ -46,66 +46,44 @@ export const defaultContextName = (numLabels: number) => {
 
 export function toRelatedPlot(
   plot: DataExplorerPlotConfig,
-  selectedLabels: Set<string>,
+  selectedIds: Set<string>,
   identifiers: { id: string; label: string }[]
 ): DataExplorerPlotConfig {
-  const numDimensions = Math.min(selectedLabels.size, 2);
-  const slice_labels = [...selectedLabels];
+  const numDimensions = Math.min(selectedIds.size, 2);
+  const slice_ids = [...selectedIds];
 
   const idToLabelMap = Object.fromEntries(
     identifiers.map(({ id, label }) => [id, label])
   );
 
-  const labelToIdMap = Object.fromEntries(
-    identifiers.map(({ label, id }) => [label, id])
-  );
+  // The input set is real Breadbox IDs, regardless of `index_type` or
+  // `slice_type`. The context expressions emitted below reference those
+  // IDs directly through `given_id` — no per-type translation.
 
-  const toSliceName = (label: string, slice_type: string) => {
-    if (slice_type === "depmap_model") {
-      return idToLabelMap[label];
-    }
+  const toSliceName = (id: string) => idToLabelMap[id];
 
-    return label;
+  const toVarEqualityExpression = (id: string) => {
+    return { "==": [{ var: "given_id" }, id] };
   };
 
-  const toVarEqualityExpression = (label: string, slice_type: string) => {
-    let given_id = labelToIdMap[label];
-
-    if (
-      (plot.plot_type === "correlation_heatmap" &&
-        slice_type === "depmap_model") ||
-      (plot.plot_type !== "correlation_heatmap" &&
-        plot.index_type === "depmap_model")
-    ) {
-      given_id = label;
-    }
-
-    return { "==": [{ var: "given_id" }, given_id] };
-  };
-
-  const toVarInclusionExpression = (labels: string[]) => {
-    const ids =
-      plot.index_type === "depmap_model"
-        ? labels
-        : labels.map((label) => labelToIdMap[label]);
-
+  const toVarInclusionExpression = (ids: string[]) => {
     return { in: [{ var: "given_id" }, ids] };
   };
 
-  const toSingleSliceContext = (slice_type: string, label: string) => {
+  const toSingleSliceContext = (slice_type: string, id: string) => {
     return {
-      name: toSliceName(label, slice_type),
+      name: toSliceName(id),
       dimension_type: slice_type,
-      expr: toVarEqualityExpression(label, slice_type),
+      expr: toVarEqualityExpression(id),
       vars: {},
     };
   };
 
-  const toMultiSliceContext = (slice_type: string, labels: string[]) => {
+  const toMultiSliceContext = (slice_type: string, ids: string[]) => {
     return {
-      name: defaultContextName(selectedLabels.size),
+      name: defaultContextName(selectedIds.size),
       dimension_type: slice_type,
-      expr: toVarInclusionExpression(labels),
+      expr: toVarInclusionExpression(ids),
       vars: {},
     };
   };
@@ -150,7 +128,7 @@ export function toRelatedPlot(
             dataset_id,
             axis_type: "raw_slice",
             aggregation: "first",
-            context: toSingleSliceContext(slice_type, slice_labels[index]),
+            context: toSingleSliceContext(slice_type, slice_ids[index]),
           },
         }),
         {}
@@ -164,8 +142,8 @@ export function toRelatedPlot(
   const slice_type = plot.index_type;
 
   // { density_1d, waterfall, scatter } -> correlation_heatmap
-  if (selectedLabels.size > 2) {
-    const context = toMultiSliceContext(slice_type, slice_labels);
+  if (selectedIds.size > 2) {
+    const context = toMultiSliceContext(slice_type, slice_ids);
 
     const isCompatibleTwoContextComparison =
       plot.dimensions.x!.axis_type === "aggregated_slice" &&
@@ -238,7 +216,7 @@ export function toRelatedPlot(
           aggregation: "first",
           slice_type,
           dataset_id,
-          context: toSingleSliceContext(slice_type, slice_labels[index]),
+          context: toSingleSliceContext(slice_type, slice_ids[index]),
         },
       }),
       {}

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/__tests__/breadboxMethods.test.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/__tests__/breadboxMethods.test.ts
@@ -1,0 +1,401 @@
+import { breadboxAPI } from "@depmap/api";
+import {
+  DataExplorerPlotConfigDimension,
+  DataExplorerPlotResponse,
+} from "@depmap/types";
+import { fetchCorrelation, fetchPlotDimensions } from "../breadboxMethods";
+
+// Fixtures shared across cases.
+
+const modelIdentifiers = [
+  { id: "ACH-000425", label: "NIHOVCAR3" },
+  { id: "ACH-000552", label: "HT29" },
+  { id: "ACH-000001", label: "MCF7" },
+];
+
+const geneIdentifiers = [
+  { id: "ENSG00000164687", label: "FABP5" },
+  { id: "ENSG00000181449", label: "SOX2" },
+  { id: "ENSG00000176697", label: "BDNF" },
+];
+
+const dimensionTypes = [
+  {
+    name: "depmap_model",
+    display_name: "Cell Line",
+    id_column: "depmap_id",
+    axis: "sample" as const,
+    metadata_dataset_id: "depmap_model_metadata",
+  },
+  {
+    name: "gene",
+    display_name: "Gene",
+    id_column: "entrez_id",
+    axis: "feature" as const,
+    metadata_dataset_id: "gene_metadata",
+  },
+];
+
+const chronosDataset = {
+  id: "Chronos_Combined",
+  given_id: "Chronos_Combined",
+  name: "CRISPR (Chronos)",
+  format: "matrix_dataset" as const,
+  feature_type_name: "gene",
+  sample_type_name: "depmap_model",
+  units: "Gene effect",
+  value_type: "continuous" as const,
+  data_type: "CRISPR",
+  priority: 1,
+};
+
+// Shared mock setup: per-test we'll layer specifics on top.
+function mockDimensionTypes() {
+  breadboxAPI.getDimensionTypes = jest
+    .fn<ReturnType<typeof breadboxAPI.getDimensionTypes>, []>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockResolvedValue(dimensionTypes as any);
+}
+
+function mockDatasets() {
+  breadboxAPI.getDatasets = jest
+    .fn<ReturnType<typeof breadboxAPI.getDatasets>, []>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockResolvedValue([chronosDataset] as any);
+
+  breadboxAPI.getDataset = jest
+    .fn<ReturnType<typeof breadboxAPI.getDataset>, [string]>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockResolvedValue(chronosDataset as any);
+}
+
+function mockDatasetIdentifiers() {
+  breadboxAPI.getDatasetSamples = jest
+    .fn<ReturnType<typeof breadboxAPI.getDatasetSamples>, [string]>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockResolvedValue(modelIdentifiers as any);
+
+  breadboxAPI.getDatasetFeatures = jest
+    .fn<ReturnType<typeof breadboxAPI.getDatasetFeatures>, [string]>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockResolvedValue(geneIdentifiers as any);
+}
+
+function mockDimensionTypeIdentifiers() {
+  // Used by the metadata fetcher's id→label map. Routed by index_type name.
+  breadboxAPI.getDimensionTypeIdentifiers = jest
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .fn<any, [string]>()
+    .mockImplementation((name: string) => {
+      if (name === "depmap_model") {
+        return Promise.resolve(modelIdentifiers);
+      }
+      if (name === "gene") {
+        return Promise.resolve(geneIdentifiers);
+      }
+      return Promise.resolve([]);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+}
+
+// The matrix-data endpoint always returns Record<feature_id, Record<sample_id, value>>,
+// regardless of which `*_identifier: "label"` was requested in the params.
+// For the tests below, we shape responses to match the dimension being fetched.
+function mockMatrixDataFor(slice: "gene" | "depmap_model") {
+  // Selecting one feature (gene) returns one row keyed by that gene id,
+  // with all sample ids underneath.
+  // Selecting one sample (model) returns all gene ids, each with one
+  // entry for that sample id.
+  const response =
+    slice === "gene"
+      ? {
+          ENSG00000164687: {
+            "ACH-000425": 0.5,
+            "ACH-000552": -0.3,
+            "ACH-000001": 1.2,
+          },
+        }
+      : {
+          ENSG00000164687: { "ACH-000425": 0.5 },
+          ENSG00000181449: { "ACH-000425": -0.7 },
+          ENSG00000176697: { "ACH-000425": 0.1 },
+        };
+
+  breadboxAPI.getMatrixDatasetData = jest
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .fn<ReturnType<typeof breadboxAPI.getMatrixDatasetData>, [string, any]>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockResolvedValue(response as any);
+}
+
+// `fetchPlotDimensions` will *unconditionally* fetch two hardcoded metadata
+// columns when `index_type === "depmap_model"` (OncotreePrimaryDisease,
+// OncotreeLineage on depmap_model_metadata, both routed as `column` slices
+// through `getTabularDatasetData`). Mock a response keyed by depmap ids.
+function mockDepmapModelHardcodedExtras() {
+  breadboxAPI.getTabularDatasetData = jest
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .fn<any, [string, any]>()
+    .mockImplementation((_datasetId: string, params: { columns: string[] }) => {
+      const out: Record<string, Record<string, string | null>> = {};
+      for (const column of params.columns) {
+        out[column] = {
+          "ACH-000425": `${column}_NIHOVCAR3`,
+          "ACH-000552": `${column}_HT29`,
+          "ACH-000001": `${column}_MCF7`,
+        };
+      }
+      return Promise.resolve(out);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+}
+
+// Asserts the structural invariants of the new contract: index_ids and
+// index_labels are aligned, every id maps to the expected label, every
+// label is the real label (not the id repeated), and every returned
+// values array is aligned with index_ids.
+function expectIdsAndLabelsAligned(
+  response: DataExplorerPlotResponse,
+  expectedIdToLabel: Record<string, string>
+) {
+  expect(response.index_ids).toBeDefined();
+  expect(response.index_labels).toBeDefined();
+  expect(response.index_ids.length).toBe(response.index_labels.length);
+
+  for (let i = 0; i < response.index_ids.length; i += 1) {
+    const id = response.index_ids[i];
+    const label = response.index_labels[i];
+    expect(expectedIdToLabel[id]).toBeDefined();
+    // The label is the *real* display label, not the id mirrored back.
+    // This catches the regression where `depmap_model` carried IDs in
+    // `index_labels` for legacy-compat reasons.
+    expect(label).toBe(expectedIdToLabel[id]);
+  }
+
+  // Dimension value arrays are aligned with index_ids.
+  Object.values(response.dimensions || {}).forEach((dim) => {
+    if (dim && Array.isArray(dim.values)) {
+      expect(dim.values.length).toBe(response.index_ids.length);
+    }
+  });
+}
+
+describe("fetchPlotDimensions", () => {
+  describe("with depmap_model index_type", () => {
+    test("raw_slice dimension produces aligned index_ids and index_labels", async () => {
+      mockDimensionTypes();
+      mockDatasets();
+      mockDatasetIdentifiers();
+      mockDimensionTypeIdentifiers();
+      mockMatrixDataFor("gene");
+      mockDepmapModelHardcodedExtras();
+
+      const xDimension: DataExplorerPlotConfigDimension = {
+        axis_type: "raw_slice",
+        aggregation: "first",
+        slice_type: "gene",
+        dataset_id: "Chronos_Combined",
+        context: {
+          name: "FABP5",
+          context_type: "gene",
+          expr: { "==": [{ var: "entity_label" }, "FABP5"] },
+        },
+      };
+
+      const response = await fetchPlotDimensions("depmap_model", {
+        x: xDimension,
+      });
+
+      const expectedMap = Object.fromEntries(
+        modelIdentifiers.map(({ id, label }) => [id, label])
+      );
+
+      expectIdsAndLabelsAligned(response, expectedMap);
+
+      // The id column name is forwarded from Breadbox.
+      expect(response.index_id_column).toBe("depmap_id");
+
+      // Every returned id is a real depmap id.
+      response.index_ids.forEach((id) => {
+        expect(id).toMatch(/^ACH-/);
+      });
+    });
+  });
+
+  describe("with gene index_type", () => {
+    test("raw_slice dimension produces aligned index_ids and index_labels", async () => {
+      mockDimensionTypes();
+      mockDatasets();
+      mockDatasetIdentifiers();
+      mockDimensionTypeIdentifiers();
+      mockMatrixDataFor("depmap_model");
+
+      const xDimension: DataExplorerPlotConfigDimension = {
+        axis_type: "raw_slice",
+        aggregation: "first",
+        slice_type: "depmap_model",
+        dataset_id: "Chronos_Combined",
+        context: {
+          name: "NIHOVCAR3",
+          context_type: "depmap_model",
+          expr: { "==": [{ var: "entity_label" }, "ACH-000425"] },
+        },
+      };
+
+      const response = await fetchPlotDimensions("gene", {
+        x: xDimension,
+      });
+
+      const expectedMap = Object.fromEntries(
+        geneIdentifiers.map(({ id, label }) => [id, label])
+      );
+
+      expectIdsAndLabelsAligned(response, expectedMap);
+
+      // The id column name is forwarded from Breadbox.
+      expect(response.index_id_column).toBe("entrez_id");
+
+      // Every returned id is a real gene id.
+      response.index_ids.forEach((id) => {
+        expect(id).toMatch(/^ENSG/);
+      });
+    });
+  });
+});
+
+// Correlation-specific fixtures. These genes are chosen so the correlation
+// matrix has a unique, predictable structure: GENE_A and GENE_B are
+// perfectly correlated; GENE_C is perfectly anti-correlated with both.
+const correlationGeneIdentifiers = [
+  { id: "11111", label: "GENE_A" },
+  { id: "22222", label: "GENE_B" },
+  { id: "33333", label: "GENE_C" },
+];
+
+// For the matrix request: features × samples, with sample IDs as inner keys.
+// GENE_A and GENE_B have identical value rows (ρ = 1).
+// GENE_C has reversed values (ρ = −1 vs A and B).
+const correlationMatrixResponse = {
+  GENE_A: { "ACH-000001": 1.0, "ACH-000002": 2.0, "ACH-000003": 3.0, "ACH-000004": 4.0 },
+  GENE_B: { "ACH-000001": 1.0, "ACH-000002": 2.0, "ACH-000003": 3.0, "ACH-000004": 4.0 },
+  GENE_C: { "ACH-000001": 4.0, "ACH-000002": 3.0, "ACH-000003": 2.0, "ACH-000004": 1.0 },
+};
+
+function mockCorrelationContext() {
+  // `correlateDimension` calls `evaluateContext` on the input context
+  // (and on `filter` if one is provided — not here). Returns the parallel
+  // labels and ids arrays for the genes being correlated.
+  breadboxAPI.evaluateContext = jest
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .fn<any, [any]>()
+    .mockResolvedValue({
+      ids: correlationGeneIdentifiers.map((g) => g.id),
+      labels: correlationGeneIdentifiers.map((g) => g.label),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any) as any;
+}
+
+function mockCorrelationMatrixData() {
+  breadboxAPI.getMatrixDatasetData = jest
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .fn<ReturnType<typeof breadboxAPI.getMatrixDatasetData>, [string, any]>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockResolvedValue(correlationMatrixResponse as any);
+}
+
+describe("fetchCorrelation", () => {
+  const xDimension: DataExplorerPlotConfigDimension = ({
+    axis_type: "aggregated_slice",
+    aggregation: "correlation",
+    slice_type: "gene",
+    dataset_id: "Chronos_Combined",
+    context: {
+      name: "(3 selected)",
+      context_type: "gene",
+      expr: {
+        in: [{ var: "given_id" }, ["11111", "22222", "33333"]],
+      },
+      vars: {},
+    },
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as unknown) as any;
+
+  const setupMocks = () => {
+    mockDimensionTypes();
+    mockDatasets();
+    mockDatasetIdentifiers();
+    mockDimensionTypeIdentifiers();
+    mockCorrelationContext();
+    mockCorrelationMatrixData();
+  };
+
+  // Helper: find each gene's position in the response so assertions can be
+  // written without depending on a specific clustering order.
+  const positionsOf = (response: DataExplorerPlotResponse) => {
+    const idToIndex: Record<string, number> = {};
+    response.index_ids.forEach((id, i) => {
+      idToIndex[id] = i;
+    });
+    return idToIndex;
+  };
+
+  test("returns aligned index_ids and index_labels for gene-by-gene correlation", async () => {
+    setupMocks();
+
+    const response = await fetchCorrelation("gene", { x: xDimension });
+
+    // The fundamental invariant: ids and labels are parallel arrays of
+    // equal length, and each (id, label) pair refers to the same gene.
+    expect(response.index_ids.length).toBe(3);
+    expect(response.index_labels.length).toBe(3);
+
+    const labelById = Object.fromEntries(
+      correlationGeneIdentifiers.map(({ id, label }) => [id, label])
+    );
+    for (let i = 0; i < response.index_ids.length; i += 1) {
+      expect(response.index_labels[i]).toBe(labelById[response.index_ids[i]]);
+    }
+  });
+
+  test("matrix rows/columns are aligned with index_ids regardless of clustering order", async () => {
+    setupMocks();
+
+    const response = await fetchCorrelation("gene", { x: xDimension }, undefined, true);
+    const matrix = response.dimensions.x.values as unknown as number[][];
+
+    expect(matrix.length).toBe(3);
+    matrix.forEach((row) => expect(row.length).toBe(3));
+
+    // Diagonal is always self-correlation = 1.
+    for (let i = 0; i < 3; i += 1) {
+      expect(matrix[i][i]).toBeCloseTo(1, 5);
+    }
+
+    // Find each gene's position post-clustering, then verify the matrix
+    // cell at those positions matches the expected correlation. This is
+    // the regression assertion for patch-10: if `index_ids` got reordered
+    // by clustering but the matrix didn't (or vice versa), this fails.
+    const pos = positionsOf(response);
+    const a = pos["11111"];
+    const b = pos["22222"];
+    const c = pos["33333"];
+
+    // A and B: perfectly correlated.
+    expect(matrix[a][b]).toBeCloseTo(1, 5);
+    expect(matrix[b][a]).toBeCloseTo(1, 5);
+
+    // C vs A and B: perfectly anti-correlated.
+    expect(matrix[a][c]).toBeCloseTo(-1, 5);
+    expect(matrix[c][a]).toBeCloseTo(-1, 5);
+    expect(matrix[b][c]).toBeCloseTo(-1, 5);
+    expect(matrix[c][b]).toBeCloseTo(-1, 5);
+  });
+
+  test("the id_column name is forwarded from Breadbox", async () => {
+    setupMocks();
+
+    const response = await fetchCorrelation("gene", { x: xDimension });
+
+    expect(response.index_id_column).toBe("entrez_id");
+  });
+});

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/breadboxMethods.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/breadboxMethods.ts
@@ -161,6 +161,7 @@ const isPrimaryMetatadata = (dataset?: Dataset) => {
  */
 function buildExtendedMetadata(
   index_type: string,
+  index_id_column?: string,
   metadata?: DataExplorerMetadata,
   filters?: DataExplorerFilters
 ): DataExplorerMetadata {
@@ -211,6 +212,13 @@ function buildExtendedMetadata(
     filters || {}
   ) as DataExplorerContextV2[]) {
     for (const variable of Object.values(filter.vars)) {
+      if (
+        variable.identifier === "label" ||
+        variable.identifier === index_id_column
+      ) {
+        continue;
+      }
+
       const asSliceQuery: SliceQuery = {
         dataset_id: variable.dataset_id,
         identifier: variable.identifier,
@@ -238,8 +246,6 @@ export async function fetchPlotDimensions(
   filters?: DataExplorerFilters,
   metadata?: DataExplorerMetadata
 ): Promise<DataExplorerPlotResponse> {
-  const extendedMetadata = buildExtendedMetadata(index_type, metadata, filters);
-
   // Pre-fetch data we know we'll need below. This only works because
   // postJson() caches the Promises. When we later repeat each fetch with an
   // `await`, we're actually awaiting an inflight promise, effectively making
@@ -248,6 +254,17 @@ export async function fetchPlotDimensions(
   fetchDatasetLabel(dimensions.x?.dataset_id);
   fetchDatasetLabel(dimensions.y?.dataset_id);
   fetchDatasetLabel(dimensions.color?.dataset_id);
+
+  const dimTypes = await cached(breadboxAPI).getDimensionTypes();
+  const index_id_column = dimTypes.find((t) => t.name === index_type)
+    ?.id_column;
+
+  const extendedMetadata = buildExtendedMetadata(
+    index_type,
+    index_id_column,
+    metadata,
+    filters
+  );
 
   const dimensionKeys = Object.keys(dimensions).filter((key) => {
     return isCompleteDimension(dimensions[key]);
@@ -259,17 +276,19 @@ export async function fetchPlotDimensions(
   // https://github.com/broadinstitute/depmap-portal/blob/5099618/frontend/packages/portal-frontend/src/data-explorer-2/deprecated-api.ts#L412-L435
   const metadataKeys = Object.keys(extendedMetadata || {});
 
-  // FIXME: We shouldn't be indexing things by label. We should use id instead.
-  // This is just to get things working for now.
+  // Tracks every distinct label seen across the dimension fetches. Drives
+  // `index_labels` (and, via `labelToIdMapping`, `index_ids`) in the
+  // assembled response.
   const uniqueLabels = new Set<string>();
 
-  // HACK: For now we'll reverse the relationship of id and label for models.
-  const cellLineIdMapping = {} as Record<string, string>;
+  // Tracks the label→id correspondence for every (label, id) pair seen
+  // during dimension fetches. Used to populate `index_ids` in the
+  // response by mapping `uniqueLabels` to their corresponding IDs.
+  const labelToIdMapping = {} as Record<string, string>;
 
   async function fetchRawDimension(key: string) {
     const { context, dataset_id, slice_type } = dimensions[key];
 
-    // FIXME: Remove this when we convert everything to use IDs.
     const idToLabelMapping = await (() => {
       return fetchDatasetIdentifiers(
         index_type,
@@ -305,16 +324,11 @@ export async function fetchPlotDimensions(
 
       for (let i = 0; i < ids.length; i++) {
         const id = ids[i];
-        // TODO: Change this to use ids instead of labels.
         const label = idToLabelMapping[id];
         uniqueLabels.add(label);
+        labelToIdMapping[label] = id;
 
-        if (index_type === "depmap_model") {
-          indexed_values[id] = values[i];
-          cellLineIdMapping[label] = id;
-        } else {
-          indexed_values[label] = values[i];
-        }
+        indexed_values[id] = values[i];
       }
 
       return {
@@ -373,13 +387,9 @@ export async function fetchPlotDimensions(
 
     index_indentifiers.forEach(({ id, label }) => {
       uniqueLabels.add(label);
+      labelToIdMapping[label] = id;
 
-      if (index_type === "depmap_model") {
-        indexed_values[id] = response[aggregation][id] ?? null;
-        cellLineIdMapping[label] = id;
-      } else {
-        indexed_values[label] = response[aggregation][id] ?? null;
-      }
+      indexed_values[id] = response[aggregation][id] ?? null;
     });
 
     return {
@@ -404,12 +414,8 @@ export async function fetchPlotDimensions(
         .then((result) => {
           const indexed_values: Record<string, true> = {};
 
-          // TODO: Change this to use ids instead of labels for all types (not
-          // just depmap_model)
-          for (let i = 0; i < result.labels.length; i++) {
-            const label =
-              index_type === "depmap_model" ? result.ids[i] : result.labels[i];
-            indexed_values[label] = true;
+          for (let i = 0; i < result.ids.length; i++) {
+            indexed_values[result.ids[i]] = true;
           }
 
           return {
@@ -433,24 +439,13 @@ export async function fetchPlotDimensions(
       const data = await getDimensionDataWithoutLabels(sliceQuery);
       let value_type = await fetchValueType(sliceQuery);
 
-      // FIXME: Remove this when we convert everything to use IDs.
-      const idToLabelMapping = await (() => {
-        return cached(breadboxAPI)
-          .getDimensionTypeIdentifiers(index_type)
-          .then((identifiers) =>
-            Object.fromEntries(identifiers.map(({ id, label }) => [id, label]))
-          );
-      })();
-
       const distinct = new Set<unknown>();
 
       for (let i = 0; i < data.values.length; i += 1) {
         const id = data.ids[i];
-        const indexKey =
-          index_type === "depmap_model" ? id : idToLabelMapping[id];
         const indexedValue = data.values[i];
 
-        indexed_values[indexKey] = indexedValue;
+        indexed_values[id] = indexedValue;
 
         if (indexedValue) {
           if (Array.isArray(indexedValue)) {
@@ -487,19 +482,19 @@ export async function fetchPlotDimensions(
     }),
   ]);
 
-  const index_labels =
-    index_type === "depmap_model"
-      ? [...uniqueLabels].map((label) => cellLineIdMapping[label])
-      : [...uniqueLabels];
+  // `index_labels` always carries real, human-readable labels — the
+  // post-refactor contract: identity is `index_ids`, display is
+  // `index_labels`.
+  const index_labels = [...uniqueLabels];
 
-  const index_display_labels =
-    index_type === "depmap_model" ? [...uniqueLabels] : index_labels;
+  const index_ids = [...uniqueLabels].map((label) => labelToIdMapping[label]);
 
   return (async () => {
     const out = {
       index_type,
+      index_id_column,
+      index_ids,
       index_labels,
-      index_display_labels,
       linreg_by_group: [],
       dimensions: {} as DataExplorerPlotResponse["dimensions"],
       filters: {} as DataExplorerPlotResponse["filters"],
@@ -507,7 +502,6 @@ export async function fetchPlotDimensions(
     };
 
     const datasets = await cached(breadboxAPI).getDatasets();
-    const dimTypes = await cached(breadboxAPI).getDimensionTypes();
     const dimTypeMap = buildDimTypeMap(dimTypes);
     const tablesByDim = buildTablesByDim(datasets);
 
@@ -594,8 +588,8 @@ export async function fetchPlotDimensions(
 
       if (property === "dimensions") {
         let value_type = valueTypes[key];
-        const values = out.index_labels.map((label) => {
-          return indexed_values[label] ?? null;
+        const values = out.index_ids.map((id) => {
+          return indexed_values[id] ?? null;
         }) as number[];
 
         if (key === "color") {
@@ -628,8 +622,8 @@ export async function fetchPlotDimensions(
 
         out.filters[key as FilterKey] = {
           name: filters![key as FilterKey]!.name,
-          values: out.index_labels.map((label) => {
-            return boolValues[label] ?? false;
+          values: out.index_ids.map((id) => {
+            return boolValues[id] ?? false;
           }),
         };
       }
@@ -651,8 +645,8 @@ export async function fetchPlotDimensions(
           dataset && !isPrimaryMetatadata(dataset) ? dataset.name : undefined;
 
         const value_type = (response as any).value_type;
-        const values = out.index_labels.map((label) => {
-          return indexed_values[label] ?? null;
+        const values = out.index_ids.map((id) => {
+          return indexed_values[id] ?? null;
         });
 
         // HACK! I never imagined there would be continuous metadata. We'll
@@ -968,19 +962,43 @@ const correlateDimension = memoize(
       );
     }
 
-    const representedIds: string[] = [];
+    // Build label↔id lookups from the parallel arrays returned by
+    // `evaluateContext`. Used to rekey `data` from labels to IDs before
+    // the correlation computation, so the entire downstream path is
+    // ID-keyed (matching the rest of Data Explorer's post-refactor
+    // contract). Labels are only needed at the very end for the display
+    // side of the response.
+    const labelToId: Record<string, string> = {};
+    const idToLabel: Record<string, string> = {};
+    for (let i = 0; i < labels.length; i += 1) {
+      labelToId[labels[i]] = ids[i];
+      idToLabel[ids[i]] = labels[i];
+    }
 
-    Object.keys(data).forEach((key, i) => {
+    // Rekey `data` from label-keyed to ID-keyed. `correlationMatrix` is
+    // agnostic about what its keys mean — it just preserves them through
+    // any internal reordering — so handing it IDs makes the returned
+    // `columns` already be IDs in cluster order, no post-hoc alignment
+    // needed.
+    data = Object.fromEntries(
+      Object.entries(data).map(([label, values]) => [labelToId[label], values])
+    );
+
+    Object.keys(data).forEach((key) => {
       const values = data[key];
       const distinct = new Set(values);
       if (distinct.size === 1 && [...distinct][0] == null) {
         delete data[key];
-      } else {
-        representedIds.push(ids[i]);
       }
     });
 
     const { columns, matrix } = correlationMatrix(data, use_clustering);
+
+    // `columns` is now the post-clustering ID order, aligned with the
+    // rows and columns of `matrix`. Derive the parallel label array for
+    // the display side of the response.
+    const representedIds = columns;
+    const representedLabels = columns.map((id) => idToLabel[id]);
 
     const isAutoNamedContext = context.name.match(/^\(\d+ selected\)/) !== null;
     const entities = await fetchEntitiesLabel(slice_type);
@@ -1017,7 +1035,7 @@ const correlateDimension = memoize(
       values: (matrix as unknown) as number[],
     };
 
-    return [outputDimension, columns, representedIds];
+    return [outputDimension, representedIds, representedLabels];
   }
 );
 
@@ -1029,7 +1047,7 @@ export async function fetchCorrelation(
   // eslint-disable-next-line
   use_clustering?: boolean
 ): Promise<DataExplorerPlotResponse> {
-  const [x, xColumns, ids] = await correlateDimension(
+  const [x, ids, labels] = await correlateDimension(
     dimensions.x,
     index_type,
     filters?.distinguish1 as DataExplorerContextV2,
@@ -1045,12 +1063,15 @@ export async function fetchCorrelation(
       )
     : [null];
 
-  const isModelCorrelation = dimensions.x.slice_type === "depmap_model";
+  const dimTypes = await cached(breadboxAPI).getDimensionTypes();
+  const index_id_column = dimTypes.find((t) => t.name === index_type)
+    ?.id_column;
 
   return {
     index_type,
-    index_labels: isModelCorrelation ? ids : xColumns,
-    index_display_labels: xColumns,
+    index_id_column,
+    index_ids: ids,
+    index_labels: labels,
     dimensions: x2 ? { x, x2 } : { x },
     filters: {},
     metadata: {},
@@ -1173,14 +1194,13 @@ export async function fetchWaterfall(
     };
   });
 
-  const sortedIndexDisplayLabels = sortByReindexedLabels(
-    unsortedData.index_display_labels
-  );
+  const sortedIndexIds = sortByReindexedLabels(unsortedData.index_ids);
 
   return {
     index_type,
+    index_id_column: unsortedData.index_id_column,
+    index_ids: sortedIndexIds,
     index_labels: sortedLabels,
-    index_display_labels: sortedIndexDisplayLabels,
     dimensions: sortedDimensions,
     filters: sortedFilters,
     metadata: sortedMetadata,

--- a/frontend/packages/@depmap/selects/src/components/AnnotationSelect/computeLevel.ts
+++ b/frontend/packages/@depmap/selects/src/components/AnnotationSelect/computeLevel.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-continue */
 import type {
   ColumnEntry,
   ColumnGroup,

--- a/frontend/packages/@depmap/selects/src/components/AnnotationSelect/schemaHelpers.ts
+++ b/frontend/packages/@depmap/selects/src/components/AnnotationSelect/schemaHelpers.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-continue */
 import type { Dataset, TabularDataset } from "@depmap/types";
 import type { DimensionTypeDescriptor, TableDescriptor } from "./types";
 

--- a/frontend/packages/@depmap/selects/src/components/AnnotationSelect/sliceQueryUtils.ts
+++ b/frontend/packages/@depmap/selects/src/components/AnnotationSelect/sliceQueryUtils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-continue */
 import { SliceQuery } from "@depmap/types";
 import type {
   ChainHop,

--- a/frontend/packages/@depmap/selects/src/components/AnnotationSelect/useChainSelectorData.ts
+++ b/frontend/packages/@depmap/selects/src/components/AnnotationSelect/useChainSelectorData.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-continue */
 import { useEffect, useMemo, useState } from "react";
 import { breadboxAPI, cached } from "@depmap/api";
 import type { Dataset, TabularDataset, MatrixDataset } from "@depmap/types";

--- a/frontend/packages/@depmap/slice-table/src/components/useData.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/useData.tsx
@@ -145,7 +145,6 @@ async function extractColumnRenames(
       // eslint-disable-next-line no-cond-assign
       while ((entryMatch = entryRegex.exec(outerMatch[1])) !== null) {
         if (entryMatch[2] === "label" && hasLabelTransform) {
-          // eslint-disable-next-line no-continue
           continue;
         }
 
@@ -366,7 +365,6 @@ export function transformToTableData(
 
     for (let i = 0; i < response.ids.length; i++) {
       if (index > 0 && !labelIds.has(response.ids[i])) {
-        // eslint-disable-next-line no-continue
         continue;
       }
       keyed[response.ids[i]] = response.values[i];
@@ -768,7 +766,6 @@ export default function useAlignedData({
           );
 
           if (!dataset) {
-            // eslint-disable-next-line no-continue
             continue;
           }
 

--- a/frontend/packages/@depmap/slice-table/src/components/useSliceTableState.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/useSliceTableState.tsx
@@ -197,7 +197,6 @@ export function useSliceTableState({
 
     for (const col of columns) {
       if (!isValidSliceQuery(col.meta.sliceQuery)) {
-        // eslint-disable-next-line no-continue
         continue;
       }
 

--- a/frontend/packages/@depmap/types/src/data-explorer-2.ts
+++ b/frontend/packages/@depmap/types/src/data-explorer-2.ts
@@ -130,15 +130,21 @@ export type PartialDataExplorerPlotConfig = PartialDeep<DataExplorerPlotConfig>;
 export interface DataExplorerPlotResponse {
   index_type: string;
 
-  // Human-readable labels. Legacy code also uses these as makeshift IDs but
-  // that practice is discouraged going forward.
-  index_labels: string[];
+  // The id column name for `index_type` as reported by Breadbox
+  // (e.g. "depmap_id", "entrez_id"). Used to give the bare id values in
+  // `index_ids` a human-readable label in display contexts like hover
+  // text. Optional because some legacy code paths construct responses
+  // without consulting Breadbox.
+  index_id_column?: string;
 
-  // Temporary! Eventually we want to be in a situation where index_ids and
-  // index_labels are well defined for all dimension types. We're/ not there
-  // yet. Lots of legacy code wants to use index_labels as makeshift IDs.
-  // These labels are explicitly for display purposes only.
-  index_display_labels: string[];
+  // Real, stable identifiers from Breadbox. Use this for identity:
+  // joins, lookups, selection state, filters, URL state, anything
+  // persistent.
+  index_ids: string[];
+
+  // Human-readable display labels, parallel to `index_ids`. Use this
+  // for any user-facing text — hover, axis ticks, list rendering.
+  index_labels: string[];
 
   dimensions: {
     x: DataExplorerPlotResponseDimension;


### PR DESCRIPTION
Data Explorer used to support a legacy backend that did not expose separate ids and labels for entities. To paper over that, the codebase adopted a convention where `index_labels` served as both the display string and the join key / identity handle. For non-model dimension types this worked accidentally well; for `depmap_model` it didn't, so a special case keyed by id when the index_type was `depmap_model` and by label otherwise.

That special case had become load-bearing across the dimension, filter, and metadata fetchers, and across downstream consumers that read `index_labels` as if it were an id (selection state, URL state, persistent handles). With the legacy backend retired and Breadbox providing separate id and label columns for every dimension type, the conflation was pure technical debt.

After this change, the rule is:

  * Joins, lookups, selection, filters, URL state, persistent handles → ids
  * Display strings, axis labels, hover text → labels
  * Code that needs both has both, explicitly

Highlights of the change:

  * `DataExplorerPlotResponse` gains `index_ids` as the identity field alongside `index_labels` (always real labels now); `index_display_labels` is removed.

  * All fetchers in `breadboxMethods.ts` key `indexed_values` by id and populate `index_ids` and `index_labels` as honest parallel arrays for every dimension type. `correlateDimension` rekeys matrix data from labels to ids before clustering, so the returned columns are aligned with the matrix automatically.

  * Selection state in all four plot components, the click handlers, `toRelatedPlot`, `promptForSelectionFromContext`, and `PlotSelections` now holds ids. The GeneTea integration converts to labels at the boundary.

  * `PrototypeCorrelationHeatmap` sets `type: "category"` on its axes so numeric-string ids (Entrez gene ids) don't get treated as a linear scale.

  * Hover text shows the label prominently and prefixes the secondary id line with the dimension type's `id_column` ("entrez_id: 1503" rather than a bare "1503").

  * The depmap_model id-as-entity_label quirk is confined to one place: `PrecomputedAssociations` skips its label-to-id lookup for depmap_model legacy V1 contexts, where the "entity_label" value is already a depmap id. Nothing else in Data Explorer needs to know about it.

Test coverage adds `fetchPlotDimensions` per-type symmetry, `fetchCorrelation` matrix/id alignment under clustering, and `toRelatedPlot` end-to-end behavior. The data-explorer-2 jest setup gains the API-mocking proxy from portal-frontend so per-test mock assignment works for breadbox calls.