### PR TITLE
Fix problem preventing BI-3802 dose curve from render

### DIFF
--- a/portal-backend/depmap/compound/new_dose_curves_utils.py
+++ b/portal-backend/depmap/compound/new_dose_curves_utils.py
@@ -3,6 +3,7 @@ from depmap.compound.models import Compound, CompoundDoseReplicate, CompoundExpe
 from depmap.dataset.models import Dataset, DependencyDataset
 from depmap.partials.matrix.models import Matrix
 import pandas as pd
+import math
 
 
 def get_dose_replicate_points(
@@ -66,6 +67,17 @@ def _get_model_map(valid_depmap_ids: set) -> dict:
     return model_map
 
 
+def _float_or_none(x):
+    if x is None or math.isnan(x) or math.isinf(x):
+        return None
+    else:
+        # adding an assert because I'm replacing a call
+        # to `float(x)` but as far as I can tell, it
+        # should have been a float in the first place.
+        assert isinstance(x, float)
+    return x
+
+
 def get_curve_params_for_model_ids(
     compound_id: str,
     drc_dataset_label: str,
@@ -125,10 +137,10 @@ def get_curve_params_for_model_ids(
             curve_param = {
                 "id": curve.depmap_id,
                 "displayName": model.stripped_cell_line_name,
-                "ec50": float(curve.ec50),
-                "slope": float(curve.slope),
-                "lowerAsymptote": float(curve.lower_asymptote),
-                "upperAsymptote": float(curve.upper_asymptote),
+                "ec50": _float_or_none(curve.ec50),
+                "slope": _float_or_none(curve.slope),
+                "lowerAsymptote": _float_or_none(curve.lower_asymptote),
+                "upperAsymptote": _float_or_none(curve.upper_asymptote),
             }
             curve_params.append(curve_param)
 

--- a/portal-backend/depmap/settings/settings.py
+++ b/portal-backend/depmap/settings/settings.py
@@ -530,3 +530,9 @@ class TestConfig(Config):
     CLOUD_TRACE_ENABLED = False
     DOWNLOADS_PATHS = []
     THEME_PATH = os.path.join(Config.PROJECT_ROOT, f"../config/{ENV_TYPE}/theme")
+
+    # make sure REST endpoints are not allowed to emit Infinity or other NaN
+    # values that cause the front end to fail to parse. It turns into an exception
+    # but a server side exception is easier to identify where the
+    # problem is coming from.
+    RESTX_JSON = {"allow_nan": False}

--- a/portal-backend/tests/depmap/compound/test_api.py
+++ b/portal-backend/tests/depmap/compound/test_api.py
@@ -1,0 +1,92 @@
+from flask import url_for
+from tests.factories import (
+    CompoundDoseReplicateFactory,
+    CompoundExperimentFactory,
+    CompoundFactory,
+    DependencyDatasetFactory,
+    DepmapModelFactory,
+    DoseResponseCurveFactory,
+    MatrixFactory,
+)
+from depmap.dataset.models import DependencyDataset
+
+
+def _setup_dose_curve_data(db, compound_id, model_id, ec50):
+    compound = CompoundFactory(compound_id=compound_id)
+    cpd_exp = CompoundExperimentFactory(
+        xref_type="BRD", xref="PRC-00001", label="BRD:PRC-00001", compound=compound
+    )
+    model = DepmapModelFactory(model_id=model_id, stripped_cell_line_name="TestLine")
+
+    dose_rep = CompoundDoseReplicateFactory(
+        compound_experiment=cpd_exp, dose=1.0, replicate=1
+    )
+    DependencyDatasetFactory(
+        name=DependencyDataset.DependencyEnum.Prism_oncology_dose_replicate,
+        matrix=MatrixFactory(
+            entities=[dose_rep],
+            cell_lines=[model],
+            data=__import__("pandas").DataFrame(
+                {model.cell_line_name: [50.0]}, index=["dose_1"]
+            ),
+            using_depmap_model_table=True,
+        ),
+    )
+    DoseResponseCurveFactory(
+        compound_exp=cpd_exp,
+        cell_line=model.cell_line,
+        drc_dataset_label="Prism_oncology_per_curve",
+        ec50=ec50,
+        slope=1.0,
+        upper_asymptote=1.0,
+        lower_asymptote=0.0,
+    )
+    db.session.flush()
+    return compound
+
+
+def test_dose_curve_data_normal(empty_db_mock_downloads):
+    compound = _setup_dose_curve_data(
+        empty_db_mock_downloads, compound_id="DPC-00001", model_id="ACH-001", ec50=0.5,
+    )
+
+    with empty_db_mock_downloads.app.test_client() as c:
+        r = c.get(
+            url_for(
+                "api.compound_dose_curve_data",
+                compound_id=str(compound.compound_id),
+                drc_dataset_label="Prism_oncology_per_curve",
+                replicate_dataset_name="Prism_oncology_dose_replicate",
+            )
+        )
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data is not None
+        assert "curve_params" in data
+        assert len(data["curve_params"]) == 1
+        assert data["curve_params"][0]["ec50"] == 0.5
+
+
+def test_dose_curve_data_infinity_ec50_serialized_as_null(empty_db_mock_downloads):
+    compound = _setup_dose_curve_data(
+        empty_db_mock_downloads,
+        compound_id="DPC-00002",
+        model_id="ACH-002",
+        ec50=float("inf"),
+    )
+
+    with empty_db_mock_downloads.app.test_client() as c:
+        r = c.get(
+            url_for(
+                "api.compound_dose_curve_data",
+                compound_id=str(compound.compound_id),
+                drc_dataset_label="Prism_oncology_per_curve",
+                replicate_dataset_name="Prism_oncology_dose_replicate",
+            )
+        )
+        assert r.status_code == 200
+        data = r.get_json()
+        assert data is not None
+        assert "curve_params" in data
+        assert len(data["curve_params"]) == 1
+        assert data["curve_params"][0]["ec50"] is None


### PR DESCRIPTION
Problem was EC50 is "infinity" which is invalid json.

Add changes to prevent **any** serialization of non numeric floats to json in restx endpoints. (We have such a check for flask endpoints -- but apparently not restx)

Fixed the specific case with ec50 and added a test to verify behavior