### PR TITLE
fixed mistake which caused 'self' points to be dropped from correlation analysis

### DIFF
--- a/frontend/packages/portal-frontend/src/correlationAnalysis/hooks/useCorrelationAnalysisData.ts
+++ b/frontend/packages/portal-frontend/src/correlationAnalysis/hooks/useCorrelationAnalysisData.ts
@@ -77,8 +77,10 @@ export function useGeneCorrelationData(
 
         const filtered = rawCorrelates.filter(
           (cor: SortedCorrelations) =>
-            cor.feature !== featureName &&
-            cor.featureDatasetGivenId !== selectedDataset.datasetId
+            !(
+              cor.feature === featureName &&
+              cor.featureDatasetGivenId === selectedDataset.datasetId
+            )
         );
 
         setState({


### PR DESCRIPTION

Specifically, when viewing correlation analysis results for CRISPR BRAF, the BRAF Hotspot Mutation is being dropped.

It should only filter out CRISPR BRAF correlated with CRISPR BRAF. (Because it will be 1 by definition and messes up the scale on the plots)

Problem was trivial mistake in logical test