### PR TITLE
Forcibly abort any SQL queries which take too long

### DIFF
--- a/breadbox/breadbox/api/compute.py
+++ b/breadbox/breadbox/api/compute.py
@@ -99,7 +99,6 @@ def compute_univariate_associations(
     For two class comparisons, the queryValues are the strings "in" and "out".
     """
 
-    resultsDirPrefix = settings.compute_results_location
     dataset_id = computeParams.datasetId
     vector_variable_type = computeParams.vectorVariableType
     depmap_model_ids = computeParams.queryCellLines
@@ -123,9 +122,7 @@ def compute_univariate_associations(
 
     vector_is_dependent = _get_vector_is_dependent(analysis_type, vector_variable_type)
 
-    results_dir = os.path.join(
-        resultsDirPrefix, str(datetime.datetime.now().strftime("%Y%m%d")),
-    )
+    results_dir = settings.get_todays_result_dir()
 
     result = utils.cast_celery_task(analysis_tasks.run_custom_analysis).delay(
         user=user,

--- a/breadbox/breadbox/api/temp/sql.py
+++ b/breadbox/breadbox/api/temp/sql.py
@@ -1,3 +1,4 @@
+from celery.worker.control import time_limit
 from pydantic import BaseModel
 from typing import Annotated, Optional
 
@@ -9,10 +10,13 @@ from breadbox.schemas.custom_http_exception import ResourceNotFoundError
 from ...config import get_settings, Settings
 from ...db.session import SessionWithUser
 from ...service.sql import generate_simulated_schema, execute_sql_in_virtual_db
-from fastapi.responses import PlainTextResponse, StreamingResponse
+from fastapi.responses import PlainTextResponse, FileResponse
+from ...celery_task import utils
+import asyncio
+from ...compute.sql import execute_sql_in_virtual_db_task
 
 
-class StreamingCSVResponse(StreamingResponse):
+class CSVFileResponse(FileResponse):
     media_type = "text/csv"
 
 
@@ -47,10 +51,69 @@ def get_sql_schema(
     return statements_by_given_id
 
 
-@router.post(
-    "/sql/query", operation_id="query_sql", response_class=StreamingCSVResponse
-)
-def query_sql(
+MAX_PENDING_SQL_QUERIES = 5
+SQL_QUERY_TIMELIMIT = 30
+semaphore = asyncio.Semaphore(MAX_PENDING_SQL_QUERIES)
+
+from contextlib import contextmanager, asynccontextmanager
+from fastapi.responses import JSONResponse
+
+
+@asynccontextmanager
+async def _concurrency_guard():
+    """
+    Used to ensure that we are not running too many queries in parallel. If we see we're executing more than MAX_PENDING_SQL_QUERIES
+    will yield a response that the caller should return so the client knows they should try again later.
+    """
+    try:
+        await asyncio.wait_for(semaphore.acquire(), timeout=0.1)
+    except asyncio.TimeoutError:
+        # If we couldn't obtain the semaphore (meaning we've used up our quota) then return the response saying
+        # to try again later
+        yield JSONResponse(
+            status_code=503,
+            headers={"Retry-After": f"{SQL_QUERY_TIMELIMIT + 5}"},
+            content={
+                "detail": "Service is currently executing too many other SQL queries. Try again later"
+            },
+        )
+        return
+
+    # otherwise proceed
+    try:
+        # let the control flow return to the block inside the 'with' passing back None to indicate it can proceed
+        yield None
+    finally:
+        # and release the semaphore
+        semaphore.release()
+
+
+import anyio.to_thread
+from typing import Any
+
+
+async def _run_time_bounded_celery_task(
+    task_fn: Any, args: list, time_limit: int, time_limit_padding=5
+):
+    """
+    Run a celery task, setting a time limit on its execution. Technically, this function may take up
+    to time_limit + time_limit_padding to complete. Also, if the celery queue is full, the task might
+    not actually get any chance to run before the time limit expires. Regardless, this is a way to at
+    least enforce some bound on the execution time of a function.
+    """
+    task = task_fn.apply_async(args=args, time_limit=time_limit)
+
+    # run the get() in an executor so that this coroutine can yield to any other requests
+    breakpoint()
+    result = await anyio.to_thread.run_sync(
+        lambda: task.get(timeout=time_limit + time_limit_padding)
+    )
+
+    return result
+
+
+@router.post("/sql/query", operation_id="query_sql", response_class=CSVFileResponse)
+async def query_sql(
     query: SqlQuery,
     db: SessionWithUser = Depends(get_db_with_user),
     settings: Settings = Depends(get_settings),
@@ -58,7 +121,19 @@ def query_sql(
     if not settings.sql_endpoints_enabled:
         raise HTTPException(403, "SQL endpoints not enabled in this environment")
 
-    streaming_result = execute_sql_in_virtual_db(
-        db, settings.filestore_location, query.sql
-    )
-    return streaming_result
+    async with _concurrency_guard() as _response:
+        if _response is not None:
+            response = _response
+        else:
+            results_dir = settings.get_todays_result_dir()
+
+            output_file = await _run_time_bounded_celery_task(
+                execute_sql_in_virtual_db_task,
+                [db.user, results_dir, query.sql, settings.filestore_location],
+                time_limit=SQL_QUERY_TIMELIMIT,
+            )
+
+            assert isinstance(output_file, str)
+            response = CSVFileResponse(output_file)
+
+    return response

--- a/breadbox/breadbox/api/temp/sql.py
+++ b/breadbox/breadbox/api/temp/sql.py
@@ -10,15 +10,50 @@ from breadbox.schemas.custom_http_exception import ResourceNotFoundError
 from ...config import get_settings, Settings
 from ...db.session import SessionWithUser
 from ...service.sql import generate_simulated_schema, execute_sql_in_virtual_db
-from fastapi.responses import PlainTextResponse, FileResponse
+from fastapi.responses import PlainTextResponse, FileResponse, Response
 from ...celery_task import utils
 import asyncio
 from ...compute.sql import execute_sql_in_virtual_db_task
 from celery.exceptions import TimeLimitExceeded
 
+import anyio.to_thread
+from typing import Any, Callable, Awaitable
+
+from fastapi.responses import JSONResponse
+
+MAX_PENDING_SQL_QUERIES = 5
+SQL_QUERY_TIMELIMIT = 30
+semaphore = asyncio.Semaphore(MAX_PENDING_SQL_QUERIES)
+
 
 class CSVFileResponse(FileResponse):
     media_type = "text/csv"
+
+
+async def _concurrency_guard(callback: Callable[[], Awaitable[Response]]):
+    """
+    Used to ensure that we are not running too many queries in parallel. If we see we're executing more than MAX_PENDING_SQL_QUERIES
+    will return a response that the caller should return so the client knows they should try again later.
+    """
+    try:
+        await asyncio.wait_for(semaphore.acquire(), timeout=0.1)
+    except asyncio.TimeoutError:
+        # If we couldn't obtain the semaphore (meaning we've used up our quota) then return the response saying
+        # to try again later
+        return JSONResponse(
+            status_code=503,
+            headers={"Retry-After": f"{SQL_QUERY_TIMELIMIT + 5}"},
+            content={
+                "detail": "Service is currently executing too many other SQL queries. Try again later"
+            },
+        )
+
+    try:
+        # otherwise proceed
+        return await callback()
+    finally:
+        # and make sure to always release the semaphore
+        semaphore.release()
 
 
 class SqlQuery(BaseModel):
@@ -52,47 +87,6 @@ def get_sql_schema(
     return statements_by_given_id
 
 
-MAX_PENDING_SQL_QUERIES = 5
-SQL_QUERY_TIMELIMIT = 30
-semaphore = asyncio.Semaphore(MAX_PENDING_SQL_QUERIES)
-
-from contextlib import contextmanager, asynccontextmanager
-from fastapi.responses import JSONResponse
-
-
-@asynccontextmanager
-async def _concurrency_guard():
-    """
-    Used to ensure that we are not running too many queries in parallel. If we see we're executing more than MAX_PENDING_SQL_QUERIES
-    will yield a response that the caller should return so the client knows they should try again later.
-    """
-    try:
-        await asyncio.wait_for(semaphore.acquire(), timeout=0.1)
-    except asyncio.TimeoutError:
-        # If we couldn't obtain the semaphore (meaning we've used up our quota) then return the response saying
-        # to try again later
-        yield JSONResponse(
-            status_code=503,
-            headers={"Retry-After": f"{SQL_QUERY_TIMELIMIT + 5}"},
-            content={
-                "detail": "Service is currently executing too many other SQL queries. Try again later"
-            },
-        )
-        return
-
-    # otherwise proceed
-    try:
-        # let the control flow return to the block inside the 'with' passing back None to indicate it can proceed
-        yield None
-    finally:
-        # and release the semaphore
-        semaphore.release()
-
-
-import anyio.to_thread
-from typing import Any
-
-
 async def _run_time_bounded_celery_task(
     task_fn: Any, args: list, time_limit: int, time_limit_padding=5
 ):
@@ -118,32 +112,47 @@ async def query_sql(
     db: SessionWithUser = Depends(get_db_with_user),
     settings: Settings = Depends(get_settings),
 ):
+    # Implementation note: SQL queries are user-supplied and may run for an unbounded amount of
+    # time, which poses a server overload risk. This is particularly acute because uvicorn handles
+    # requests on a thread pool of limited size — a synchronous (non-async) function called from
+    # a route handler blocks one of those threads for its entire duration. If enough slow queries
+    # pile up, the thread pool is exhausted and the server becomes unable to handle any requests,
+    # including unrelated ones.
+    #
+    # To enforce a time limit, we delegate execution to a Celery worker process via
+    # execute_sql_in_virtual_db_task. A separate process is necessary because Python threads
+    # cannot be forcibly terminated from outside; only OS-level process signals can reliably
+    # stop runaway code. Celery's time_limit feature sends SIGKILL to the worker if it exceeds
+    # the allowed time, which is the only reliable way to enforce a hard deadline on arbitrary SQL.
+    #
+    # Even with a per-query time limit, a burst of slow queries could fill Celery's queue faster
+    # than workers can drain it, causing requests to sit pending until their time limits expire
+    # without ever executing. The semaphore (MAX_PENDING_SQL_QUERIES) provides backpressure: once
+    # that many queries are in-flight, new requests immediately receive a 503 rather than queuing
+    # indefinitely and consuming resources while waiting.
+
     if not settings.sql_endpoints_enabled:
         raise HTTPException(403, "SQL endpoints not enabled in this environment")
 
-    async with _concurrency_guard() as _response:
-        if _response is not None:
-            response = _response
-        else:
-            results_dir = settings.get_todays_result_dir()
+    async def _run():
+        results_dir = settings.get_todays_result_dir()
 
-            output_file = None
-            try:
-                output_file = await _run_time_bounded_celery_task(
-                    execute_sql_in_virtual_db_task,
-                    [db.user, results_dir, query.sql, settings.filestore_location],
-                    time_limit=SQL_QUERY_TIMELIMIT,
-                )
-            except TimeLimitExceeded:
-                response = JSONResponse(
-                    status_code=504,
-                    content={
-                        "detail": "The SQL query took too long to execute and was terminated"
-                    },
-                )
+        output_file = None
+        try:
+            output_file = await _run_time_bounded_celery_task(
+                execute_sql_in_virtual_db_task,
+                [db.user, results_dir, query.sql, settings.filestore_location],
+                time_limit=SQL_QUERY_TIMELIMIT,
+            )
+        except TimeLimitExceeded:
+            return JSONResponse(
+                status_code=504,
+                content={
+                    "detail": "The SQL query took too long to execute and was terminated"
+                },
+            )
 
-            if output_file is not None:
-                assert isinstance(output_file, str)
-                response = CSVFileResponse(output_file)
+        assert isinstance(output_file, str)
+        return CSVFileResponse(output_file)
 
-    return response
+    return await _concurrency_guard(_run)

--- a/breadbox/breadbox/api/temp/sql.py
+++ b/breadbox/breadbox/api/temp/sql.py
@@ -14,6 +14,7 @@ from fastapi.responses import PlainTextResponse, FileResponse
 from ...celery_task import utils
 import asyncio
 from ...compute.sql import execute_sql_in_virtual_db_task
+from celery.exceptions import TimeLimitExceeded
 
 
 class CSVFileResponse(FileResponse):
@@ -104,7 +105,6 @@ async def _run_time_bounded_celery_task(
     task = task_fn.apply_async(args=args, time_limit=time_limit)
 
     # run the get() in an executor so that this coroutine can yield to any other requests
-    breakpoint()
     result = await anyio.to_thread.run_sync(
         lambda: task.get(timeout=time_limit + time_limit_padding)
     )
@@ -127,13 +127,23 @@ async def query_sql(
         else:
             results_dir = settings.get_todays_result_dir()
 
-            output_file = await _run_time_bounded_celery_task(
-                execute_sql_in_virtual_db_task,
-                [db.user, results_dir, query.sql, settings.filestore_location],
-                time_limit=SQL_QUERY_TIMELIMIT,
-            )
+            output_file = None
+            try:
+                output_file = await _run_time_bounded_celery_task(
+                    execute_sql_in_virtual_db_task,
+                    [db.user, results_dir, query.sql, settings.filestore_location],
+                    time_limit=SQL_QUERY_TIMELIMIT,
+                )
+            except TimeLimitExceeded:
+                response = JSONResponse(
+                    status_code=504,
+                    content={
+                        "detail": "The SQL query took too long to execute and was terminated"
+                    },
+                )
 
-            assert isinstance(output_file, str)
-            response = CSVFileResponse(output_file)
+            if output_file is not None:
+                assert isinstance(output_file, str)
+                response = CSVFileResponse(output_file)
 
     return response

--- a/breadbox/breadbox/compute/sql.py
+++ b/breadbox/breadbox/compute/sql.py
@@ -1,0 +1,33 @@
+from .celery import app, LogErrorsTask
+from ..db.util import db_context
+from ..service import sql
+import logging
+
+log = logging.getLogger(__name__)
+import time
+import os
+
+
+@app.task(base=LogErrorsTask, bind=True)
+def execute_sql_in_virtual_db_task(
+    self, user: str, results_dir: str, sql_statement: str, filestore_location: str
+):
+    if self.request.called_directly:
+        task_id = "called_directly"
+    else:
+        task_id = self.request.id
+
+    os.makedirs(results_dir, exist_ok=True)
+    output_filename = f"{results_dir}/{task_id}"
+    log.warning(
+        f"Starting SQL execution: {sql_statement}, writing to {output_filename}"
+    )
+
+    with db_context(user) as db:
+        output = sql.execute_sql_in_virtual_db(db, filestore_location, sql_statement)
+        with open(output_filename, "wt") as fd:
+            for line in output:
+                fd.write(line)
+
+    log.warning(f"Completed SQL execution, wrote to {output_filename}")
+    return output_filename

--- a/breadbox/breadbox/service/sql/query.py
+++ b/breadbox/breadbox/service/sql/query.py
@@ -235,6 +235,7 @@ def make_virtual_module(
 
 def add_matrix_dataset(connection, dataset: MatrixDataset, schema: SchemaNames):
     table_name = schema.get_dataset_table_name(dataset.id)
+    print("Creating ", table_name)
     connection.execute(
         f"CREATE VIRTUAL TABLE \"{table_name}\" using query_matrix_dataset('{dataset.id}')"
     )

--- a/breadbox/tests/api/test_temp_sql.py
+++ b/breadbox/tests/api/test_temp_sql.py
@@ -5,6 +5,7 @@ from breadbox.models.dataset import AnnotationType
 from tests import factories
 import pandas as pd
 from fastapi.testclient import TestClient
+import pytest
 
 
 def _assert_sql_result_eq(client, sql, expected_result, expected_status_code=200):
@@ -20,7 +21,77 @@ def _assert_sql_result_eq(client, sql, expected_result, expected_status_code=200
         assert response.text == expected_result
 
 
-def test_overlapping_samples(minimal_db: SessionWithUser, settings, client: TestClient):
+# @pytest.mark.celery
+# def test_compute_univariate_associations_intersection_with_minimum_points(
+#     tmpdir,
+#     minimal_db: SessionWithUser,
+#     client: TestClient,
+#     settings,
+#     celery_app,
+#     celery_worker,
+#     monkeypatch,
+# ):
+#     # celery_app is a test celery fixture that comes from celery, see https://docs.celeryproject.org/en/stable/userguide/testing.html#celery-app-celery-app-used-for-testing)
+#     # replace the task function with one bound to the celery_app, bypassing redis
+#     @contextmanager
+#     def mock_db_context(user, commit=True):
+#         yield minimal_db
+
+#     def get_test_settings():
+#         return settings
+
+#     def mock_check_celery():
+#         return True
+
+#     # Monkeypatch check_celery and pretend celery is running for test
+#     monkeypatch.setattr(utils, "check_celery", mock_check_celery)
+
+#     monkeypatch.setattr(
+#         analysis_tasks, "get_settings", get_test_settings,
+#     )
+
+#     monkeypatch.setattr(
+#         analysis_tasks, "db_context", mock_db_context,
+#     )
+
+#     monkeypatch.setattr(
+#         analysis_tasks,
+#         "run_custom_analysis",
+#         celery_app.task(bind=True)(run_custom_analysis),
+#     )
+
+from breadbox.compute import sql as sql_tasks
+from breadbox.api.temp import sql as sql_api
+
+
+@pytest.fixture
+def mock_run_time_bounded_celery_task(minimal_db: SessionWithUser, monkeypatch):
+    # instead of running via celery, just execute it directly
+    async def _mock(task_fn, args: list, time_limit: int, time_limit_padding=5):
+        return task_fn(*args)
+
+    monkeypatch.setattr(
+        sql_api, "_run_time_bounded_celery_task", _mock,
+    )
+
+    # now, this task is going to want to create its own connection to the db because
+    # ordinarily it'd be running in a seperate process. However, in this test, we're not
+    # so also override db_context to return the already open connection
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _mock_db_context(user: str):
+        yield minimal_db
+
+    monkeypatch.setattr(sql_tasks, "db_context", _mock_db_context)
+
+
+def test_overlapping_samples(
+    minimal_db: SessionWithUser,
+    settings,
+    client: TestClient,
+    mock_run_time_bounded_celery_task,
+):
     sample_ids = ["s1", "s2", "s3", "s4"]
     factories.sample_type(
         minimal_db, minimal_db.user, "simple_sample_type", given_ids=sample_ids
@@ -69,7 +140,12 @@ def test_overlapping_samples(minimal_db: SessionWithUser, settings, client: Test
     )
 
 
-def test_matrix_query(minimal_db: SessionWithUser, settings, client: TestClient):
+def test_matrix_query(
+    minimal_db: SessionWithUser,
+    settings,
+    client: TestClient,
+    mock_run_time_bounded_celery_task,
+):
     sample_ids = ["s1", "s2", "s3"]
     factories.sample_type(
         minimal_db, minimal_db.user, "simple_sample_type", given_ids=sample_ids
@@ -146,10 +222,14 @@ def assert_schema_is_valid(client):
         # make sure we can parse the resulting SQL that describes the schema
         parsed = sqlglot.parse(schema, dialect="sqlite")
         assert len(parsed) > 0
-        print(f"Schema:\n{schema}")
 
 
-def test_bad_queries(minimal_db: SessionWithUser, settings, client: TestClient):
+def test_bad_queries(
+    minimal_db: SessionWithUser,
+    settings,
+    client: TestClient,
+    mock_run_time_bounded_celery_task,
+):
     # malformed query
     _assert_sql_result_eq(
         client,
@@ -167,7 +247,12 @@ def test_bad_queries(minimal_db: SessionWithUser, settings, client: TestClient):
     )
 
 
-def test_tabular_query(minimal_db: SessionWithUser, settings, client: TestClient):
+def test_tabular_query(
+    minimal_db: SessionWithUser,
+    settings,
+    client: TestClient,
+    mock_run_time_bounded_celery_task,
+):
     # Define metadata
     factories.add_dimension_type(
         minimal_db,


### PR DESCRIPTION
Best explanation is the comment on `query_sql`

SQL queries are user-supplied and may run for an unbounded amount of
time, which poses a server overload risk. This is particularly acute because uvicorn handles
requests on a thread pool of limited size — a synchronous (non-async) function called from
a route handler blocks one of those threads for its entire duration. If enough slow queries
pile up, the thread pool is exhausted and the server becomes unable to handle any requests,
including unrelated ones.

To enforce a time limit, we delegate execution to a Celery worker process via
execute_sql_in_virtual_db_task. A separate process is necessary because Python threads
cannot be forcibly terminated from outside; only OS-level process signals can reliably
stop runaway code. Celery's time_limit feature sends SIGKILL to the worker if it exceeds
the allowed time, which is the only reliable way to enforce a hard deadline on arbitrary SQL.

Even with a per-query time limit, a burst of slow queries could fill Celery's queue faster
than workers can drain it, causing requests to sit pending until their time limits expire
without ever executing. The semaphore (MAX_PENDING_SQL_QUERIES) provides backpressure: once
that many queries are in-flight, new requests immediately receive a 503 rather than queuing
indefinitely and consuming resources while waiting.
