### PR TITLE
embeddable version of SliceTable

### DIFF
--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/PrototypeScatterPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/PrototypeScatterPlot.tsx
@@ -79,6 +79,7 @@ interface Props {
   customHoverinfo?: PlotData["hoverinfo"];
   hideXAxis?: boolean;
   hideXAxisGrid?: boolean;
+  showBuiltinLegend?: boolean;
   // optional styling
   pointSize?: number;
   pointOpacity?: number;
@@ -137,6 +138,32 @@ const moveSelectedPointsOnTopOfLines = (plot: HTMLDivElement) => {
   hoverlayer.style.transform = "translateX(8px)";
 };
 
+// These dummy traces exist only to force Plotly to add a legend with the
+// correct colors (there is no good way of rendering our custom legend as
+// part of the exported image).
+const getLegendTraces = (
+  legendForDownload: LegendInfo,
+  templateTrace: object & { marker: object }
+) =>
+  legendForDownload.items.map(({ name, hexColor }) => {
+    return {
+      ...templateTrace,
+      showlegend: true,
+      // HACK: Use a plot type of "indicator" rather than "scatter". This
+      // prevents a rare bug where these dummy traces interfere with the
+      // real ones and some points don't get rendered.
+      type: "indicator",
+      name: truncate(name),
+      x: [null], // Data doesn't matter but can't be completely empty
+      y: [null],
+      marker: {
+        ...templateTrace.marker,
+        color: hexColor,
+        line: { color: hexColor, width: 2 },
+      },
+    };
+  });
+
 function PrototypeScatterPlot({
   data,
   xKey,
@@ -165,6 +192,7 @@ function PrototypeScatterPlot({
   customHoverinfo = undefined,
   hideXAxis = false,
   hideXAxisGrid = false,
+  showBuiltinLegend = false,
   pointSize = 7,
   pointOpacity = 1.0,
   outlineWidth = 0.5,
@@ -545,6 +573,12 @@ function PrototypeScatterPlot({
       .filter(Boolean)
       .reverse() as Partial<PlotData>[];
 
+    if (showBuiltinLegend) {
+      getLegendTraces(legendForDownload!, templateTrace).forEach((t) =>
+        plotlyData.push(t as typeof plotlyData[number])
+      );
+    }
+
     const isContinuousCurve = (curveNumber: number) => {
       return plotlyData[curveNumber] === continuousColorTrace;
     };
@@ -597,7 +631,7 @@ function PrototypeScatterPlot({
       // We hide the legend because the traces don't have names and some of
       // them are merely decorative (e.g. selectionOutlineTrace). DE2 has its
       // own custom-build legend so this isn't a problem.
-      showlegend: false,
+      showlegend: true,
 
       xaxis,
       yaxis,
@@ -844,28 +878,7 @@ function PrototypeScatterPlot({
         return;
       }
 
-      // These dummy traces exist only to force Plotly to add a legend with the
-      // correct colors (there is no good way of rendering our custom legend as
-      // part of the exported image).
-      const legendTraces = legendForDownload.items.map(({ name, hexColor }) => {
-        return {
-          ...templateTrace,
-          showlegend: true,
-          // HACK: Use a plot type of "indicator" rather than "scatter". This
-          // prevents a rare bug where these dummy traces interfere with the
-          // real ones and some points don't get rendered.
-          type: "indicator",
-          name: truncate(name),
-          x: [null], // Data doesn't matter but can't be completely empty
-          y: [null],
-          marker: {
-            ...templateTrace.marker,
-            color: hexColor,
-            line: { color: hexColor, width: 2 },
-          },
-        };
-      });
-
+      const legendTraces = getLegendTraces(legendForDownload, templateTrace);
       const imagePlot = {
         ...plot,
         data: [...plot.data, ...legendTraces],
@@ -941,6 +954,7 @@ function PrototypeScatterPlot({
     customHoverinfo,
     hideXAxis,
     hideXAxisGrid,
+    showBuiltinLegend,
     pointSize,
     pointOpacity,
     outlineWidth,

--- a/frontend/packages/@depmap/react-table/src/styles/ReactTable.scss
+++ b/frontend/packages/@depmap/react-table/src/styles/ReactTable.scss
@@ -327,10 +327,12 @@
 }
 
 .columnMenu {
-  display: block;
-  position: absolute;
-  transform: translateX(-100%);
-  z-index: 2000;
+  &:global(.dropdown-menu) {
+    display: block;
+    position: absolute;
+    transform: translateX(-100%);
+    z-index: 2000;
+  }
 
   a {
     cursor: pointer;

--- a/frontend/packages/@depmap/slice-table/src/components/Controls/index.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/Controls/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import cx from "classnames";
 import { Button } from "react-bootstrap";
 import SearchBar from "./SearchBar";
 import styles from "../../styles/SliceTable.scss";
@@ -17,8 +18,16 @@ interface Props {
   hadError: boolean;
   onClickFilterButton: () => void;
   onClickDownload: () => void;
-  renderCustomControls: () => React.ReactNode;
+  renderCustomControls: (info: {
+    isLoading: boolean;
+    hadError: boolean;
+    onClickAddColumn: () => void;
+  }) => React.ReactNode;
   numFiltersApplied: number;
+  // This is threaded through just in case a consumer
+  // wants to be able to call it from a custom action.
+  onClickAddColumn: () => void;
+  controlsClassName?: string;
 }
 
 function Controls({
@@ -29,10 +38,18 @@ function Controls({
   onClickDownload,
   renderCustomControls,
   numFiltersApplied,
+  onClickAddColumn,
+  controlsClassName = undefined,
 }: Props) {
   return (
-    <div className={styles.Controls}>
-      <div className={styles.customControls}>{renderCustomControls()}</div>
+    <div className={cx(styles.Controls, controlsClassName)}>
+      <div className={styles.customControls}>
+        {renderCustomControls({
+          onClickAddColumn,
+          isLoading,
+          hadError,
+        })}
+      </div>
       <div className={styles.search}>
         <SearchBar tableRef={tableRef} />
       </div>

--- a/frontend/packages/@depmap/slice-table/src/components/SlicePreview/index.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/SlicePreview/index.tsx
@@ -113,7 +113,7 @@ function SlicePreview({
 
   if (!column) {
     return (
-      <div className={styles.previewPlaceholder}>
+      <div className={styles.previewPlaceholder} data-preview-placeholder>
         <i>a data preview will appear here</i>
       </div>
     );

--- a/frontend/packages/@depmap/slice-table/src/components/SliceTable.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/SliceTable.tsx
@@ -47,7 +47,7 @@ interface Props {
   ) => import("./useData").ColumnDisplayOptions | null;
   // Custom controls will appear at the top of the table (to left of the search
   // bar).
-  renderCustomControls: (info: {
+  renderCustomControls?: (info: {
     isLoading: boolean;
     hadError: boolean;
     onClickAddColumn: () => void;

--- a/frontend/packages/@depmap/slice-table/src/components/SliceTable.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/SliceTable.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
+import cx from "classnames";
 import { Spinner } from "@depmap/common-components";
 import ReactTable from "@depmap/react-table";
 import type { RowSelectionState } from "@depmap/react-table";
@@ -46,10 +47,21 @@ interface Props {
   ) => import("./useData").ColumnDisplayOptions | null;
   // Custom controls will appear at the top of the table (to left of the search
   // bar).
-  renderCustomControls?: () => React.ReactNode;
+  renderCustomControls: (info: {
+    isLoading: boolean;
+    hadError: boolean;
+    onClickAddColumn: () => void;
+  }) => React.ReactNode;
   // Custom actions will appear at the botom of the table (to the right of "Add
   // column").
   renderCustomActions?: () => React.ReactNode;
+  // Use this if you want to complete hide the actions bar. Does nothing if
+  // `renderCustomControls` is defined.
+  hideActions?: boolean;
+  // Use this to apply custom CSS to the container div.
+  containerClassName?: string;
+  // Use this to apply custom CSS to the controls.
+  controlsClassName?: string;
   downloadFilename?: string;
   // An implicit filter that is always applied and invisible to the end user.
   // Rows for which this returns false are excluded from the dataset entirely —
@@ -92,6 +104,9 @@ function SliceTable({
   getColumnDisplayOptions = undefined,
   renderCustomControls = () => null,
   renderCustomActions = () => null,
+  hideActions = false,
+  containerClassName = undefined,
+  controlsClassName = undefined,
   downloadFilename = "",
   implicitFilter = undefined,
   isLoading: externalLoading = false,
@@ -194,8 +209,9 @@ function SliceTable({
   }, [data, columns, implicitFilter, sliceDataCacheRef]);
 
   return (
-    <div className={styles.SliceTable}>
+    <div className={cx(styles.SliceTable, containerClassName)}>
       <Controls
+        controlsClassName={controlsClassName}
         tableRef={tableRef}
         isLoading={combinedLoading}
         hadError={Boolean(error)}
@@ -203,6 +219,7 @@ function SliceTable({
         onClickDownload={handleClickDownload}
         renderCustomControls={renderCustomControls}
         numFiltersApplied={numFiltersApplied}
+        onClickAddColumn={handleClickAddColumn}
       />
       {combinedLoading && (
         <div className={styles.loadingContainer}>
@@ -253,12 +270,14 @@ function SliceTable({
           return 0;
         }}
       />
-      <Actions
-        isLoading={combinedLoading}
-        hadError={Boolean(error)}
-        onClickAddColumn={handleClickAddColumn}
-        renderCustomActions={renderCustomActions}
-      />
+      {!hideActions && !renderCustomActions && (
+        <Actions
+          isLoading={combinedLoading}
+          hadError={Boolean(error)}
+          onClickAddColumn={handleClickAddColumn}
+          renderCustomActions={renderCustomActions}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/packages/@depmap/slice-table/src/styles/SliceTable.scss
+++ b/frontend/packages/@depmap/slice-table/src/styles/SliceTable.scss
@@ -3,7 +3,6 @@
   flex-direction: column;
   width: 100%;
   height: 100%;
-  max-height: calc(100vh - 90px);
 }
 
 .loadingContainer {
@@ -22,17 +21,20 @@
 }
 
 .Controls {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
   width: 100%;
   margin-bottom: 12px;
   gap: 8px;
-  justify-content: space-between;
+
+  & > :nth-child(1) { justify-self: start; }
+  & > :nth-child(3) { justify-self: end; }
+
 
   .customControls {
     display: flex;
     align-items: center;
-    min-width: 33%;
-    max-width: 33%;
   }
 
   .search {
@@ -58,7 +60,7 @@
   background: #fff;
   font-size: 14px;
   transition: box-shadow 0.2s;
-  height: 30px;
+  height: 27px;
 
   &:focus-within {
     outline: none;
@@ -148,7 +150,7 @@
 .Actions {
   display: flex;
   width: 100%;
-  margin-top: 20px;
+  margin-top: 14px;
   gap: 8px;
 }
 

--- a/frontend/packages/embed-frontend/package.json
+++ b/frontend/packages/embed-frontend/package.json
@@ -21,11 +21,13 @@
     "bootstrap": "^3.3.7",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
+    "react-bootstrap": "^0.32.3",
     "plotly.js": "^2.8.0"
   },
   "devDependencies": {
     "@types/plotly.js": "^1.54.17",
     "@types/react": "16.14.2",
+    "@types/react-bootstrap": "^0.32.24",
     "@types/react-dom": "16.9.8"
   }
 }

--- a/frontend/packages/embed-frontend/package.json
+++ b/frontend/packages/embed-frontend/package.json
@@ -18,6 +18,7 @@
     "@depmap/types": "1.0.0",
     "@modelcontextprotocol/ext-apps": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "bootstrap": "^3.3.7",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "plotly.js": "^2.8.0"

--- a/frontend/packages/embed-frontend/src/components/Plot/EmbeddedCorrelationHeatmap.tsx
+++ b/frontend/packages/embed-frontend/src/components/Plot/EmbeddedCorrelationHeatmap.tsx
@@ -11,7 +11,7 @@ import {
   DataExplorerPlotConfig,
   DataExplorerPlotResponse,
 } from "@depmap/types";
-import HeatmapLoader from "./loaders/HeatmapLoader";
+import HeatmapLoader from "../../loaders/HeatmapLoader";
 
 interface Props {
   data: DataExplorerPlotResponse | null;

--- a/frontend/packages/embed-frontend/src/components/Plot/EmbeddedDensity1DPlot.tsx
+++ b/frontend/packages/embed-frontend/src/components/Plot/EmbeddedDensity1DPlot.tsx
@@ -7,7 +7,7 @@ import {
   DataExplorerPlotConfig,
   DataExplorerPlotResponse,
 } from "@depmap/types";
-import DensityLoader from "./loaders/DensityLoader";
+import DensityLoader from "../../loaders/DensityLoader";
 
 interface Props {
   data: DataExplorerPlotResponse | null;

--- a/frontend/packages/embed-frontend/src/components/Plot/EmbeddedScatterPlot.tsx
+++ b/frontend/packages/embed-frontend/src/components/Plot/EmbeddedScatterPlot.tsx
@@ -8,7 +8,7 @@ import {
   DataExplorerPlotResponse,
   LinRegInfo,
 } from "@depmap/types";
-import ScatterLoader from "./loaders/ScatterLoader";
+import ScatterLoader from "../../loaders/ScatterLoader";
 
 interface Props {
   data: DataExplorerPlotResponse | null;

--- a/frontend/packages/embed-frontend/src/components/Plot/EmbeddedScatterPlot.tsx
+++ b/frontend/packages/embed-frontend/src/components/Plot/EmbeddedScatterPlot.tsx
@@ -40,6 +40,13 @@ function EmbeddedScatterPlot({
     return null;
   }
 
+  const showBuiltinLegend = Boolean(
+    data?.metadata.color_property ||
+      data?.dimensions.color ||
+      data?.filters.color1 ||
+      data?.filters.color2
+  );
+
   return (
     <PlotlyLoaderProvider PlotlyLoader={ScatterLoader}>
       <PrototypeScatterPlot
@@ -68,6 +75,7 @@ function EmbeddedScatterPlot({
         palette={palette}
         xAxisFontSize={12}
         yAxisFontSize={12}
+        showBuiltinLegend={showBuiltinLegend}
       />
     </PlotlyLoaderProvider>
   );

--- a/frontend/packages/embed-frontend/src/components/Plot/EmbeddedWaterfallPlot.tsx
+++ b/frontend/packages/embed-frontend/src/components/Plot/EmbeddedWaterfallPlot.tsx
@@ -7,7 +7,7 @@ import {
 } from "@depmap/types";
 import PrototypeScatterPlot from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/PrototypeScatterPlot";
 import { useDataExplorerSettings } from "@depmap/data-explorer-2/src/contexts/DataExplorerSettingsContext";
-import ScatterLoader from "./loaders/ScatterLoader";
+import ScatterLoader from "../../loaders/ScatterLoader";
 
 interface Props {
   data: DataExplorerPlotResponse | null;

--- a/frontend/packages/embed-frontend/src/loaders/DensityAndBarchartLoader.tsx
+++ b/frontend/packages/embed-frontend/src/loaders/DensityAndBarchartLoader.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, ReactElement } from "react";
-import LoadingSpinner from "../../../components/LoadingSpinner";
+import LoadingSpinner from "../components/LoadingSpinner";
 
 export type PlotlyType = typeof import("plotly.js");
 
@@ -7,15 +7,15 @@ interface Props {
   children?: (Plotly: PlotlyType) => ReactElement;
 }
 
-function ScatterLoader({ children = undefined }: Props) {
+function DensityLoader({ children = undefined }: Props) {
   const [Plotly, setPlotly] = useState<PlotlyType | null>(null);
 
   useEffect(() => {
     (async () => {
       const lib = (
         await import(
-          // webpackChunkName: "plotly-bundles__scatter"
-          "../../../plotly-bundles/scatter"
+          // webpackChunkName: "plotly-bundles__density-and-barchart"
+          "../plotly-bundles/density-and-barchart"
         )
       ).default;
 
@@ -26,4 +26,4 @@ function ScatterLoader({ children = undefined }: Props) {
   return Plotly && children ? children(Plotly) : <LoadingSpinner />;
 }
 
-export default ScatterLoader;
+export default DensityLoader;

--- a/frontend/packages/embed-frontend/src/loaders/DensityLoader.tsx
+++ b/frontend/packages/embed-frontend/src/loaders/DensityLoader.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, ReactElement } from "react";
-import LoadingSpinner from "../../../components/LoadingSpinner";
+import LoadingSpinner from "../components/LoadingSpinner";
 
 export type PlotlyType = typeof import("plotly.js");
 
@@ -15,7 +15,7 @@ function DensityLoader({ children = undefined }: Props) {
       const lib = (
         await import(
           // webpackChunkName: "plotly-bundles__density"
-          "../../../plotly-bundles/density"
+          "../plotly-bundles/density"
         )
       ).default;
 

--- a/frontend/packages/embed-frontend/src/loaders/HeatmapLoader.tsx
+++ b/frontend/packages/embed-frontend/src/loaders/HeatmapLoader.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState, ReactElement } from "react";
+import LoadingSpinner from "../components/LoadingSpinner";
+
+export type PlotlyType = typeof import("plotly.js");
+
+interface Props {
+  children?: (Plotly: PlotlyType) => ReactElement;
+}
+
+function HeatmapLoader({ children = undefined }: Props) {
+  const [Plotly, setPlotly] = useState<PlotlyType | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      const lib = (
+        await import(
+          // webpackChunkName: "plotly-bundles__heatmap"
+          "../plotly-bundles/heatmap"
+        )
+      ).default;
+
+      setPlotly(lib);
+    })();
+  }, []);
+
+  return Plotly && children ? children(Plotly) : <LoadingSpinner />;
+}
+
+export default HeatmapLoader;

--- a/frontend/packages/embed-frontend/src/loaders/ScatterLoader.tsx
+++ b/frontend/packages/embed-frontend/src/loaders/ScatterLoader.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, ReactElement } from "react";
-import LoadingSpinner from "../../../components/LoadingSpinner";
+import LoadingSpinner from "../components/LoadingSpinner";
 
 export type PlotlyType = typeof import("plotly.js");
 
@@ -7,15 +7,15 @@ interface Props {
   children?: (Plotly: PlotlyType) => ReactElement;
 }
 
-function HeatmapLoader({ children = undefined }: Props) {
+function ScatterLoader({ children = undefined }: Props) {
   const [Plotly, setPlotly] = useState<PlotlyType | null>(null);
 
   useEffect(() => {
     (async () => {
       const lib = (
         await import(
-          // webpackChunkName: "plotly-bundles__heatmap"
-          "../../../plotly-bundles/heatmap"
+          // webpackChunkName: "plotly-bundles__scatter"
+          "../plotly-bundles/scatter"
         )
       ).default;
 
@@ -26,4 +26,4 @@ function HeatmapLoader({ children = undefined }: Props) {
   return Plotly && children ? children(Plotly) : <LoadingSpinner />;
 }
 
-export default HeatmapLoader;
+export default ScatterLoader;

--- a/frontend/packages/embed-frontend/src/plotly-bundles/density-and-barchart.ts
+++ b/frontend/packages/embed-frontend/src/plotly-bundles/density-and-barchart.ts
@@ -1,0 +1,8 @@
+import plotlyCore from "plotly.js/lib/core";
+import scattergl from "plotly.js/lib/scattergl";
+import violin from "plotly.js/lib/violin";
+import bar from "plotly.js/lib/bar";
+
+plotlyCore.register([scattergl, violin, bar]);
+
+export default plotlyCore;

--- a/frontend/packages/embed-frontend/src/styles/EmbeddedTable.scss
+++ b/frontend/packages/embed-frontend/src/styles/EmbeddedTable.scss
@@ -8,8 +8,27 @@
   color: red;
 }
 
+.controls {
+  grid-template-columns: 1fr auto auto;
+  border-left: 2px solid transparent;
+
+  & > :nth-child(1) { order: 1; }
+  & > :nth-child(2) { order: 0; }
+  & > :nth-child(3) { order: 2; }
+}
+
 :global .modal-dialog {
-  max-height: 100vh;
-  // border: 1px solid red !important;
-  transform: scale(0.85) !important;
+  width: calc(100vw - 10px);
+  margin: auto auto;
+  transform: scale(0.9) !important;
+
+  section {
+    & > :first-child {
+      min-height: 0px;
+    }
+
+    div[data-preview-placeholder] {
+      height: calc(100vh - 150px);
+    }
+  }
 }

--- a/frontend/packages/embed-frontend/src/styles/EmbeddedTable.scss
+++ b/frontend/packages/embed-frontend/src/styles/EmbeddedTable.scss
@@ -1,0 +1,15 @@
+.tableContainer {
+  width: 100vw;
+  height: 100vh;
+}
+
+.error {
+  padding: 15px;
+  color: red;
+}
+
+:global .modal-dialog {
+  max-height: 100vh;
+  // border: 1px solid red !important;
+  transform: scale(0.85) !important;
+}

--- a/frontend/packages/embed-frontend/src/surfaces/EmbeddedTable.tsx
+++ b/frontend/packages/embed-frontend/src/surfaces/EmbeddedTable.tsx
@@ -1,30 +1,48 @@
 import React from "react";
 import SliceTable from "@depmap/slice-table";
+import { PlotlyLoaderProvider } from "@depmap/data-explorer-2/src/contexts/PlotlyLoaderContext";
+import DensityAndBarchartLoader from "../loaders/DensityAndBarchartLoader";
+import { readSliceQuerySetFromQueryString } from "../utils/parseSliceQuerySet";
+
+import "bootstrap/dist/css/bootstrap.css";
+import "../index.scss";
+import styles from "../styles/EmbeddedTable.scss";
+
+const filenameWithTimestamp = () => {
+  const now = new Date();
+  const pad = (n: number) => String(n).padStart(2, "0");
+
+  return (
+    "delphi-" +
+    now.getFullYear() +
+    [now.getMonth() + 1, now.getDate()].map(pad).join("")
+  );
+};
+
+let config: ReturnType<typeof readSliceQuerySetFromQueryString>;
+let error: string | undefined;
+
+try {
+  config = readSliceQuerySetFromQueryString();
+} catch (e) {
+  error = (e as any).toString();
+}
 
 function EmbeddedTable() {
+  if (error) {
+    return <div className={styles.error}>{error}</div>;
+  }
+
   return (
-    <SliceTable
-      index_type_name="depmap_model"
-      getInitialState={() => ({
-        initialSlices: [
-          {
-            dataset_id: "depmap_model_metadata",
-            identifier_type: "column",
-            identifier: "Age",
-          },
-          {
-            dataset_id: "depmap_model_metadata",
-            identifier_type: "column",
-            identifier: "AgeCategory",
-          },
-          {
-            dataset_id: "depmap_model_metadata",
-            identifier_type: "column",
-            identifier: "OncotreeLineage",
-          },
-        ],
-      })}
-    />
+    <PlotlyLoaderProvider PlotlyLoader={DensityAndBarchartLoader}>
+      <div className={styles.tableContainer}>
+        <SliceTable
+          index_type_name={config.dimension_type}
+          downloadFilename={filenameWithTimestamp()}
+          getInitialState={() => ({ initialSlices: config.slices })}
+        />
+      </div>
+    </PlotlyLoaderProvider>
   );
 }
 

--- a/frontend/packages/embed-frontend/src/surfaces/EmbeddedTable.tsx
+++ b/frontend/packages/embed-frontend/src/surfaces/EmbeddedTable.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Button } from "react-bootstrap";
 import SliceTable from "@depmap/slice-table";
 import { PlotlyLoaderProvider } from "@depmap/data-explorer-2/src/contexts/PlotlyLoaderContext";
 import DensityAndBarchartLoader from "../loaders/DensityAndBarchartLoader";
@@ -40,6 +41,21 @@ function EmbeddedTable() {
           index_type_name={config.dimension_type}
           downloadFilename={filenameWithTimestamp()}
           getInitialState={() => ({ initialSlices: config.slices })}
+          controlsClassName={styles.controls}
+          hideActions
+          renderCustomControls={({ isLoading, hadError, onClickAddColumn }) => (
+            <div>
+              <Button
+                bsSize="small"
+                bsStyle="default"
+                onClick={onClickAddColumn}
+                disabled={isLoading || hadError}
+              >
+                <i className="glyphicon glyphicon-plus" />
+                <span> Add column</span>
+              </Button>
+            </div>
+          )}
         />
       </div>
     </PlotlyLoaderProvider>

--- a/frontend/packages/embed-frontend/src/utils/parseSliceQuerySet.ts
+++ b/frontend/packages/embed-frontend/src/utils/parseSliceQuerySet.ts
@@ -1,0 +1,186 @@
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+const IDENTIFIER_TYPES = [
+  "feature_id",
+  "feature_label",
+  "sample_id",
+  "sample_label",
+  "column",
+] as const;
+
+type IdentifierType = (typeof IDENTIFIER_TYPES)[number];
+
+type SliceQuery = {
+  dataset_id: string;
+  identifier: string;
+  identifier_type: IdentifierType;
+  reindex_through?: SliceQuery;
+};
+
+type SliceQuerySet = {
+  dimension_type: string;
+  slices: SliceQuery[];
+};
+
+// ---------------------------------------------------------------------------
+// Error type — lets callers `catch` parse failures specifically.
+// ---------------------------------------------------------------------------
+
+class SliceQueryParseError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "SliceQueryParseError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Human-readable description of an unexpected value, for error messages. */
+function describe(value: unknown): string {
+  if (value === undefined) return "undefined (missing)";
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "an array";
+  const t = typeof value;
+  if (t === "string" || t === "number" || t === "boolean") {
+    return `a ${t} (${JSON.stringify(value)})`;
+  }
+  return t === "object" ? "an object" : `a ${t}`;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Decode (possibly URL-safe) base64 into a UTF-8 string. */
+function base64ToString(b64: string): string {
+  const normalized = b64.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(normalized);
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+function assertSliceQuery(
+  value: unknown,
+  path: string
+): asserts value is SliceQuery {
+  if (!isPlainObject(value)) {
+    throw new SliceQueryParseError(
+      `${path} must be an object, but got ${describe(value)}`
+    );
+  }
+
+  if (typeof value.dataset_id !== "string") {
+    throw new SliceQueryParseError(
+      `${path}.dataset_id must be a string, but got ${describe(value.dataset_id)}`
+    );
+  }
+
+  if (typeof value.identifier !== "string") {
+    throw new SliceQueryParseError(
+      `${path}.identifier must be a string, but got ${describe(value.identifier)}`
+    );
+  }
+
+  if (
+    typeof value.identifier_type !== "string" ||
+    !IDENTIFIER_TYPES.includes(value.identifier_type as IdentifierType)
+  ) {
+    throw new SliceQueryParseError(
+      `${path}.identifier_type must be one of ` +
+        `${IDENTIFIER_TYPES.join(", ")}, but got ${describe(value.identifier_type)}`
+    );
+  }
+
+  if (value.reindex_through !== undefined) {
+    assertSliceQuery(value.reindex_through, `${path}.reindex_through`);
+  }
+}
+
+function assertSliceQuerySet(
+  value: unknown
+): asserts value is SliceQuerySet {
+  if (!isPlainObject(value)) {
+    throw new SliceQueryParseError(
+      `Expected a JSON object at the top level, but got ${describe(value)}`
+    );
+  }
+
+  if (typeof value.dimension_type !== "string") {
+    throw new SliceQueryParseError(
+      `"dimension_type" must be a string, but got ${describe(value.dimension_type)}`
+    );
+  }
+
+  if (!Array.isArray(value.slices)) {
+    throw new SliceQueryParseError(
+      `"slices" must be an array, but got ${describe(value.slices)}`
+    );
+  }
+
+  value.slices.forEach((slice, i) => assertSliceQuery(slice, `slices[${i}]`));
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Read a base64-encoded SliceQuerySet from the query string.
+ *
+ * @param paramName  Name of the query-string parameter holding the base64 blob.
+ * @param search     The query string to read (defaults to window.location.search).
+ * @throws {SliceQueryParseError} if the param is missing, not base64, not JSON,
+ *         or does not conform to the SliceQuerySet shape.
+ */
+function readSliceQuerySetFromQueryString(
+  paramName = "q",
+  search: string = window.location.search
+): SliceQuerySet {
+  const raw = new URLSearchParams(search).get(paramName);
+
+  if (raw === null) {
+    throw new SliceQueryParseError(
+      `Query string is missing the "${paramName}" parameter`
+    );
+  }
+
+  let jsonString: string;
+  try {
+    jsonString = base64ToString(raw);
+  } catch (cause) {
+    throw new SliceQueryParseError(
+      `The "${paramName}" parameter is not valid base64`,
+      { cause }
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonString);
+  } catch (cause) {
+    throw new SliceQueryParseError(
+      `The "${paramName}" parameter did not decode to valid JSON`,
+      { cause }
+    );
+  }
+
+  assertSliceQuerySet(parsed);
+  return parsed;
+}
+
+export {
+  IDENTIFIER_TYPES,
+  SliceQueryParseError,
+  assertSliceQuery,
+  assertSliceQuerySet,
+  readSliceQuerySetFromQueryString,
+};
+export type { IdentifierType, SliceQuery, SliceQuerySet };


### PR DESCRIPTION
An embeddable version of the `SliceTable` component.

<img width="1602" height="1222" alt="embedded-table" src="https://github.com/user-attachments/assets/e9bcd61a-0f61-4f9f-b482-0c49753d90d9" />

Once deployed, this will be accessible at `https://cds.team/depmap/breadbox/embed/table?q=<TABLE_CONFIG>`

where `<TABLE_CONFIG>` is a base64-encoded JSON payload like this one:
```json
{
  "dimension_type": "depmap_model",
  "slices": [
    {
      "dataset_id": "depmap_model_metadata",
      "identifier_type": "column",
      "identifier": "Age"
    },
    {
      "dataset_id": "depmap_model_metadata",
      "identifier_type": "column",
      "identifier": "AgeCategory"
    },
    {
      "dataset_id": "depmap_model_metadata",
      "identifier_type": "column",
      "identifier": "OncotreeLineage"
    }
  ]
}
```
Supports any slice queries that Breadbox can fetch. Each slice just needs to be indexable by the given `dimension_type` (meaning its corresponding dataset has a `feature_type_name`, `sample_type_name` or `index_type_name` that either matches `dimension_type` or can be resolved to it via a `reindex_through` chain).