### PR TITLE
Transcript Explorer prototype

### DIFF
--- a/frontend/packages/@depmap/api/src/breadboxAPI/resources/datasets.ts
+++ b/frontend/packages/@depmap/api/src/breadboxAPI/resources/datasets.ts
@@ -68,6 +68,33 @@ export function getMatrixDatasetData(
     );
   }
 
+  // Defensive trap: reject any aggregation Breadbox can't perform before it
+  // reaches the server, where it would otherwise fail opaquely. The param type
+  // already restricts `aggregation` to Breadbox's set, so this only fires when
+  // a caller has cast around the types. In particular it catches the Data
+  // Explorer "expansion" sentinel (and "first"/"correlation") — app-layer
+  // concepts that must be resolved upstream, never forwarded here.
+  if (args.aggregate) {
+    const validAggregations = [
+      "mean",
+      "median",
+      "25%tile",
+      "75%tile",
+      "stddev",
+    ];
+    const requested = args.aggregate.aggregation as string;
+    if (!validAggregations.includes(requested)) {
+      throw new Error(
+        `getMatrixDatasetData received aggregation "${requested}", which ` +
+          `Breadbox does not support (valid: ${validAggregations.join(
+            ", "
+          )}). ` +
+          `Values like "first", "correlation", or the Data Explorer "expansion" ` +
+          `sentinel must be resolved before reaching this call.`
+      );
+    }
+  }
+
   const finalArgs: typeof args = { ...args };
 
   // WORKAROUND: `aggregate` is silently ignored if you don't

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/ColorByViewOptions.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/ColorByViewOptions.tsx
@@ -58,7 +58,7 @@ function ColorByViewOptions({
         enable={Boolean(index_type)}
         value={color_by || null}
         plot_type={plot_type}
-        slice_type={index_type as string}
+        index_type={index_type as string}
         onChange={(nextColorBy) =>
           dispatch({
             type: "select_color_by",

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/LinearRegressionInfo/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/LinearRegressionInfo/index.tsx
@@ -4,7 +4,11 @@ import { Spinner } from "@depmap/common-components";
 import { dataExplorerAPI } from "../../../../../services/dataExplorerAPI";
 import { StaticTable } from "./StaticTable";
 import { reformatLinRegTable } from "./reformatLinRegTable";
-import { PartialDataExplorerPlotConfig } from "@depmap/types";
+import { PartialDataExplorerPlotConfig, LinRegInfo } from "@depmap/types";
+import {
+  computeFacetedLinReg,
+  computePooledLinReg,
+} from "../../plot/prototype/plotUtils";
 import renderConditionally from "../../../../../utils/render-conditionally";
 import { PlotConfigReducerAction } from "../../../reducers/plotConfigReducer";
 import { isCompletePlot } from "../../../validation";
@@ -36,12 +40,46 @@ function LinearRegressionTable({
       if (plot.plot_type === "scatter" && isCompletePlot(plot)) {
         try {
           setLoading(true);
-          const linreg_by_group = await dataExplorerAPI.fetchLinearRegression(
-            plot.index_type,
-            plot.dimensions,
-            plot.filters,
-            plot.metadata
-          );
+
+          // Faceted (group_by set): the regression follows the facets, so the
+          // table's rows are the per-facet fits — derived from the materialized
+          // response, the same grouping the drawn lines use. Single-panel keeps
+          // the color-grouped fit from fetchLinearRegression.
+          let linreg_by_group: LinRegInfo[];
+          if (plot.group_by) {
+            // Faceted: source the points the same way the plot does. An
+            // expanded plot (e.g. group_by "expansion") carries its per-point
+            // facet labels only in the expanded response's `expansions`, which
+            // the plain fetcher omits — so mirror usePlotData's dispatch and
+            // use the expanded fetcher whenever the plot is expanded.
+            const facetData =
+              "expand_by" in plot
+                ? await dataExplorerAPI.fetchExpandedPlot(plot as any)
+                : await dataExplorerAPI.fetchPlotDimensions(
+                    plot.index_type,
+                    plot.dimensions,
+                    plot.filters,
+                    plot.metadata
+                  );
+            linreg_by_group = computeFacetedLinReg(facetData, plot.group_by);
+          } else if ("expand_by" in plot) {
+            // Expanded + ungrouped: fetchLinearRegression rejects the
+            // "expansion" sentinel (its color-grouped fit assumes one value
+            // per entity, but an expansion axis is N×M). Compute one pooled
+            // fit from the expanded response instead — the table analog of
+            // the single pooled regression line the plot draws.
+            const facetData = await dataExplorerAPI.fetchExpandedPlot(
+              plot as any
+            );
+            linreg_by_group = computePooledLinReg(facetData);
+          } else {
+            linreg_by_group = await dataExplorerAPI.fetchLinearRegression(
+              plot.index_type,
+              plot.dimensions,
+              plot.filters,
+              plot.metadata
+            );
+          }
 
           const nextTable = reformatLinRegTable(linreg_by_group)?.map((row) => {
             return row.map((cell: string | number, i: number) => {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/selectors.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/selectors.tsx
@@ -142,19 +142,19 @@ export function ColorByTypeSelector({
   enable,
   value,
   plot_type,
-  slice_type,
+  index_type,
   onChange,
 }: {
   show: boolean;
   enable: boolean;
   value: string | null;
   plot_type: DataExplorerPlotType;
-  slice_type: string;
+  index_type: string;
   onChange: (nextValue: DataExplorerPlotConfig["color_by"]) => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
-  const [sliceTypeLabel, setSliceTypeLabel] = useState(
-    getDimensionTypeLabel(slice_type)
+  const [indexTypeLabel, setIndexTypeLabel] = useState(
+    getDimensionTypeLabel(index_type)
   );
   useEffect(() => {
     (async () => {
@@ -165,37 +165,37 @@ export function ColorByTypeSelector({
         // instead of `display_name` until `getDimensionTypes()` has been cached.
         .then(() => {
           setTimeout(() => {
-            setSliceTypeLabel(getDimensionTypeLabel(slice_type));
+            setIndexTypeLabel(getDimensionTypeLabel(index_type));
           });
         });
     })();
-  }, [slice_type]);
+  }, [index_type]);
 
   const options: Partial<Record<ColorByValue, string>> = {
-    raw_slice: sliceTypeLabel,
+    raw_slice: indexTypeLabel,
   };
 
   const helpContent: React.ReactNode[] = [
     <p key={0}>
-      Choose <b>{sliceTypeLabel}</b> to color a single point.
+      Choose <b>{indexTypeLabel}</b> to color a single point.
     </p>,
   ];
 
-  if (slice_type !== "other") {
-    options.aggregated_slice = `${sliceTypeLabel} Context`;
+  if (index_type !== null) {
+    options.aggregated_slice = `${indexTypeLabel} Context`;
     helpContent.push(
       <p key={1}>
-        Choose <b>{sliceTypeLabel} Context</b> to color by membership in a
+        Choose <b>{indexTypeLabel} Context</b> to color by membership in a
         user-defined context.
       </p>
     );
   }
 
-  options.property = `${sliceTypeLabel} Annotation`;
+  options.property = `${indexTypeLabel} Annotation`;
   helpContent.push(
     <p key={2}>
-      Choose <b>{sliceTypeLabel} Annotation</b> to color by major properties of
-      the {sliceTypeLabel}, such as selectivity for genes or lineage for models.
+      Choose <b>{indexTypeLabel} Annotation</b> to color by major properties of
+      the {indexTypeLabel}, such as selectivity for genes or lineage for models.
     </p>
   );
 
@@ -215,7 +215,7 @@ export function ColorByTypeSelector({
             {["density_1d", "waterfall"].includes(plot_type)
               ? "Color & group by"
               : "Color by"}
-            {slice_type && (
+            {index_type && (
               <HelpTip id="color-by-help" customContent={helpContent} />
             )}
           </span>

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/HelpTip.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/HelpTip.tsx
@@ -148,6 +148,38 @@ const tips = {
       </div>
     ),
   },
+
+  "temp-pagination-help": {
+    placement: "right",
+    title: "Temporary pagination",
+    content: (
+      <div>
+        <p>
+          This is a stopgap solution for viewing long lists of transcripts. Use
+          this dropdown to move through them one “page” at a time. The page size
+          is controlled by “Max transcripts to show” below.
+        </p>
+        <p>
+          This is obviously not ideal but it gets the job done for now. I plan
+          to replace this with a table view where you can hand pick the
+          transcripts you’re interested in based on computed statistics.
+        </p>
+      </div>
+    ),
+  },
+
+  "temp-transcripts-by-gene": {
+    placement: "right",
+    title: "Start here",
+    content: (
+      <div>
+        <p>
+          Select a gene and all of its transcripts will automatically be
+          fetched.
+        </p>
+      </div>
+    ),
+  },
 };
 
 type HelpTipId = keyof typeof tips;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/StartScreen/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/StartScreen/index.tsx
@@ -9,6 +9,20 @@ interface Props {
   tutorialLink: string;
 }
 
+function safeUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.toString();
+    }
+  } catch {
+    // invalid URL
+  }
+
+  return "#";
+}
+
 function StartScreen({ tutorialLink }: Props) {
   const [showCsvUploadModal, setShowCsvUploadModal] = useState(false);
 
@@ -19,7 +33,7 @@ function StartScreen({ tutorialLink }: Props) {
         Data Explorer 2.0 is a new app that expands on the capabilities of the
         original Data Explorer. It’s focused on providing greater power in terms
         of what you can plot and how you can visualize relationships.{" "}
-        <a href={tutorialLink} rel="noreferrer" target="_blank">
+        <a href={safeUrl(tutorialLink)} rel="noreferrer" target="_blank">
           View the tutorial
         </a>
       </p>

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/VisualizationPanel.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/VisualizationPanel.tsx
@@ -2,6 +2,10 @@ import React, { useEffect, useState } from "react";
 import { DataExplorerContextV2, DataExplorerPlotConfig } from "@depmap/types";
 import { usePlotData } from "../hooks";
 import DataExplorerScatterPlot from "./plot/DataExplorerScatterPlot";
+import {
+  CanShowIdentityLine,
+  defaultCanShowIdentityLine,
+} from "./plot/prototype/useScatterPlotData";
 import DataExplorerDensity1DPlot from "./plot/DataExplorerDensity1DPlot";
 import DataExplorerWaterfallPlot from "./plot/DataExplorerWaterfallPlot";
 import DataExplorerCorrelationHeatmap from "./plot/DataExplorerCorrelationHeatmap";
@@ -24,6 +28,7 @@ interface Props {
   feedbackUrl: string | null;
   contactEmail: string;
   tutorialLink: string;
+  canShowIdentityLine?: CanShowIdentityLine;
 }
 
 function VisualizationPanel({
@@ -36,6 +41,7 @@ function VisualizationPanel({
   feedbackUrl,
   contactEmail,
   tutorialLink,
+  canShowIdentityLine = defaultCanShowIdentityLine,
 }: Props) {
   const {
     data,
@@ -109,6 +115,7 @@ function VisualizationPanel({
           onClickVisualizeSelected={onClickVisualizeSelected}
           onClickSaveSelectionAsContext={onClickSaveSelectionAsContext}
           onClickColorByContext={onClickColorByContext}
+          canShowIdentityLine={canShowIdentityLine}
         />
       )}
       {plotConfig?.plot_type === "correlation_heatmap" && (

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerDensity1DPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerDensity1DPlot.tsx
@@ -1,13 +1,17 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useDataExplorerSettings } from "../../../../contexts/DataExplorerSettingsContext";
 import { isPortal } from "@depmap/globals";
 import SpinnerOverlay from "./SpinnerOverlay";
 import type ExtendedPlotType from "../../ExtendedPlotType";
 import {
   DataExplorerContextV2,
+  DataExplorerExpansion,
   DataExplorerPlotConfig,
   DataExplorerPlotConfigDimension,
   DataExplorerPlotResponse,
+  EntityRefSet,
+  entityRefKey,
+  singleRef,
 } from "@depmap/types";
 import useDensity1DPlotData from "./prototype/useDensity1DPlotData";
 import PrototypeDensity1D from "./prototype/PrototypeDensity1D";
@@ -15,8 +19,10 @@ import DataExplorerPlotControls from "./DataExplorerPlotControls";
 import SectionStack, { StackableSection } from "../SectionStack";
 import PlotLegend from "./PlotLegend";
 import PlotSelections from "./PlotSelections";
+import ExpandedPlotSelections from "./ExpandedPlotSelections";
 import GeneTea from "./integrations/GeneTea";
 import promptForSelectionFromContext from "./promptForSelectionFromContext";
+import useSelection from "../../hooks/useSelection";
 import styles from "../../styles/DataExplorer2.scss";
 
 interface Props {
@@ -43,9 +49,22 @@ function DataExplorerDensity1DPlot({
   onClickColorByContext,
 }: Props) {
   const [plotElement, setPlotElement] = useState<ExtendedPlotType | null>(null);
-  const [selectedIds, setSelectedIds] = useState<Set<string> | null>(
-    null
-  );
+  const {
+    selection,
+    selectedPoints,
+    handleClickPoint,
+    handleMultiselect,
+    setSelection,
+    clearSelection,
+  } = useSelection(data);
+
+  // Expanded plots (the response carries an expansion) get a different
+  // selection panel: ExpandedPlotSelections lists (index, expansion)
+  // pairs instead of collapsing them to index entities. Structural read
+  // on the expansion shape, matching the idiom in plotUtils / useSelection.
+  const isExpanded =
+    ((data as { expansions?: DataExplorerExpansion[] } | null)?.expansions
+      ?.length ?? 0) > 0;
   const [showSpinner, setShowSpinner] = useState(isLoading);
   const { plotStyles } = useDataExplorerSettings();
   const {
@@ -61,7 +80,9 @@ function DataExplorerDensity1DPlot({
     formattedData,
     continuousBins,
     colorData,
+    groupData,
     legendKeysWithNoData,
+    sortedGroupKeys,
     legendState,
     colorMap,
     legendDisplayNames,
@@ -92,92 +113,60 @@ function DataExplorerDensity1DPlot({
     .x as DataExplorerPlotConfigDimension;
 
   useEffect(() => {
-    setSelectedIds(null);
-  }, [slice_type]);
+    clearSelection();
+  }, [slice_type, clearSelection]);
 
+  // When the data changes (filter change, dataset switch, etc.), drop any
+  // selected refs that no longer correspond to a point in the new response.
+  // Done in terms of the derived ref key so both "single" and "pair"
+  // selections work uniformly.
   useEffect(() => {
     if (!data?.index_ids) {
       return;
     }
 
-    const validSelections = new Set(data.index_ids || []);
+    const validKeys = new Set<string>();
+    const expansions = (data as { expansions?: { ids: string[] }[] }).expansions;
+    const expansionIds = expansions?.[0]?.ids;
+    for (let i = 0; i < data.index_ids.length; i += 1) {
+      if (expansionIds) {
+        validKeys.add(`p\x1f${data.index_ids[i]}\x1f${expansionIds[i]}`);
+      } else {
+        validKeys.add(`s\x1f${data.index_ids[i]}`);
+      }
+    }
 
-    setSelectedIds((xs) => {
-      if (!xs) {
+    setSelection((current) => {
+      if (!current) {
         return null;
       }
-
-      const ys = new Set<string>();
-      const ids = [...xs];
-
-      for (let i = 0; i < ids.length; i += 1) {
-        const id = ids[i];
-        if (validSelections.has(id)) {
-          ys.add(id);
+      let next = current;
+      current.forEach((ref) => {
+        if (!validKeys.has(entityRefKey(ref))) {
+          next = next.delete(ref);
         }
-      }
-
-      return ys;
+      });
+      return next;
     });
-  }, [data]);
+  }, [data, setSelection]);
 
-  const selectedPoints = useMemo(() => {
-    const out: Set<number> = new Set();
-
-    if (!data?.index_ids) {
-      return out;
+  // Legacy panel compat: derive a Set<string> of index ids from the
+  // structured selection. See DataExplorerScatterPlot for full rationale.
+  // Replaced by ExpandedPlotSelections (patch 5) for expanded plots.
+  const selectedIdsLegacy = useMemo<Set<string> | null>(() => {
+    if (!selection) {
+      return null;
     }
-
-    for (let i = 0; i < data.index_ids.length; i += 1) {
-      if (selectedIds?.has(data.index_ids[i])) {
-        out.add(i);
-      }
-    }
-
+    const out = new Set<string>();
+    selection.forEach((ref) => out.add(ref.indexId));
     return out;
-  }, [data, selectedIds]);
+  }, [selection]);
 
-  const handleMultiselect = useCallback(
-    (pointIndices: number[]) => {
-      if (pointIndices.length > 0) {
-        const s = new Set<string>();
-        pointIndices.forEach((i: number) => {
-          s.add(data!.index_ids[i]);
-        });
-        setSelectedIds(s);
-      }
-    },
-    [data]
-  );
-
-  const handleClickPoint = useCallback(
-    (pointIndex: number, ctrlKey: boolean) => {
-      const id = data!.index_ids[pointIndex];
-
-      if (ctrlKey) {
-        setSelectedIds((xs) => {
-          const ys = new Set(xs);
-
-          if (xs?.has(id)) {
-            ys.delete(id);
-          } else {
-            ys.add(id);
-          }
-
-          return ys;
-        });
-      } else {
-        setSelectedIds(new Set([id]));
-      }
-    },
-    [data, setSelectedIds]
-  );
-
-  // GeneTea consumes display labels (gene symbols), not IDs. Convert at
-  // the boundary by indexing the data's parallel id/label arrays.
+  // GeneTea consumes display labels (gene symbols), not IDs. Derive from
+  // selection's index ids. Existing semantics preserved (index labels).
   const selectedLabels = useMemo(() => {
-    if (!data?.index_ids || !selectedIds) {
-      return selectedIds;
+    if (!data?.index_ids || !selection) {
+      return null;
     }
 
     const idToLabel: Record<string, string> = {};
@@ -186,14 +175,14 @@ function DataExplorerDensity1DPlot({
     }
 
     const out = new Set<string>();
-    selectedIds.forEach((id) => {
-      const label = idToLabel[id];
+    selection.forEach((ref) => {
+      const label = idToLabel[ref.indexId];
       if (label !== undefined) {
         out.add(label);
       }
     });
     return out;
-  }, [data, selectedIds]);
+  }, [data, selection]);
 
   return (
     <div className={styles.DataExplorerDensity1DPlot}>
@@ -205,9 +194,7 @@ function DataExplorerDensity1DPlot({
             plotConfig={plotConfig}
             plotElement={plotElement}
             handleClickPoint={handleClickPoint}
-            onClickUnselectAll={() => {
-              setSelectedIds(null);
-            }}
+            onClickUnselectAll={clearSelection}
           />
         </div>
         <div className={styles.plot}>
@@ -218,11 +205,14 @@ function DataExplorerDensity1DPlot({
               xKey="x"
               colorMap={colorMap}
               colorData={colorData}
+              groupData={groupData}
+              groupKeys={sortedGroupKeys}
               continuousColorKey="contColorData"
               legendDisplayNames={legendDisplayNames}
               legendTitle={legendTitle}
               pointVisibility={pointVisibility || undefined}
               useSemiOpaqueViolins={!plotConfig.hide_points}
+              placeholderEmptyTracks={Boolean(plotConfig.expand_by?.length)}
               hoverTextKey="hoverText"
               annotationTextKey="annotationText"
               height="auto"
@@ -230,9 +220,7 @@ function DataExplorerDensity1DPlot({
               onClickPoint={handleClickPoint}
               onMultiselect={handleMultiselect}
               selectedPoints={selectedPoints}
-              onClickResetSelection={() => {
-                setSelectedIds(null);
-              }}
+              onClickResetSelection={clearSelection}
               hiddenLegendValues={hiddenLegendValues}
               pointSize={pointSize}
               pointOpacity={pointOpacity}
@@ -259,33 +247,45 @@ function DataExplorerDensity1DPlot({
             />
           </StackableSection>
           <StackableSection title="Plot Selections" minHeight={256}>
-            <PlotSelections
-              data={data}
-              plot_type={plotConfig?.plot_type || null}
-              selectedIds={selectedIds}
-              onClickVisualizeSelected={(e) =>
-                onClickVisualizeSelected(e, selectedIds as Set<string>)
-              }
-              onClickSaveSelectionAsContext={() => {
-                onClickSaveSelectionAsContext(
-                  plotConfig.index_type,
-                  selectedIds as Set<string>
-                );
-              }}
-              onClickClearSelection={() => {
-                setSelectedIds(null);
-              }}
-              onClickSetSelectionFromContext={async () => {
-                const newSelectedIds = await promptForSelectionFromContext(data!);
-
-                if (newSelectedIds === null) {
-                  return;
+            {isExpanded ? (
+              <ExpandedPlotSelections
+                data={data}
+                selection={selection}
+                onClickClearSelection={clearSelection}
+              />
+            ) : (
+              <PlotSelections
+                data={data}
+                plot_type={plotConfig?.plot_type || null}
+                selectedIds={selectedIdsLegacy}
+                onClickVisualizeSelected={(e) =>
+                  onClickVisualizeSelected(e, selectedIdsLegacy as Set<string>)
                 }
+                onClickSaveSelectionAsContext={() => {
+                  onClickSaveSelectionAsContext(
+                    plotConfig.index_type,
+                    selectedIdsLegacy as Set<string>
+                  );
+                }}
+                onClickClearSelection={clearSelection}
+                onClickSetSelectionFromContext={async () => {
+                  const newSelectedIds = await promptForSelectionFromContext(data!);
 
-                setSelectedIds(newSelectedIds);
-                plotElement?.annotateSelected();
-              }}
-            />
+                  if (newSelectedIds === null) {
+                    return;
+                  }
+
+                  // Context resolution names entities of one type, never
+                  // pairs — wrap as single refs. If/when contexts can
+                  // describe (index, expansion) pairs, this is the place
+                  // to grow.
+                  setSelection(
+                    new EntityRefSet([...newSelectedIds].map(singleRef))
+                  );
+                  plotElement?.annotateSelected();
+                }}
+              />
+            )}
           </StackableSection>
           {isPortal && plotConfig.index_type === "gene" ? (
             <StackableSection

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerPlotControls.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerPlotControls.tsx
@@ -27,6 +27,56 @@ function DataExplorerPlotControls({
       return [];
     }
 
+    // Expanded plots are N×M (entity, member) pairs, so index_ids/index_labels
+    // repeat each index entity once per member. One option per point would list
+    // the same model many times and a click would land on an arbitrary
+    // (entity, member) point. Instead, de-dupe to one option per index entity
+    // (searchable by name or id) and let handleSearch select that entity across
+    // all its members.
+    if (data.expansions?.length) {
+      const indicesByEntity = new Map<string, number[]>();
+
+      for (let i = 0; i < data.index_ids.length; i += 1) {
+        const id = data.index_ids[i];
+        const list = indicesByEntity.get(id);
+
+        if (list) {
+          list.push(i);
+        } else {
+          indicesByEntity.set(id, [i]);
+        }
+      }
+
+      const hasPlottablePoint = (indices: number[]) =>
+        indices.some(
+          (i) =>
+            data.dimensions.x.values[i] !== null &&
+            (!data.dimensions.y || data.dimensions.y.values[i] !== null)
+        );
+
+      const nameOptions: { value: string; label: string }[] = [];
+      const idOptions: { value: string; label: string }[] = [];
+
+      indicesByEntity.forEach((indices, id) => {
+        if (!hasPlottablePoint(indices)) {
+          return;
+        }
+
+        nameOptions.push({
+          label: data.index_labels[indices[0]],
+          value: `expansion_entity:${id}`,
+        });
+
+        if (data.index_type === "depmap_model") {
+          idOptions.push({ label: id, value: `expansion_entity:${id}` });
+        }
+      });
+
+      // Names first (the human-friendly default), then IDs as a secondary
+      // search path — mirrors the non-expanded ordering below.
+      return [...nameOptions, ...idOptions];
+    }
+
     // Search options show what a user can type to pick a point. The
     // `value` prefix is unused by `handleSearch` (which parses only the
     // index after the colon); the labels in the dropdown are what the
@@ -110,6 +160,28 @@ function DataExplorerPlotControls({
 
   const handleSearch = useCallback(
     (selected: { value: string; label: string }) => {
+      // Expanded plots de-dupe search to one entry per index entity; selecting
+      // it selects that entity across all its members (every (entity, member)
+      // point), accumulating via the existing single-point click.
+      if (selected.value.startsWith("expansion_entity:")) {
+        const id = selected.value.slice("expansion_entity:".length);
+        const indices: number[] = [];
+
+        for (let i = 0; i < data.index_ids.length; i += 1) {
+          if (data.index_ids[i] === id) {
+            indices.push(i);
+          }
+        }
+
+        indices.forEach((i) => handleClickPoint(i, true));
+
+        if (indices.length > 0 && !plotElement.isPointInView(indices[0])) {
+          setTimeout(() => plotElement.resetZoom(), 0);
+        }
+
+        return;
+      }
+
       const pointIndex = Number(selected.value.split(":")[1]);
       handleClickPoint(pointIndex, true);
 
@@ -117,7 +189,7 @@ function DataExplorerPlotControls({
         setTimeout(() => plotElement.resetZoom(), 0);
       }
     },
-    [plotElement, handleClickPoint]
+    [data, plotElement, handleClickPoint]
   );
 
   const searchPlaceholder = plotConfig.index_type

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerScatterPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerScatterPlot.tsx
@@ -1,22 +1,32 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { isPortal } from "@depmap/globals";
 import {
   DataExplorerContextV2,
+  DataExplorerExpansion,
   DataExplorerPlotConfig,
   DataExplorerPlotResponse,
+  EntityRefSet,
   LinRegInfo,
+  entityRefKey,
+  singleRef,
 } from "@depmap/types";
 import { useDataExplorerSettings } from "../../../../contexts/DataExplorerSettingsContext";
 import type ExtendedPlotType from "../../ExtendedPlotType";
 import SpinnerOverlay from "./SpinnerOverlay";
-import useScatterPlotData from "./prototype/useScatterPlotData";
+import useScatterPlotData, {
+  CanShowIdentityLine,
+} from "./prototype/useScatterPlotData";
 import PrototypeScatterPlot from "./prototype/PrototypeScatterPlot";
+import SmallMultiplesScatter from "./prototype/SmallMultiplesScatter";
+import { findCategoricalSlice } from "./prototype/plotUtils";
 import DataExplorerPlotControls from "./DataExplorerPlotControls";
 import PlotLegend from "./PlotLegend";
 import PlotSelections from "./PlotSelections";
+import ExpandedPlotSelections from "./ExpandedPlotSelections";
 import GeneTea from "./integrations/GeneTea";
 import SectionStack, { StackableSection } from "../SectionStack";
 import promptForSelectionFromContext from "./promptForSelectionFromContext";
+import useSelection from "../../hooks/useSelection";
 import styles from "../../styles/DataExplorer2.scss";
 
 interface Props {
@@ -33,6 +43,9 @@ interface Props {
     selectedIds: Set<string>
   ) => void;
   plotConfig: DataExplorerPlotConfig;
+  // Overrides the rule for when the x = y identity line is eligible. Omit to use
+  // the default (same dataset on both axes). Threaded down from VisualizationPanel.
+  canShowIdentityLine?: CanShowIdentityLine;
 }
 
 function DataExplorerScatterPlot({
@@ -43,9 +56,41 @@ function DataExplorerScatterPlot({
   onClickSaveSelectionAsContext,
   onClickVisualizeSelected,
   plotConfig,
+  canShowIdentityLine = undefined,
 }: Props) {
   const [plotElement, setPlotElement] = useState<ExtendedPlotType | null>(null);
-  const [selectedIds, setSelectedIds] = useState<Set<string> | null>(null);
+  const {
+    selection,
+    selectedPoints,
+    handleClickPoint,
+    handleMultiselect,
+    setSelection,
+    clearSelection,
+  } = useSelection(data);
+
+  // Expanded plots (the response carries an expansion) get a different
+  // selection panel: ExpandedPlotSelections lists (index, expansion)
+  // pairs instead of collapsing them to index entities. Structural read
+  // on the expansion shape, matching the idiom in plotUtils / useSelection.
+  const isExpanded =
+    ((data as { expansions?: DataExplorerExpansion[] } | null)?.expansions
+      ?.length ?? 0) > 0;
+
+  // Small multiples = the 2D realization of group_by. Unlike the 1D plots,
+  // scatter does NOT fall back to color_by when group_by is unset: auto-
+  // faceting a colored scatter by its own color dimension would explode into
+  // per-category panels. So facet only on an *explicit* group_by. The facet
+  // key per point comes from the same reader color_by uses.
+  const facetKeys = useMemo(() => {
+    if (!plotConfig.group_by) {
+      return null;
+    }
+    const slice = findCategoricalSlice(data, plotConfig.group_by);
+    return (
+      slice?.values.map((v) => (v == null ? "(no value)" : String(v))) ?? null
+    );
+  }, [data, plotConfig.group_by]);
+  const isFaceted = Boolean(facetKeys);
   const [showSpinner, setShowSpinner] = useState(isLoading);
   const { plotStyles } = useDataExplorerSettings();
   const {
@@ -67,8 +112,15 @@ function DataExplorerScatterPlot({
     legendForDownload,
     pointVisibility,
     regressionLines,
+    regressionLinesByFacet,
     showIdentityLine,
-  } = useScatterPlotData(data, plotConfig, linreg_by_group, palette);
+  } = useScatterPlotData(
+    data,
+    plotConfig,
+    linreg_by_group,
+    palette,
+    canShowIdentityLine
+  );
 
   const {
     hiddenLegendValues,
@@ -93,96 +145,73 @@ function DataExplorerScatterPlot({
   const slice_type1 = plotConfig.dimensions.y?.slice_type;
 
   useEffect(() => {
-    setSelectedIds(null);
-  }, [slice_type0, slice_type1]);
+    clearSelection();
+  }, [slice_type0, slice_type1, clearSelection]);
 
+  // When the data changes (filter change, dataset switch, etc.), drop any
+  // selected refs that no longer correspond to a point in the new response.
+  // Done in terms of the derived ref key so both "single" and "pair"
+  // selections work uniformly.
   useEffect(() => {
     if (!data?.index_ids) {
       return;
     }
 
-    const validSelections = new Set(data.index_ids || []);
+    const validKeys = new Set<string>();
+    const expansions = (data as { expansions?: { ids: string[] }[] })
+      .expansions;
+    const expansionIds = expansions?.[0]?.ids;
+    for (let i = 0; i < data.index_ids.length; i += 1) {
+      if (expansionIds) {
+        validKeys.add(`p\x1f${data.index_ids[i]}\x1f${expansionIds[i]}`);
+      } else {
+        validKeys.add(`s\x1f${data.index_ids[i]}`);
+      }
+    }
 
-    setSelectedIds((xs) => {
-      if (!xs) {
+    setSelection((current) => {
+      if (!current) {
         return null;
       }
-
-      const ys = new Set<string>();
-      const ids = [...xs];
-
-      for (let i = 0; i < ids.length; i += 1) {
-        const id = ids[i];
-        if (validSelections.has(id)) {
-          ys.add(id);
+      let next = current;
+      current.forEach((ref) => {
+        if (!validKeys.has(entityRefKey(ref))) {
+          next = next.delete(ref);
         }
-      }
-
-      return ys;
+      });
+      return next;
     });
-  }, [data]);
+  }, [data, setSelection]);
 
-  const selectedPoints = useMemo(() => {
-    const out: Set<number> = new Set();
-
-    if (!data?.index_ids) {
-      return out;
+  // Legacy panel compat: derive a Set<string> of index ids from the
+  // structured selection. PlotSelections still keys on `data.index_ids`,
+  // and the parent's onClickVisualizeSelected / onClickSaveSelectionAsContext
+  // callbacks expect a Set<string>. For single-ref selections this is a
+  // lossless identity; for pair-ref selections, multiple pairs of the
+  // same model collapse to one index id — the same shape the legacy code
+  // produced (and one the legacy operations know how to consume).
+  //
+  // Patch 5 introduces ExpandedPlotSelections which consumes `selection`
+  // directly for expanded plots; once that lands this `selectedIdsLegacy`
+  // remains only for the non-expanded path and for the parent callbacks.
+  const selectedIdsLegacy = useMemo<Set<string> | null>(() => {
+    if (!selection) {
+      return null;
     }
-
-    for (let i = 0; i < data.index_ids.length; i += 1) {
-      if (selectedIds?.has(data.index_ids[i])) {
-        out.add(i);
-      }
-    }
-
+    const out = new Set<string>();
+    selection.forEach((ref) => out.add(ref.indexId));
     return out;
-  }, [data, selectedIds]);
+  }, [selection]);
 
-  const handleMultiselect = useCallback(
-    (pointIndices: number[]) => {
-      if (data && pointIndices.length > 0) {
-        const s = new Set<string>();
-        pointIndices.forEach((i: number) => {
-          s.add(data.index_ids[i]);
-        });
-        setSelectedIds(s);
-      }
-    },
-    [data]
-  );
-
-  const handleClickPoint = useCallback(
-    (pointIndex: number, ctrlKey: boolean) => {
-      if (!data) {
-        return;
-      }
-
-      const id = data.index_ids[pointIndex];
-
-      if (ctrlKey) {
-        setSelectedIds((xs) => {
-          const ys = new Set(xs);
-
-          if (xs?.has(id)) {
-            ys.delete(id);
-          } else {
-            ys.add(id);
-          }
-
-          return ys;
-        });
-      } else {
-        setSelectedIds(new Set([id]));
-      }
-    },
-    [data, setSelectedIds]
-  );
-
-  // GeneTea consumes display labels (gene symbols), not IDs. Convert at
-  // the boundary by indexing the data's parallel id/label arrays.
+  // GeneTea consumes display labels (gene symbols), not IDs. Derive from
+  // selection's index ids — index labels are the depmap_model / gene label
+  // path, unchanged by the migration. (For expanded plots, what GeneTea
+  // *should* consume — model labels or the expansion's labels — is an
+  // open question, but the migration shouldn't decide it; existing
+  // semantics preserved.)
   const selectedLabels = useMemo(() => {
-    if (!data?.index_ids || !selectedIds) {
-      return selectedIds;
+    if (!data?.index_ids || !selection) {
+      return null;
     }
 
     const idToLabel: Record<string, string> = {};
@@ -191,14 +220,14 @@ function DataExplorerScatterPlot({
     }
 
     const out = new Set<string>();
-    selectedIds.forEach((id) => {
-      const label = idToLabel[id];
+    selection.forEach((ref) => {
+      const label = idToLabel[ref.indexId];
       if (label !== undefined) {
         out.add(label);
       }
     });
     return out;
-  }, [data, selectedIds]);
+  }, [data, selection]);
 
   return (
     <div className={styles.DataExplorerScatterPlot}>
@@ -210,44 +239,78 @@ function DataExplorerScatterPlot({
             isLoading={showSpinner}
             plotElement={plotElement}
             handleClickPoint={handleClickPoint}
-            onClickUnselectAll={() => setSelectedIds(null)}
+            onClickUnselectAll={clearSelection}
           />
         </div>
         <div className={styles.plot}>
           {showSpinner && <SpinnerOverlay />}
-          {formattedData && (
-            <PrototypeScatterPlot
-              data={formattedData}
-              xKey="x"
-              yKey="y"
-              pointVisibility={pointVisibility || undefined}
-              colorKey1="color1"
-              colorKey2="color2"
-              categoricalColorKey="catColorData"
-              continuousColorKey="contColorData"
-              contLegendKeys={contLegendKeys}
-              colorMap={colorMap}
-              hoverTextKey="hoverText"
-              annotationTextKey="annotationText"
-              height="auto"
-              xLabel={formattedData?.xLabel || ""}
-              yLabel={formattedData?.yLabel || ""}
-              onLoad={setPlotElement}
-              onClickPoint={handleClickPoint}
-              onMultiselect={handleMultiselect}
-              selectedPoints={selectedPoints}
-              showIdentityLine={showIdentityLine}
-              regressionLines={regressionLines}
-              onClickResetSelection={() => setSelectedIds(null)}
-              legendForDownload={legendForDownload}
-              pointSize={pointSize}
-              pointOpacity={pointOpacity}
-              outlineWidth={outlineWidth}
-              palette={palette}
-              xAxisFontSize={xAxisFontSize}
-              yAxisFontSize={yAxisFontSize}
-            />
-          )}
+          {formattedData &&
+            (isFaceted ? (
+              <SmallMultiplesScatter
+                data={formattedData}
+                xKey="x"
+                yKey="y"
+                pointVisibility={pointVisibility || undefined}
+                colorKey1="color1"
+                colorKey2="color2"
+                categoricalColorKey="catColorData"
+                continuousColorKey="contColorData"
+                contLegendKeys={contLegendKeys}
+                colorMap={colorMap}
+                hoverTextKey="hoverText"
+                annotationTextKey="annotationText"
+                height="auto"
+                xLabel={formattedData?.xLabel || ""}
+                yLabel={formattedData?.yLabel || ""}
+                facetKeys={facetKeys ?? []}
+                placeholderEmptyFacets={Boolean(plotConfig.expand_by?.length)}
+                showIdentityLine={showIdentityLine}
+                regressionLinesByFacet={regressionLinesByFacet}
+                onLoad={setPlotElement}
+                onClickPoint={handleClickPoint}
+                onMultiselect={handleMultiselect}
+                selectedPoints={selectedPoints}
+                onClickResetSelection={clearSelection}
+                pointSize={pointSize}
+                pointOpacity={pointOpacity}
+                outlineWidth={outlineWidth}
+                palette={palette}
+                xAxisFontSize={xAxisFontSize}
+                yAxisFontSize={yAxisFontSize}
+              />
+            ) : (
+              <PrototypeScatterPlot
+                data={formattedData}
+                xKey="x"
+                yKey="y"
+                pointVisibility={pointVisibility || undefined}
+                colorKey1="color1"
+                colorKey2="color2"
+                categoricalColorKey="catColorData"
+                continuousColorKey="contColorData"
+                contLegendKeys={contLegendKeys}
+                colorMap={colorMap}
+                hoverTextKey="hoverText"
+                annotationTextKey="annotationText"
+                height="auto"
+                xLabel={formattedData?.xLabel || ""}
+                yLabel={formattedData?.yLabel || ""}
+                onLoad={setPlotElement}
+                onClickPoint={handleClickPoint}
+                onMultiselect={handleMultiselect}
+                selectedPoints={selectedPoints}
+                showIdentityLine={showIdentityLine}
+                regressionLines={regressionLines}
+                onClickResetSelection={clearSelection}
+                legendForDownload={legendForDownload}
+                pointSize={pointSize}
+                pointOpacity={pointOpacity}
+                outlineWidth={outlineWidth}
+                palette={palette}
+                xAxisFontSize={xAxisFontSize}
+                yAxisFontSize={yAxisFontSize}
+              />
+            ))}
         </div>
       </div>
       <div className={styles.right}>
@@ -265,35 +328,47 @@ function DataExplorerScatterPlot({
             />
           </StackableSection>
           <StackableSection title="Plot Selections" minHeight={256}>
-            <PlotSelections
-              data={data}
-              plot_type={plotConfig?.plot_type || null}
-              selectedIds={selectedIds}
-              onClickVisualizeSelected={(e) =>
-                onClickVisualizeSelected(e, selectedIds as Set<string>)
-              }
-              onClickSaveSelectionAsContext={() => {
-                onClickSaveSelectionAsContext(
-                  plotConfig.index_type,
-                  selectedIds as Set<string>
-                );
-              }}
-              onClickClearSelection={() => {
-                setSelectedIds(null);
-              }}
-              onClickSetSelectionFromContext={async () => {
-                const newSelectedIds = await promptForSelectionFromContext(
-                  data!
-                );
-
-                if (newSelectedIds === null) {
-                  return;
+            {isExpanded ? (
+              <ExpandedPlotSelections
+                data={data}
+                selection={selection}
+                onClickClearSelection={clearSelection}
+              />
+            ) : (
+              <PlotSelections
+                data={data}
+                plot_type={plotConfig?.plot_type || null}
+                selectedIds={selectedIdsLegacy}
+                onClickVisualizeSelected={(e) =>
+                  onClickVisualizeSelected(e, selectedIdsLegacy as Set<string>)
                 }
+                onClickSaveSelectionAsContext={() => {
+                  onClickSaveSelectionAsContext(
+                    plotConfig.index_type,
+                    selectedIdsLegacy as Set<string>
+                  );
+                }}
+                onClickClearSelection={clearSelection}
+                onClickSetSelectionFromContext={async () => {
+                  const newSelectedIds = await promptForSelectionFromContext(
+                    data!
+                  );
 
-                setSelectedIds(newSelectedIds);
-                plotElement?.annotateSelected();
-              }}
-            />
+                  if (newSelectedIds === null) {
+                    return;
+                  }
+
+                  // Context resolution names entities of one type, never
+                  // pairs — wrap as single refs. If/when contexts can
+                  // describe (index, expansion) pairs, this is the place
+                  // to grow.
+                  setSelection(
+                    new EntityRefSet([...newSelectedIds].map(singleRef))
+                  );
+                  plotElement?.annotateSelected();
+                }}
+              />
+            )}
           </StackableSection>
           {isPortal && plotConfig.index_type === "gene" ? (
             <StackableSection

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerWaterfallPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerWaterfallPlot.tsx
@@ -1,21 +1,27 @@
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { useDataExplorerSettings } from "../../../../contexts/DataExplorerSettingsContext";
 import { isPortal } from "@depmap/globals";
 import SpinnerOverlay from "./SpinnerOverlay";
 import type ExtendedPlotType from "../../ExtendedPlotType";
 import {
   DataExplorerContextV2,
+  DataExplorerExpansion,
   DataExplorerPlotConfig,
   DataExplorerPlotResponse,
+  EntityRefSet,
+  entityRefKey,
+  singleRef,
 } from "@depmap/types";
 import useWaterfallPlotData from "./prototype/useWaterfallPlotData";
 import PrototypeScatterPlot from "./prototype/PrototypeScatterPlot";
 import DataExplorerPlotControls from "./DataExplorerPlotControls";
 import PlotLegend from "./PlotLegend";
 import PlotSelections from "./PlotSelections";
+import ExpandedPlotSelections from "./ExpandedPlotSelections";
 import GeneTea from "./integrations/GeneTea";
 import SectionStack, { StackableSection } from "../SectionStack";
 import promptForSelectionFromContext from "./promptForSelectionFromContext";
+import useSelection from "../../hooks/useSelection";
 import styles from "../../styles/DataExplorer2.scss";
 
 interface Props {
@@ -42,7 +48,22 @@ function DataExplorerWaterfallPlot({
   onClickVisualizeSelected,
 }: Props) {
   const [plotElement, setPlotElement] = useState<ExtendedPlotType | null>(null);
-  const [selectedIds, setSelectedIds] = useState<Set<string> | null>(null);
+  const {
+    selection,
+    selectedPoints,
+    handleClickPoint,
+    handleMultiselect,
+    setSelection,
+    clearSelection,
+  } = useSelection(data);
+
+  // Expanded plots (the response carries an expansion) get a different
+  // selection panel: ExpandedPlotSelections lists (index, expansion)
+  // pairs instead of collapsing them to index entities. Structural read
+  // on the expansion shape, matching the idiom in plotUtils / useSelection.
+  const isExpanded =
+    ((data as { expansions?: DataExplorerExpansion[] } | null)?.expansions
+      ?.length ?? 0) > 0;
   const [showSpinner, setShowSpinner] = useState(isLoading);
   const { plotStyles } = useDataExplorerSettings();
   const {
@@ -89,96 +110,61 @@ function DataExplorerWaterfallPlot({
   const slice_type1 = plotConfig.dimensions.y?.slice_type;
 
   useEffect(() => {
-    setSelectedIds(null);
-  }, [slice_type0, slice_type1]);
+    clearSelection();
+  }, [slice_type0, slice_type1, clearSelection]);
 
+  // When the data changes (filter change, dataset switch, etc.), drop any
+  // selected refs that no longer correspond to a point in the new response.
+  // Done in terms of the derived ref key so both "single" and "pair"
+  // selections work uniformly.
   useEffect(() => {
     if (!data?.index_ids) {
       return;
     }
 
-    const validSelections = new Set(data.index_ids || []);
+    const validKeys = new Set<string>();
+    const expansions = (data as { expansions?: { ids: string[] }[] })
+      .expansions;
+    const expansionIds = expansions?.[0]?.ids;
+    for (let i = 0; i < data.index_ids.length; i += 1) {
+      if (expansionIds) {
+        validKeys.add(`p\x1f${data.index_ids[i]}\x1f${expansionIds[i]}`);
+      } else {
+        validKeys.add(`s\x1f${data.index_ids[i]}`);
+      }
+    }
 
-    setSelectedIds((xs) => {
-      if (!xs) {
+    setSelection((current) => {
+      if (!current) {
         return null;
       }
-
-      const ys = new Set<string>();
-      const ids = [...xs];
-
-      for (let i = 0; i < ids.length; i += 1) {
-        const id = ids[i];
-        if (validSelections.has(id)) {
-          ys.add(id);
+      let next = current;
+      current.forEach((ref) => {
+        if (!validKeys.has(entityRefKey(ref))) {
+          next = next.delete(ref);
         }
-      }
-
-      return ys;
+      });
+      return next;
     });
-  }, [data]);
+  }, [data, setSelection]);
 
-  const selectedPoints = useMemo(() => {
-    const out: Set<number> = new Set();
-
-    if (!data?.index_ids) {
-      return out;
+  // Legacy panel compat: derive a Set<string> of index ids from the
+  // structured selection. See DataExplorerScatterPlot for full rationale.
+  // Replaced by ExpandedPlotSelections (patch 5) for expanded plots.
+  const selectedIdsLegacy = useMemo<Set<string> | null>(() => {
+    if (!selection) {
+      return null;
     }
-
-    for (let i = 0; i < data.index_ids.length; i += 1) {
-      if (selectedIds?.has(data.index_ids[i])) {
-        out.add(i);
-      }
-    }
-
+    const out = new Set<string>();
+    selection.forEach((ref) => out.add(ref.indexId));
     return out;
-  }, [data, selectedIds]);
+  }, [selection]);
 
-  const handleMultiselect = useCallback(
-    (pointIndices: number[]) => {
-      if (data && pointIndices.length > 0) {
-        const s = new Set<string>();
-        pointIndices.forEach((i: number) => {
-          s.add(data.index_ids[i]);
-        });
-        setSelectedIds(s);
-      }
-    },
-    [data]
-  );
-
-  const handleClickPoint = useCallback(
-    (pointIndex: number, ctrlKey: boolean) => {
-      if (!data) {
-        return;
-      }
-
-      const id = data.index_ids[pointIndex];
-
-      if (ctrlKey) {
-        setSelectedIds((xs) => {
-          const ys = new Set(xs);
-
-          if (xs?.has(id)) {
-            ys.delete(id);
-          } else {
-            ys.add(id);
-          }
-
-          return ys;
-        });
-      } else {
-        setSelectedIds(new Set([id]));
-      }
-    },
-    [data, setSelectedIds]
-  );
-
-  // GeneTea consumes display labels (gene symbols), not IDs. Convert at
-  // the boundary by indexing the data's parallel id/label arrays.
+  // GeneTea consumes display labels (gene symbols), not IDs. Derive from
+  // selection's index ids. Existing semantics preserved (index labels).
   const selectedLabels = useMemo(() => {
-    if (!data?.index_ids || !selectedIds) {
-      return selectedIds;
+    if (!data?.index_ids || !selection) {
+      return null;
     }
 
     const idToLabel: Record<string, string> = {};
@@ -187,14 +173,14 @@ function DataExplorerWaterfallPlot({
     }
 
     const out = new Set<string>();
-    selectedIds.forEach((id) => {
-      const label = idToLabel[id];
+    selection.forEach((ref) => {
+      const label = idToLabel[ref.indexId];
       if (label !== undefined) {
         out.add(label);
       }
     });
     return out;
-  }, [data, selectedIds]);
+  }, [data, selection]);
 
   return (
     <div className={styles.DataExplorerScatterPlot}>
@@ -206,7 +192,7 @@ function DataExplorerWaterfallPlot({
             isLoading={showSpinner}
             plotElement={plotElement}
             handleClickPoint={handleClickPoint}
-            onClickUnselectAll={() => setSelectedIds(null)}
+            onClickUnselectAll={clearSelection}
           />
         </div>
         <div className={styles.plot}>
@@ -233,7 +219,7 @@ function DataExplorerWaterfallPlot({
               onMultiselect={handleMultiselect}
               selectedPoints={selectedPoints}
               showIdentityLine={false}
-              onClickResetSelection={() => setSelectedIds(null)}
+              onClickResetSelection={clearSelection}
               legendForDownload={legendForDownload}
               pointSize={pointSize}
               pointOpacity={pointOpacity}
@@ -264,35 +250,47 @@ function DataExplorerWaterfallPlot({
             />
           </StackableSection>
           <StackableSection title="Plot Selections" minHeight={256}>
-            <PlotSelections
-              data={data}
-              plot_type={plotConfig?.plot_type || null}
-              selectedIds={selectedIds}
-              onClickVisualizeSelected={(e) =>
-                onClickVisualizeSelected(e, selectedIds as Set<string>)
-              }
-              onClickSaveSelectionAsContext={() => {
-                onClickSaveSelectionAsContext(
-                  plotConfig.index_type,
-                  selectedIds as Set<string>
-                );
-              }}
-              onClickClearSelection={() => {
-                setSelectedIds(null);
-              }}
-              onClickSetSelectionFromContext={async () => {
-                const newSelectedIds = await promptForSelectionFromContext(
-                  data!
-                );
-
-                if (newSelectedIds === null) {
-                  return;
+            {isExpanded ? (
+              <ExpandedPlotSelections
+                data={data}
+                selection={selection}
+                onClickClearSelection={clearSelection}
+              />
+            ) : (
+              <PlotSelections
+                data={data}
+                plot_type={plotConfig?.plot_type || null}
+                selectedIds={selectedIdsLegacy}
+                onClickVisualizeSelected={(e) =>
+                  onClickVisualizeSelected(e, selectedIdsLegacy as Set<string>)
                 }
+                onClickSaveSelectionAsContext={() => {
+                  onClickSaveSelectionAsContext(
+                    plotConfig.index_type,
+                    selectedIdsLegacy as Set<string>
+                  );
+                }}
+                onClickClearSelection={clearSelection}
+                onClickSetSelectionFromContext={async () => {
+                  const newSelectedIds = await promptForSelectionFromContext(
+                    data!
+                  );
 
-                setSelectedIds(newSelectedIds);
-                plotElement?.annotateSelected();
-              }}
-            />
+                  if (newSelectedIds === null) {
+                    return;
+                  }
+
+                  // Context resolution names entities of one type, never
+                  // pairs — wrap as single refs. If/when contexts can
+                  // describe (index, expansion) pairs, this is the place
+                  // to grow.
+                  setSelection(
+                    new EntityRefSet([...newSelectedIds].map(singleRef))
+                  );
+                  plotElement?.annotateSelected();
+                }}
+              />
+            )}
           </StackableSection>
           {isPortal && plotConfig.index_type === "gene" ? (
             <StackableSection

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DummyPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DummyPlot.tsx
@@ -17,6 +17,30 @@ interface Props {
   errorMessage?: string;
 }
 
+function safeUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.toString();
+    }
+  } catch {
+    // invalid URL
+  }
+
+  return "#";
+}
+
+function safeMailto(email: string): string {
+  const trimmed = email.trim();
+
+  if (!/^[^\s@]+@[^\s@.]+\.[^\s@]+$/.test(trimmed)) {
+    return "#";
+  }
+
+  return `mailto:${encodeURIComponent(trimmed)}`;
+}
+
 function ErrorState({
   feedbackUrl,
   contactEmail,
@@ -32,7 +56,11 @@ function ErrorState({
       {feedbackUrl ? (
         <p>
           If this problem persists, please submit a report with{" "}
-          <a href={feedbackUrl} target="_blank" rel="noopener noreferrer">
+          <a
+            href={safeUrl(feedbackUrl)}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             this form
           </a>
           .
@@ -40,7 +68,7 @@ function ErrorState({
       ) : (
         <p>
           If this problem persists, please contact us at{" "}
-          <a href={`mailto:${contactEmail}`}>{contactEmail}</a>.
+          <a href={safeMailto(`mailto:${contactEmail}`)}>{contactEmail}</a>.
         </p>
       )}
       {errorMessage && <details>{errorMessage}</details>}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/ExpandedPlotSelections/ExpandedSelectionsTable.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/ExpandedPlotSelections/ExpandedSelectionsTable.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+
+// ExpandedSelectionsTable
+//
+// Bespoke table for the expanded-selections "Show Table" modal. One row per
+// selected point — a (model, transcript) pair — with one column per axis of
+// the pair: the index entity plus each expansion. We support a single
+// expansion today, so that's two columns (Model, Transcript); the same shape
+// generalizes to num_expansions + 1 columns. Includes a CSV download of the
+// same rows (with ids, which a label-only export would lose).
+export interface SelectionPair {
+  modelId: string;
+  modelLabel: string;
+  transcriptId: string;
+  transcriptLabel: string;
+  key: string;
+}
+
+const escapeCsv = (value: string) =>
+  /[",\n\r]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+
+function downloadPairsCsv(pairs: SelectionPair[]) {
+  const header = ["Model", "Model ID", "Transcript", "Transcript ID"];
+  const lines = [header.join(",")];
+
+  pairs.forEach((p) => {
+    lines.push(
+      [p.modelLabel, p.modelId, p.transcriptLabel, p.transcriptId]
+        .map(escapeCsv)
+        .join(",")
+    );
+  });
+
+  const blob = new Blob([lines.join("\r\n")], {
+    type: "text/csv;charset=utf-8;",
+  });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = "selected_transcripts.csv";
+  link.click();
+  URL.revokeObjectURL(url);
+}
+
+const thStyle: React.CSSProperties = {
+  textAlign: "left",
+  padding: "4px 8px",
+  borderBottom: "2px solid #ccc",
+  position: "sticky",
+  top: 0,
+  background: "#fff",
+};
+
+const tdStyle: React.CSSProperties = {
+  padding: "4px 8px",
+  borderBottom: "1px solid #eee",
+};
+
+function ExpandedSelectionsTable({ pairs }: { pairs: SelectionPair[] }) {
+  return (
+    <div>
+      <div style={{ marginBottom: 8, textAlign: "right" }}>
+        <button type="button" onClick={() => downloadPairsCsv(pairs)}>
+          Download CSV
+        </button>
+      </div>
+      <div style={{ maxHeight: 400, overflow: "auto" }}>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr>
+              <th style={thStyle}>Model</th>
+              <th style={thStyle}>Transcript</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pairs.map((p) => (
+              <tr key={p.key}>
+                <td style={tdStyle}>{p.modelLabel}</td>
+                <td style={tdStyle}>{p.transcriptLabel}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export default ExpandedSelectionsTable;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/ExpandedPlotSelections/PairsVirtualList.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/ExpandedPlotSelections/PairsVirtualList.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import VirtualList from "react-tiny-virtual-list";
+import styles from "../../../styles/DataExplorer2.scss";
+
+// PairsVirtualList
+//
+// Presentational sibling of PlotSelections/LabelsVirtualList for expanded
+// plots. The list stays flat and fixed-item-size (so virtualization stays
+// trivial), but rows come in two kinds: a `header` row per selected index
+// entity (model) and a `member` row per selected expansion (transcript)
+// beneath it. Members are indented with a margin so the flat list reads as a
+// grouped one. ExpandedPlotSelections builds the rows; this just renders them.
+//
+// `key` carries a stable id per row (entityRefKey for members, a header-
+// prefixed index id for headers) so React keys survive reordering and never
+// collide.
+export interface SelectionRow {
+  kind: "header" | "member";
+  label: string;
+  key: string;
+}
+
+const ITEM_SIZE = 20;
+
+function PairsVirtualList({
+  items,
+  maxHeight,
+}: {
+  items: SelectionRow[];
+  maxHeight: number;
+}) {
+  const height = Math.min(items.length * ITEM_SIZE, maxHeight);
+
+  return (
+    <VirtualList
+      className={styles.plotSelectionsList}
+      width="100%"
+      height={height}
+      itemCount={items.length}
+      itemSize={ITEM_SIZE}
+      data-overflow
+      renderItem={({ index, style }) => {
+        const item = items[index];
+
+        return (
+          <div
+            className={styles.pairsVirtualListItem}
+            key={item.key}
+            style={style}
+            data-kind={item.kind}
+          >
+            <div style={{ marginLeft: item.kind === "member" ? 16 : 0 }}>
+              {item.label}
+            </div>
+          </div>
+        );
+      }}
+    />
+  );
+}
+
+export default PairsVirtualList;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/ExpandedPlotSelections/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/ExpandedPlotSelections/index.tsx
@@ -1,0 +1,191 @@
+import React, { useContext, useMemo } from "react";
+import { Button } from "react-bootstrap";
+import { showInfoModal } from "@depmap/common-components";
+import {
+  DataExplorerExpansion,
+  DataExplorerPlotResponse,
+  EntityRefSet,
+  entityRefKey,
+  pairRef,
+} from "@depmap/types";
+import { SectionStackContext } from "../../SectionStack";
+import HelpTip from "../../HelpTip";
+import PairsVirtualList, { SelectionRow } from "./PairsVirtualList";
+import ExpandedSelectionsTable, {
+  SelectionPair,
+} from "./ExpandedSelectionsTable";
+import styles from "../../../styles/DataExplorer2.scss";
+
+// ExpandedPlotSelections
+//
+// The selection panel for expanded plots — the sibling of PlotSelections
+// that the plot wrappers dispatch to when the response carries an
+// expansion. Where PlotSelections lists one row per selected *index*
+// entity (a model), this groups the selected *points* under their index
+// entity: a header row per model, with its selected expansions
+// (transcripts) listed and indented beneath it.
+//
+// Why a separate component rather than a flag on PlotSelections:
+//   - It consumes the selection as an EntityRefSet directly (pairs), not
+//     the index-id-only Set<string> the legacy panel is built around.
+//   - It has no Visualize / Copy / Save-as-Context buttons. Those
+//     operations are defined over index entities (a context names one
+//     entity type, never a pair), so they're meaningless here until pair
+//     contexts exist. Per Phil's direction the panel is buttons-free
+//     except for clearing the selection.
+//   - "Set selection from a context" is omitted for the same reason: a
+//     context resolves to single refs, which can never match a pair ref,
+//     so the control would silently select nothing.
+//
+// The component deliberately consumes only { data, selection,
+// onClickClearSelection } — every prop is used, so the signature is
+// honest about what the panel actually needs. Hyperlinking the individual
+// pair components is deferred (a two-entity row wants a two-column
+// design); rows are plain text for now.
+interface Props {
+  data: DataExplorerPlotResponse | null;
+  selection: EntityRefSet | null;
+  onClickClearSelection: () => void;
+}
+
+// The height of everything in the section *except* the scrolling list: the
+// instructions/clear-button block plus the sectionContent padding. Used the
+// same way PlotSelections uses its own constant — subtracted from the
+// SectionStack's allocated height to size the list. PlotSelections reserves
+// ~194 because it also has a three-button column below the list; this panel
+// has no buttons, so reserving that much leaves the list box ~120px short and
+// hides trailing rows. This is an eyeballed value for the fragile SectionStack
+// measurement, not a precise one — nudge it if the list ends up slightly too
+// tall or too short.
+const SECTION_HEIGHT_WITHOUT_LIST = 104;
+
+function ExpandedPlotSelections({
+  data,
+  selection,
+  onClickClearSelection,
+}: Props) {
+  const { sectionHeights } = useContext(SectionStackContext);
+
+  const pairs = useMemo<SelectionPair[]>(() => {
+    const expansions = (data as { expansions?: DataExplorerExpansion[] } | null)
+      ?.expansions;
+
+    if (!data || !selection || !expansions || expansions.length === 0) {
+      return [];
+    }
+
+    // MVP "at most one expansion": the points index is expansions[0],
+    // parallel to index_ids / index_labels. Walk points (not the selection
+    // set) so rows come out in the plot's own point order, matching how
+    // PlotSelections derives its list.
+    const expansion = expansions[0];
+    const out: SelectionPair[] = [];
+
+    for (let i = 0; i < data.index_ids.length; i += 1) {
+      const ref = pairRef(data.index_ids[i], expansion.ids[i]);
+
+      if (selection.has(ref)) {
+        out.push({
+          modelId: data.index_ids[i],
+          modelLabel: data.index_labels[i],
+          transcriptId: expansion.ids[i],
+          transcriptLabel: expansion.labels[i],
+          key: entityRefKey(ref),
+        });
+      }
+    }
+
+    return out;
+  }, [data, selection]);
+
+  const rows = useMemo<SelectionRow[]>(() => {
+    // Group the flat pairs by index id (unique — two models can share a
+    // label) and display the label; the list carries a header row per model
+    // followed by its selected expansions as indented members.
+    const groups = new Map<
+      string,
+      { label: string; members: SelectionRow[] }
+    >();
+
+    pairs.forEach((pair) => {
+      let group = groups.get(pair.modelId);
+
+      if (!group) {
+        group = { label: pair.modelLabel, members: [] };
+        groups.set(pair.modelId, group);
+      }
+
+      group.members.push({
+        kind: "member",
+        label: pair.transcriptLabel,
+        key: pair.key,
+      });
+    });
+
+    const out: SelectionRow[] = [];
+
+    groups.forEach((group, id) => {
+      out.push({ kind: "header", label: group.label, key: `header:${id}` });
+      group.members.forEach((member) => out.push(member));
+    });
+
+    return out;
+  }, [pairs]);
+
+  const count = rows.length;
+
+  const maxHeightOfList =
+    count > 0 ? sectionHeights[1] - SECTION_HEIGHT_WITHOUT_LIST : Infinity;
+
+  // "Show Table" opens a (model, transcript) table of the selected pairs,
+  // with a CSV download. Pair selections don't support the usual
+  // PlotSelections operations, so this is a read-only view for now.
+  const onClickShowTable = () => {
+    showInfoModal({
+      title: "Selected transcripts",
+      content: <ExpandedSelectionsTable pairs={pairs} />,
+    });
+  };
+
+  return (
+    <div>
+      <div className={styles.plotInstructions}>
+        <div>
+          Select points to populate list
+          <HelpTip id="select-points-help" />
+        </div>
+        {selection && selection.size > 0 && (
+          <div>
+            <div>
+              <button
+                className={styles.setSelectionButton}
+                type="button"
+                onClick={onClickClearSelection}
+              >
+                clear {selection.size.toLocaleString()} selected{" "}
+                {selection.size === 1 ? "pair" : "pairs"}
+              </button>
+            </div>
+            <div>
+              <Button
+                className={styles.seeTableButton}
+                onClick={onClickShowTable}
+                bsStyle="primary"
+                bsSize="xs"
+              >
+                See Table
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+      <div className={styles.plotSelectionsContent}>
+        <div>
+          <PairsVirtualList items={rows} maxHeight={maxHeightOfList} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ExpandedPlotSelections;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/ExpandedPlotSelections/showExpandedSelectionsTable.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/ExpandedPlotSelections/showExpandedSelectionsTable.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { showInfoModal } from "@depmap/common-components";
+import { DataExplorerPlotResponse, EntityRefSet } from "@depmap/types";
+
+function showExpandedSelectionsTable(
+  data: DataExplorerPlotResponse,
+  selection: EntityRefSet
+) {
+  showInfoModal({
+    title: "Selected pairs",
+    content: (
+      <pre style={{ maxHeight: 400, overflow: "auto" }}>
+        {JSON.stringify(selection, null, 2)}
+      </pre>
+    ),
+  });
+}
+
+export default showExpandedSelectionsTable;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/PrototypeDensity1D.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/PrototypeDensity1D.tsx
@@ -19,7 +19,9 @@ import {
   hexToRgba,
   isEveryValueNull,
   LEGEND_ALL,
+  LEGEND_OTHER,
   LegendKey,
+  orderContinuousPointsByBin,
 } from "./plotUtils";
 import usePlotResizer from "./usePlotResizer";
 import type ExtendedPlotType from "../../../ExtendedPlotType";
@@ -33,7 +35,17 @@ interface Props {
   annotationTextKey?: string;
   height: number | "auto";
   colorMap: Map<LegendKey, string>;
+  // colorData: per-point color key. Drives bgcolor on scatter traces and
+  // (in the converged case where modes match) violin fillcolor.
   colorData?: any;
+  // groupData: per-point group key. Drives violin-track assignment. When
+  // not supplied, falls back to colorData for backward compatibility with
+  // existing callers and the converged case.
+  groupData?: any;
+  // groupKeys: track display order. When not supplied, derived from
+  // [...colorMap.keys()] (which is the legend order under the old
+  // single-array convention).
+  groupKeys?: LegendKey[];
   continuousColorKey?: string;
   legendDisplayNames: Partial<Record<LegendKey, string>>;
   legendTitle?: string | null;
@@ -52,6 +64,11 @@ interface Props {
   palette?: DataExplorerColorPalette;
   xAxisFontSize?: number;
   yAxisFontSize?: number;
+  // When true, group tracks whose points are entirely null are kept as
+  // labeled "(no data)" placeholders instead of being dropped. Used by
+  // expanded plots so a paginated transcript window renders at full size even
+  // when the dataset doesn't measure every transcript in the window.
+  placeholderEmptyTracks?: boolean;
 }
 
 const calcPlotHeight = (plot: HTMLDivElement) => {
@@ -143,6 +160,8 @@ function PrototypeDensity1D({
   xKey,
   colorMap,
   colorData,
+  groupData,
+  groupKeys: groupKeysProp,
   continuousColorKey,
   legendDisplayNames,
   legendTitle,
@@ -163,6 +182,7 @@ function PrototypeDensity1D({
   palette = DEFAULT_PALETTE,
   xAxisFontSize = 14,
   yAxisFontSize = 14,
+  placeholderEmptyTracks = false,
   Plotly,
 }: any) {
   const ref = useRef<ExtendedPlotType>(null);
@@ -226,13 +246,43 @@ function PrototypeDensity1D({
   useEffect(() => {
     const plot = ref.current as ExtendedPlotType;
     const colorKeys = [...colorMap.keys()];
+    // Group side (drives track assignment). Falls back to color side when
+    // not supplied, preserving existing behavior for callers that don't
+    // distinguish group from color.
+    const effectiveGroupData = groupData ?? colorData;
+    // Annotate explicitly: the component params are typed `any` (see the
+    // `}: any)` signature), so groupKeysProp/colorKeys arrive as `any` and the
+    // downstream .map/.filter callbacks would otherwise be implicitly-any.
+    // Pinning the element type here types the whole violin-trace chain.
+    const effectiveGroupKeys: LegendKey[] = groupKeysProp ?? colorKeys;
     const x = data[xKey] as number[];
-    const y = calcY(x, colorKeys, colorData, hiddenLegendValues);
+    const y = calcY(
+      x,
+      effectiveGroupKeys,
+      effectiveGroupData,
+      hiddenLegendValues
+    );
     const text = hoverTextKey ? data[hoverTextKey] : null;
     const annotationText = annotationTextKey ? data[annotationTextKey] : null;
     const visible = pointVisibility ?? x.map(() => true);
 
     const contColorData = data[continuousColorKey];
+
+    // Continuous color: order points so the smallest-population bins draw last
+    // (on top) and null points on the bottom, matching PrototypeScatterPlot.
+    // The reorder lives inside the single continuous trace, so contTraceIndex
+    // maps a clicked/selected position back to the original point index. For
+    // continuous color, colorData is already the per-point bin-key series.
+    const contTraceIndex =
+      contColorData && colorData
+        ? orderContinuousPointsByBin(
+            contColorData,
+            colorData,
+            colorMap,
+            visible
+          )
+        : [];
+
     const hasColorOptionsEnabled = colorKeys[0] !== LEGEND_ALL;
 
     const isSelectionMode =
@@ -292,9 +342,36 @@ function PrototypeDensity1D({
 
     const defaultTrace = hasColorOptionsEnabled ? null : templateTrace;
 
+    // Paint order for categorical color groups. We stack so the smallest
+    // groups end up on top and the catch-all "Other" group on the bottom,
+    // matching the scatter path (getSolidColorGroups). plotlyData is reversed
+    // below, so the first key here is drawn last (on top): we sort ascending
+    // by visible-point count and pin LEGEND_OTHER to the end. Membership and
+    // color assignment are unchanged — this only reorders the traces, which
+    // matters once color groups span multiple stacks (group_by !== color_by).
+    const orderedColorKeys = (() => {
+      if (!colorMap || !colorData) {
+        return [] as LegendKey[];
+      }
+      const counts = new Map<LegendKey, number>();
+      for (let i = 0; i < colorData.length; i += 1) {
+        if (visible[i] === false) {
+          continue;
+        }
+        const k = colorData[i] as LegendKey;
+        counts.set(k, (counts.get(k) ?? 0) + 1);
+      }
+      const keys = [...colorMap.keys()];
+      const others = keys.filter((key) => key === LEGEND_OTHER);
+      const rest = keys
+        .filter((key) => key !== LEGEND_OTHER)
+        .sort((a, b) => (counts.get(a) ?? 0) - (counts.get(b) ?? 0));
+      return [...rest, ...others];
+    })();
+
     const colorTraces =
       colorMap && colorData && !contColorData
-        ? [...colorMap.keys()].map((key) =>
+        ? orderedColorKeys.map((key) =>
             makeColorTrace(
               colorMap.get(key)!,
               (i) => colorMap.get(key) === colorMap.get(colorData[i])
@@ -306,13 +383,27 @@ function PrototypeDensity1D({
     const continuousColorTrace = contColorData
       ? {
           ...templateTrace,
+          x: contTraceIndex.map((i) => (visible[i] ? x[i] : null)),
+          y: contTraceIndex.map((i) => y[i]),
+          text: text ? contTraceIndex.map((i) => text[i]) : text,
+          // selectedpoints are indices into the (reordered) trace, so map each
+          // selected original index to its position in contTraceIndex.
+          selectedpoints: contTraceIndex.reduce(
+            (acc: number[], origIndex, i) => {
+              if (selectedPoints?.has(origIndex)) {
+                acc.push(i);
+              }
+              return acc;
+            },
+            []
+          ),
           hoverlabel: {
-            bgcolor: colorData.map((key: LegendKey) => colorMap.get(key)),
+            bgcolor: contTraceIndex.map((i) => colorMap.get(colorData[i])),
           },
           marker: {
             size: pointSize,
-            color: contColorData.map(
-              (c: number | null) => c ?? hexToRgba(palette.other, pointOpacity)
+            color: contTraceIndex.map(
+              (i) => contColorData[i] ?? hexToRgba(palette.other, pointOpacity)
             ),
             colorscale: palette.sequentialScale.map(
               ([value, color]: [string, string]) => [
@@ -322,8 +413,8 @@ function PrototypeDensity1D({
             ),
             line: {
               width: outlineWidth,
-              color: contColorData.map(
-                (c: number | null) => c ?? palette.other
+              color: contTraceIndex.map(
+                (i) => contColorData[i] ?? palette.other
               ),
               colorscale: palette.sequentialScale,
             },
@@ -361,10 +452,15 @@ function PrototypeDensity1D({
       showlegend: false,
     } as Partial<ViolinData>;
 
-    const violinTraces = colorKeys
+    const violinTraces = effectiveGroupKeys
       .filter((key) => !hiddenLegendValues.has(key))
       .map((legendKey, index) => {
-        let fillcolor = colorMap.get(legendKey);
+        // In the converged case (group_by === color_by, default) the
+        // group key IS a color key and lives in colorMap. In the divergent
+        // case (group_by ≠ color_by) the group key may not be in colorMap;
+        // fall back to a neutral fill so the violin is still drawn but
+        // doesn't fight with the per-point colors that carry the legend.
+        let fillcolor = colorMap.get(legendKey) ?? palette.other;
 
         if (useSemiOpaqueViolins) {
           fillcolor += "88";
@@ -372,19 +468,45 @@ function PrototypeDensity1D({
 
         return {
           ...templateViolin,
-          name: legendDisplayNames[legendKey],
-          x: colorData
-            ? x.filter((_: any, i: number) => colorData[i] === legendKey)
+          // The "all" bucket is the ungrouped sentinel (a single track holding
+          // every point); it carries no meaningful group label, so render it
+          // blank rather than leaking the raw Symbol(All) into the y-axis tick.
+          name:
+            legendKey === LEGEND_ALL
+              ? ""
+              : legendDisplayNames[legendKey] ?? String(legendKey),
+          x: effectiveGroupData
+            ? x.filter(
+                (_: any, i: number) => effectiveGroupData[i] === legendKey
+              )
             : x,
-          y0: colorKeys.length - hiddenLegendValues.size - index,
+          y0: effectiveGroupKeys.length - hiddenLegendValues.size - index,
           fillcolor,
         };
       })
-      .filter((trace) => !isEveryValueNull(trace.x));
+      // A track whose points are entirely null normally gets dropped (an empty
+      // violin is noise). But for expanded plots that drop is what makes a
+      // paginated window look short: a transcript the dataset doesn't measure
+      // is all-null. When `placeholderEmptyTracks` is set we instead keep it as
+      // a labeled "(no data)" slot — its y0 position is already reserved, so it
+      // just fills the gap the drop would have left. BANDAID tied to the
+      // interim pagination stopgap.
+      .map((trace) =>
+        placeholderEmptyTracks && isEveryValueNull(trace.x)
+          ? {
+              ...trace,
+              // Prepend, not append: the y-axis ticktext truncates each name to
+              // ~25 chars and a transcript label alone already exceeds that, so
+              // an appended marker gets cut off. Leading "(no data)" survives.
+              name: trace.name ? `(no data) ${trace.name}` : "(no data)",
+            }
+          : trace
+      )
+      .filter((trace) => placeholderEmptyTracks || !isEveryValueNull(trace.x));
 
     // Add an extra violin with a light outline to make
     // it stand out on top many dark-colored points.
-    const violinOutlineTraces = colorKeys
+    const violinOutlineTraces = effectiveGroupKeys
       .filter((key) => !hiddenLegendValues.has(key))
       .map((legendKey, index) => {
         return {
@@ -392,10 +514,12 @@ function PrototypeDensity1D({
           line: { color: hexToRgba("#fff", 0.5), width: 4 },
           meanline: { visible: false },
           fillcolor: "transparent",
-          x: colorData
-            ? x.filter((_: any, i: number) => colorData[i] === legendKey)
+          x: effectiveGroupData
+            ? x.filter(
+                (_: any, i: number) => effectiveGroupData[i] === legendKey
+              )
             : x,
-          y0: colorKeys.length - hiddenLegendValues.size - index,
+          y0: effectiveGroupKeys.length - hiddenLegendValues.size - index,
         } as any;
       });
 
@@ -418,6 +542,12 @@ function PrototypeDensity1D({
         ...colorTraces,
       ] as Partial<PlotData>[]).includes(plotlyData[n]);
     };
+
+    // The continuous trace is the only one whose points are reordered, so its
+    // plotly pointIndex must be mapped back through contTraceIndex.
+    const isContinuousCurve = (n: number) =>
+      continuousColorTrace !== null &&
+      (plotlyData[n] as any) === continuousColorTrace;
 
     const collapseLeftMargin = violinTraces.length === 1;
 
@@ -455,8 +585,8 @@ function PrototypeDensity1D({
         ...(axes.current.yaxis || { autorange: true }),
 
         visible:
-          Boolean(colorData) &&
-          colorData.length > 0 &&
+          Boolean(effectiveGroupData) &&
+          effectiveGroupData.length > 0 &&
           violinTraces.length < 40,
         automargin: true,
         tickvals: violinTraces.map((vt) => vt.y0),
@@ -611,7 +741,12 @@ function PrototypeDensity1D({
         e.event.ctrlKey || e.event.metaKey || e.event.shiftKey;
 
       if (isClickableTrace(curveNumber) && onClickPoint) {
-        onClickPoint(pointIndex, anyModifier);
+        onClickPoint(
+          isContinuousCurve(curveNumber)
+            ? contTraceIndex[pointIndex]
+            : pointIndex,
+          anyModifier
+        );
       }
 
       // WORKAROUND: If you mean to double-click to zoom out and
@@ -638,7 +773,11 @@ function PrototypeDensity1D({
           .filter(
             (p) => p.data.hoverinfo !== "skip" && p.data.hoverinfo !== "none"
           )
-          .map((p) => p.pointIndex) || [];
+          .map((p) =>
+            isContinuousCurve(p.curveNumber)
+              ? contTraceIndex[p.pointIndex]
+              : p.pointIndex
+          ) || [];
 
       assignAnnotationPositions(points);
       onMultiselect(points);
@@ -751,6 +890,8 @@ function PrototypeDensity1D({
     xKey,
     colorMap,
     colorData,
+    groupData,
+    groupKeysProp,
     continuousColorKey,
     legendDisplayNames,
     legendTitle,
@@ -771,6 +912,7 @@ function PrototypeDensity1D({
     palette,
     xAxisFontSize,
     yAxisFontSize,
+    placeholderEmptyTracks,
     Plotly,
   ]);
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/PrototypeScatterPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/PrototypeScatterPlot.tsx
@@ -25,6 +25,7 @@ import {
   getRange,
   hexToRgba,
   LegendKey,
+  orderContinuousPointsByBin,
   RegressionLine,
 } from "./plotUtils";
 import usePlotResizer from "./usePlotResizer";
@@ -310,10 +311,6 @@ function PrototypeScatterPlot({
     const contColorData: (number | null)[] = continuousColorKey
       ? data[continuousColorKey]
       : null;
-    const contColorValueCounts = categoricalDataToValueCounts(
-      contLegendKeys,
-      x.map(() => true)
-    );
     const hasColorOptionsEnabled = Boolean(
       color1 || color2 || catColorData || contColorData
     );
@@ -461,45 +458,25 @@ function PrototypeScatterPlot({
       const sortedAnnotationText: string[] = [];
       const remappedSelectedPoints: number[] = [];
 
-      const sortedBins = [...colorMap.keys()]
-        .sort(byValueCountOf(contColorValueCounts))
-        .reverse();
+      const order = orderContinuousPointsByBin(
+        contColorData,
+        contLegendKeys,
+        colorMap,
+        visible
+      );
 
-      contColorData
-        .map((value, origIndex) => ({
-          value,
-          origIndex,
-        }))
-        .sort((a, b) => {
-          const binIndexA = sortedBins.indexOf(contLegendKeys[a.origIndex]);
-          const binIndexB = sortedBins.indexOf(contLegendKeys[b.origIndex]);
-
-          if (binIndexA < binIndexB) {
-            return -1;
-          }
-
-          if (binIndexA > binIndexB) {
-            return 1;
-          }
-
-          if (a.value === b.value || a.value == null || b.value == null) {
-            return 0;
-          }
-
-          return a.value < b.value ? -1 : 1;
-        })
-        .forEach(({ origIndex }, i: number) => {
-          contTraceIndex.push(origIndex);
-          sortedX.push(templateTrace.x[origIndex]);
-          sortedY.push(templateTrace.y[origIndex]);
-          sortedColor.push(contColorData[origIndex]);
-          hoverColor.push(colorMap.get(contLegendKeys[origIndex])!);
-          sortedText.push(text[origIndex]);
-          sortedAnnotationText.push(annotationText[origIndex]);
-          if (selectedPoints?.has(origIndex)) {
-            remappedSelectedPoints.push(i);
-          }
-        });
+      order.forEach((origIndex, i) => {
+        contTraceIndex.push(origIndex);
+        sortedX.push(templateTrace.x[origIndex]);
+        sortedY.push(templateTrace.y[origIndex]);
+        sortedColor.push(contColorData[origIndex]);
+        hoverColor.push(colorMap.get(contLegendKeys[origIndex])!);
+        sortedText.push(text[origIndex]);
+        sortedAnnotationText.push(annotationText[origIndex]);
+        if (selectedPoints?.has(origIndex)) {
+          remappedSelectedPoints.push(i);
+        }
+      });
 
       continuousColorTrace = {
         ...templateTrace,

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/SmallMultiplesScatter.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/SmallMultiplesScatter.tsx
@@ -1,0 +1,847 @@
+/* eslint-disable react/require-default-props */
+// SmallMultiplesScatter
+//
+// The faceted ("small multiples") rendering of the scatter plot — the 2D
+// realization of group_by, sibling to PrototypeScatterPlot. Built as a single
+// plotly figure with a grid of subplots: one panel per facet, ranges shared
+// across panels via axis `matches`.
+//
+// It takes the SAME props as PrototypeScatterPlot (the `formattedData` lookup
+// plus key names, colorMap, palette, handlers) and adds `facetKeys`
+// (per-point facet identity — e.g. findCategoricalSlice(data,"expansion").
+// values) and `facetOrder`. So the eventual wrapper dispatch is the existing
+// prop block plus those two.
+//
+// Point encoding mirrors PrototypeScatterPlot: every trace carries the
+// full-length arrays with non-member points nulled, and `selectedpoints` uses
+// global indices. That keeps selection faceting-agnostic and makes
+// plotly_click / plotly_selected report global indices with no remap. Color
+// grouping comes from the shared getSolidColorGroups() seam.
+//
+// Deliberately deferred for this first cut (each a focused follow-up, flagged
+// rather than half-built):
+//   - Continuous color keeps no on-top re-sort: one colorscale trace per facet
+//     in natural order. Drops the contTraceIndex remap (and the index-mangling
+//     it caused); the cost is dense bins may overdraw sparse ones within a
+//     panel, which faceting already mitigates.
+//   - Regression lines (per-facet fit). Identity lines are now supported (see
+//     the showIdentityLine prop): per-subplot shapes injected after autorange,
+//     with a master-only autoscale hack propagated across panels via `matches`.
+//   - The imperative handle's extended methods (annotateSelected / download
+//     image). onLoad still fires with the single figure node.
+import React, { useEffect, useRef, useState } from "react";
+import type Plotly from "plotly.js";
+import type {
+  Config,
+  Layout,
+  PlotData,
+  PlotlyHTMLElement,
+  PlotMouseEvent,
+  PlotSelectionEvent,
+} from "plotly.js";
+import { usePlotlyLoader } from "../../../../../contexts/PlotlyLoaderContext";
+import {
+  calcAutoscaleShapes,
+  calcPlotIndicatorLineShapes,
+  DataExplorerColorPalette,
+  DEFAULT_PALETTE,
+  facetMaskFor,
+  getRange,
+  getSolidColorGroups,
+  hexToRgba,
+  LegendKey,
+  orderContinuousPointsByBin,
+  RegressionLine,
+} from "./plotUtils";
+import usePlotResizer from "./usePlotResizer";
+import type ExtendedPlotType from "../../../ExtendedPlotType";
+import styles from "../../../styles/ScatterPlot.scss";
+
+type Data = Record<string, any>;
+
+interface Props {
+  data: Data;
+  xKey: string;
+  yKey: string;
+  xLabel: string;
+  yLabel: string;
+  // Per-point facet identity, length matches data[xKey]. For the expansion
+  // case this is the per-point expansion label.
+  facetKeys: string[];
+  // Explicit facet identity/order; defaults to first-seen order of facetKeys.
+  facetOrder?: string[];
+  height: number | "auto";
+  hoverTextKey?: string;
+  annotationTextKey?: string;
+  colorKey1?: string;
+  colorKey2?: string;
+  categoricalColorKey?: string;
+  continuousColorKey?: string;
+  // Per-point bin-key series for continuous color (LEGEND_RANGE_*), parallel to
+  // the continuous values. Supplied by the caller (e.g. useScatterPlotData) so
+  // continuous points can stack by bin like PrototypeScatterPlot.
+  contLegendKeys?: LegendKey[] | null;
+  colorMap: Map<LegendKey, string>;
+  selectedPoints?: Set<number>;
+  pointVisibility?: boolean[];
+  onClickPoint?: (pointIndex: number, anyModifier: boolean) => void;
+  onMultiselect?: (pointIndices: number[]) => void;
+  onClickResetSelection?: () => void;
+  onLoad?: (plot: ExtendedPlotType) => void;
+  pointSize?: number;
+  pointOpacity?: number;
+  outlineWidth?: number;
+  palette?: DataExplorerColorPalette;
+  xAxisFontSize?: number;
+  yAxisFontSize?: number;
+  // Per-point selection annotations are off by default for faceted plots:
+  // tiled across small panels they clutter fast, and the panel title plus
+  // the selection panel already carry identity. Set > 0 to re-enable a cap.
+  maxAnnotations?: number;
+  // Draw the x = y identity line in every panel. Off by default (current
+  // faceted behavior). When on, a master-only autoscale hack equalizes the x/y
+  // scale and propagates to all panels via `matches`, so the line reads ~45°
+  // everywhere; the line itself is injected per subplot after autorange.
+  showIdentityLine?: boolean;
+  // Per-facet regression lines keyed by facet label (from useScatterPlotData).
+  // Each panel draws its own; a facet with no entry draws none.
+  regressionLinesByFacet?: Map<string, RegressionLine> | null;
+  // When true, a facet with no plottable point is kept as an empty panel
+  // labeled "(no data)" rather than dropped. Used by expanded plots so a
+  // paginated transcript window keeps its full set of panels even when the
+  // dataset doesn't measure every transcript.
+  placeholderEmptyFacets?: boolean;
+}
+
+type PlotlyType = typeof Plotly;
+type PropsWithPlotly = Props & { Plotly: PlotlyType };
+
+const GAP_X = 0.06;
+const GAP_Y = 0.1;
+
+function SmallMultiplesScatter({
+  data,
+  xKey,
+  yKey,
+  xLabel,
+  yLabel,
+  facetKeys,
+  facetOrder,
+  height,
+  hoverTextKey,
+  annotationTextKey,
+  colorKey1,
+  colorKey2,
+  categoricalColorKey,
+  continuousColorKey,
+  contLegendKeys,
+  colorMap,
+  selectedPoints,
+  pointVisibility,
+  onClickPoint = () => {},
+  onMultiselect = () => {},
+  onClickResetSelection = () => {},
+  onLoad = () => {},
+  pointSize = 7,
+  pointOpacity = 1,
+  outlineWidth = 0.5,
+  palette = DEFAULT_PALETTE,
+  xAxisFontSize = 12,
+  yAxisFontSize = 12,
+  maxAnnotations = 0,
+  showIdentityLine = false,
+  regressionLinesByFacet,
+  placeholderEmptyFacets = false,
+  Plotly,
+}: PropsWithPlotly) {
+  const ref = useRef<(HTMLDivElement & ExtendedPlotType) | null>(null);
+  usePlotResizer(Plotly, ref);
+
+  // Dragmode is React state, not just plotly's internal layout, so every
+  // Plotly.react re-applies the *current* mode. The hidden modebar means
+  // setDragmode (below) is the only way it changes; driving it imperatively
+  // would get clobbered the next time the effect re-reacts (e.g. after a
+  // click updates the selection), flipping the mode back and desyncing the
+  // custom toolbar. Matches PrototypeScatterPlot.
+  const [dragmode, setDragmode] = useState<Layout["dragmode"]>("zoom");
+
+  // Master axis ranges, preserved across re-reacts so that changing dragmode
+  // (or selecting) doesn't snap the zoom back to full extent. Every non-
+  // master axis uses `matches`, so only the master ("xaxis"/"yaxis") pair
+  // carries a range and the rest follow it. Mirrors PrototypeScatterPlot.
+  const axes = useRef<{
+    xaxis?: { range?: number[]; autorange: boolean };
+    yaxis?: { range?: number[]; autorange: boolean };
+  }>({});
+  // Identity of the data currently on the axes. When it changes (a new x/y
+  // dataset), the preserved zoom is dropped so the plot re-autoranges.
+  const lastDataset = useRef<string | null>(null);
+
+  useEffect(() => {
+    // Capture the node now; ref.current may have changed by the time this
+    // cleanup runs (react-hooks/exhaustive-deps).
+    const node = ref.current;
+    return () => {
+      if (node) {
+        Plotly.purge(node as HTMLElement);
+      }
+    };
+  }, [Plotly]);
+
+  useEffect(() => {
+    const plot = ref.current;
+    if (!plot) {
+      return undefined;
+    }
+
+    // Reset the preserved zoom when an axis's dataset changes. The axis label
+    // is the signal: coloring, grouping, selection, and dragmode don't change
+    // it (so those keep the current zoom), but swapping the x/y dataset does.
+    const datasetKey = `${xLabel}\u0000${yLabel}`;
+    if (lastDataset.current !== datasetKey) {
+      axes.current = {};
+      lastDataset.current = datasetKey;
+    }
+
+    const x = data[xKey] as (number | null)[];
+    const y = data[yKey] as (number | null)[];
+    const text = hoverTextKey
+      ? (data[hoverTextKey] as string[])
+      : x.map(() => "");
+    const annotationText = annotationTextKey
+      ? (data[annotationTextKey] as string[])
+      : x.map((_, i) => `${x[i]?.toFixed(2)}, ${y[i]?.toFixed(2)}`);
+    const visible = pointVisibility ?? x.map(() => true);
+
+    const color1 = colorKey1 ? (data[colorKey1] as (boolean | null)[]) : null;
+    const color2 = colorKey2 ? (data[colorKey2] as (boolean | null)[]) : null;
+    const catColorData = categoricalColorKey
+      ? (data[categoricalColorKey] as (string | number | null)[])
+      : null;
+    const contColorData = continuousColorKey
+      ? (data[continuousColorKey] as (number | null)[])
+      : null;
+
+    const selected = selectedPoints ?? new Set<number>();
+    const selectedpoints = [...selected];
+
+    // Candidate facets, then drop any with no plottable point at all (every
+    // point null on an axis). This is the legend's non-plottable-entity rule
+    // applied to facet selection: a facet that can never render shouldn't
+    // hold a slot. Deliberately ignores visibility — a facet hidden only by a
+    // legend toggle still has plottable data, so it's kept (and renders empty
+    // for now; the toggled-off placeholder is handled separately).
+    const candidateFacets = facetOrder ?? Array.from(new Set(facetKeys));
+    const plottableFacets = new Set<string>();
+    const visibleFacets = new Set<string>();
+    for (let i = 0; i < x.length; i += 1) {
+      if (x[i] !== null && y[i] !== null) {
+        plottableFacets.add(facetKeys[i]);
+        if (visible[i]) {
+          visibleFacets.add(facetKeys[i]);
+        }
+      }
+    }
+    const facets = placeholderEmptyFacets
+      ? candidateFacets
+      : candidateFacets.filter((f) => plottableFacets.has(f));
+    const F = facets.length;
+    const cols = Math.max(1, Math.ceil(Math.sqrt(F)));
+    const rows = Math.max(1, Math.ceil(F / cols));
+
+    // Shared extents across all points (mirrors PrototypeScatterPlot). Every
+    // panel shares one range via `matches`, so the identity line and the
+    // autoscale hack are computed once from these.
+    const [minX, maxX] = getRange(x as number[]);
+    const [minY, maxY] = getRange(y as number[]);
+    const rangeX = maxX - minX;
+    const rangeY = maxY - minY;
+    const ratio = Math.min(rangeX, rangeY) / Math.max(rangeX, rangeY);
+    const extents = { minX, maxX, minY, maxY, rangeX, rangeY, ratio };
+
+    const resolvedHeight =
+      typeof height === "number"
+        ? height
+        : plot.clientHeight || plot.parentElement?.clientHeight || 600;
+
+    const layout: Record<string, any> = {
+      height: resolvedHeight,
+      margin: { t: 28, r: 16, b: 60, l: 68 },
+      showlegend: false,
+      hovermode: "closest",
+      dragmode,
+      annotations: [] as any[],
+      // Master-only autoscale hack: equalizes x/y scale so the identity line is
+      // ~45°, propagating to matched panels. Returns [] when showIdentityLine is
+      // off, so default behavior is unchanged. The visible indicator shapes are
+      // injected post-autorange (see plotly_afterplot).
+      shapes: calcAutoscaleShapes(showIdentityLine, extents),
+    };
+
+    const plotlyData: Partial<PlotData>[] = [];
+
+    // Color grouping is facet-independent, so resolve it once. Continuous color
+    // is handled separately (see below), so skip the seam in that case.
+    const solidGroups = contColorData
+      ? null
+      : getSolidColorGroups({
+          color1,
+          color2,
+          catColorData,
+          colorMap,
+          palette,
+          visible,
+        });
+
+    // The mask shared by every trace: a point is plottable in facet `facet`
+    // only if it's visible, in that facet, and has values on both axes.
+    const maskFor = (facet: string, member: (i: number) => boolean) => {
+      const inFacet = facetMaskFor(facetKeys, facet, x, y, visible);
+      return (i: number) => (inFacet(i) ? member(i) : false);
+    };
+
+    // Maps a continuous trace's curveNumber to its bin-stacked draw order, so
+    // click/select can map a reordered pointIndex back to the original index.
+    // Only continuous traces are reordered; every other trace stays in natural
+    // (global-index) order, so they're simply absent from this map.
+    const contOrderByCurve = new Map<number, number[]>();
+
+    facets.forEach((facet, k) => {
+      const col = k % cols;
+      const row = Math.floor(k / cols);
+
+      const xDomain: [number, number] = [
+        col / cols + (col === 0 ? 0 : GAP_X / 2),
+        (col + 1) / cols - (col === cols - 1 ? 0 : GAP_X / 2),
+      ];
+      const yTop = 1 - row / rows;
+      const yBot = 1 - (row + 1) / rows;
+      const yDomain: [number, number] = [yBot + GAP_Y / 2, yTop - GAP_Y / 2];
+
+      const suffix = k === 0 ? "" : String(k + 1);
+      const xRef = `x${suffix}`;
+      const yRef = `y${suffix}`;
+
+      // A selection lives in exactly one facet, so only that panel should dim
+      // its unselected points; the others stay at full opacity.
+      const facetHasSelection = selectedpoints.some(
+        (i) => facetKeys[i] === facet
+      );
+
+      // A facet kept by the plottable check above but with no currently
+      // visible point is hidden by a legend toggle (e.g. coloring AND
+      // grouping by expansion, then toggling a transcript off). Keep its
+      // slot so the grid stays stable, but mark it so the empty frame reads
+      // as intentional rather than a rendering bug. (A facet with no
+      // plottable data at all was already dropped, so this is toggle-only.)
+      const facetNoData = !plottableFacets.has(facet);
+      const facetHidden = !facetNoData && !visibleFacets.has(facet);
+
+      layout[`xaxis${suffix}`] = {
+        domain: xDomain,
+        anchor: yRef,
+        matches: k === 0 ? undefined : "x",
+        tickfont: { size: Math.max(8, xAxisFontSize - 3) },
+        exponentformat: "e",
+        zeroline: false,
+        // Only the master carries a range; matched axes follow it.
+        ...(k === 0 ? axes.current.xaxis ?? { autorange: true } : {}),
+      };
+      layout[`yaxis${suffix}`] = {
+        domain: yDomain,
+        anchor: xRef,
+        matches: k === 0 ? undefined : "y",
+        tickfont: { size: Math.max(8, yAxisFontSize - 3) },
+        exponentformat: "e",
+        zeroline: false,
+        ...(k === 0 ? axes.current.yaxis ?? { autorange: true } : {}),
+      };
+
+      // Bottom of the stack: the selection-outline trace (a larger, dark-ringed
+      // transparent marker that peeks out from behind selected points).
+      const outlineMask = maskFor(facet, () => true);
+      plotlyData.push({
+        type: "scattergl",
+        mode: "markers",
+        xaxis: xRef,
+        yaxis: yRef,
+        x: x.map((v, i) => (outlineMask(i) ? v : null)),
+        y: y.map((v, i) => (outlineMask(i) ? v : null)),
+        name: "",
+        hoverinfo: "skip",
+        showlegend: false,
+        selectedpoints,
+        marker: {
+          color: "transparent",
+          size: pointSize + outlineWidth * 2,
+          line: { color: "#000", width: Math.max(outlineWidth, 2) },
+        },
+        selected: { marker: { opacity: 1 } },
+        unselected: { marker: { opacity: 0 } },
+      } as Partial<PlotData>);
+
+      const pushSolid = (color: string, member: (i: number) => boolean) => {
+        const mask = maskFor(facet, member);
+        plotlyData.push({
+          type: "scattergl",
+          mode: "markers",
+          xaxis: xRef,
+          yaxis: yRef,
+          x: x.map((v, i) => (mask(i) ? v : null)),
+          y: y.map((v, i) => (mask(i) ? v : null)),
+          text,
+          name: "",
+          hoverinfo: "x+y+text",
+          hoverlabel: { bgcolor: color },
+          showlegend: false,
+          selectedpoints,
+          marker: {
+            color: hexToRgba(color, pointOpacity),
+            size: pointSize,
+            line: { color, width: outlineWidth },
+          },
+          selected: { marker: { opacity: 1 } },
+          unselected: { marker: { opacity: facetHasSelection ? 0.5 : 1 } },
+        } as Partial<PlotData>);
+      };
+
+      if (contColorData) {
+        // Continuous: the "other" (null-valued) points first (bottom), then one
+        // colorscale trace whose points are ordered so this facet's
+        // smallest-population bins draw last (on top), matching
+        // PrototypeScatterPlot. The order is computed from this facet's visible
+        // points (outlineMask) so each panel stacks by its own populations.
+        // Because the points are reordered, we record the order under the
+        // trace's curveNumber so click/select can map back to original indices.
+        pushSolid(palette.other, (i) => contColorData[i] === null);
+
+        const contMask = maskFor(facet, (i) => contColorData[i] !== null);
+        // Count basis must match PrototypeScatterPlot, which counts plain
+        // `visible` with no plottability check. facetMaskFor (via outlineMask)
+        // also requires x/y non-null, which would drop visible-but-unplottable
+        // points from the per-facet bin counts and can flip the stacking order
+        // wherever two bins have near-equal populations.
+        const facetVisible = x.map(
+          (_, i) => visible[i] && facetKeys[i] === facet
+        );
+        const order =
+          contLegendKeys && colorMap
+            ? orderContinuousPointsByBin(
+                contColorData,
+                contLegendKeys,
+                colorMap,
+                facetVisible
+              )
+            : x.map((_, i) => i);
+
+        contOrderByCurve.set(plotlyData.length, order);
+        plotlyData.push({
+          type: "scattergl",
+          mode: "markers",
+          xaxis: xRef,
+          yaxis: yRef,
+          x: order.map((i) => (contMask(i) ? x[i] : null)),
+          y: order.map((i) => (contMask(i) ? y[i] : null)),
+          text: text ? order.map((i) => text[i]) : text,
+          name: "",
+          hoverinfo: "x+y+text",
+          showlegend: false,
+          selectedpoints: order.reduce((acc: number[], origIndex, i) => {
+            if (selected.has(origIndex)) {
+              acc.push(i);
+            }
+            return acc;
+          }, []),
+          // Per-point hover background keyed to each point's bin color (in the
+          // reordered draw order), matching PrototypeScatterPlot. Without this
+          // the continuous trace's hover box falls back to Plotly's default
+          // black; only the separate "other" trace (via pushSolid) was colored.
+          hoverlabel: {
+            bgcolor: order.map(
+              (i) =>
+                (contLegendKeys
+                  ? colorMap.get(contLegendKeys[i])
+                  : undefined) ?? palette.other
+            ) as any,
+          },
+          marker: {
+            size: pointSize,
+            color: order.map((i) => contColorData[i] ?? "transparent"),
+            colorscale: palette.sequentialScale.map(([value, color]) => [
+              value,
+              hexToRgba(color as string, pointOpacity),
+            ]),
+            line: {
+              width: outlineWidth,
+              color: order.map((i) => contColorData[i] ?? "transparent"),
+              colorscale: palette.sequentialScale,
+            },
+          },
+          selected: { marker: { opacity: 1 } },
+          unselected: { marker: { opacity: facetHasSelection ? 0.5 : 1 } },
+        } as Partial<PlotData>);
+      } else {
+        // Solid color groups (none / categorical / comparison), in paint order.
+        (solidGroups ?? []).forEach((group) =>
+          pushSolid(group.color, group.includes)
+        );
+      }
+
+      // Facet title (paper-positioned, centered above the panel).
+      (layout.annotations as any[]).push({
+        text: facet,
+        x: (xDomain[0] + xDomain[1]) / 2,
+        y: yTop - GAP_Y / 2 + 0.012,
+        xref: "paper",
+        yref: "paper",
+        xanchor: "center",
+        yanchor: "bottom",
+        showarrow: false,
+        font: {
+          size: 11,
+          color: facetHidden || facetNoData ? "#999" : undefined,
+        },
+      });
+
+      // No data for this facet in the chosen dataset: an inert "(no data)"
+      // placeholder over the empty panel, so the page keeps its full set of
+      // panels and the gap is explained rather than silently missing.
+      if (facetNoData) {
+        (layout.annotations as any[]).push({
+          text: "(no data)",
+          x: (xDomain[0] + xDomain[1]) / 2,
+          y: (yDomain[0] + yDomain[1]) / 2,
+          xref: "paper",
+          yref: "paper",
+          xanchor: "center",
+          yanchor: "middle",
+          showarrow: false,
+          font: { size: 12, color: "#999" },
+        });
+      }
+
+      // Toggled-off facet: an inert placeholder over the (empty) panel.
+      if (facetHidden) {
+        (layout.annotations as any[]).push({
+          text: "(hidden)",
+          x: (xDomain[0] + xDomain[1]) / 2,
+          y: (yDomain[0] + yDomain[1]) / 2,
+          xref: "paper",
+          yref: "paper",
+          xanchor: "center",
+          yanchor: "middle",
+          showarrow: false,
+          font: { size: 12, color: "#999" },
+        });
+      }
+    });
+
+    // Selected-point annotations, placed on their own facet's axes. Above the
+    // per-facet cap we fall back to a single count, mirroring the single-panel
+    // plot.
+    // One shared title per axis, centered along the grid's bottom and left
+    // edges, instead of repeating a title on every bottom/left subplot. The
+    // shifts push each into its margin; tune with the margins above.
+    (layout.annotations as any[]).push(
+      {
+        text: xLabel,
+        x: 0.5,
+        y: 0,
+        xref: "paper",
+        yref: "paper",
+        yshift: -44,
+        xanchor: "center",
+        yanchor: "bottom",
+        showarrow: false,
+        font: { size: xAxisFontSize },
+      },
+      {
+        text: yLabel,
+        x: 0,
+        y: 0.5,
+        xref: "paper",
+        yref: "paper",
+        xshift: -54,
+        xanchor: "center",
+        yanchor: "middle",
+        textangle: -90,
+        showarrow: false,
+        font: { size: yAxisFontSize },
+      }
+    );
+
+    const facetIndex = new Map(facets.map((f, i) => [f, i]));
+    if (
+      maxAnnotations > 0 &&
+      selected.size > 0 &&
+      selected.size <= maxAnnotations
+    ) {
+      [...selected].forEach((pointIndex) => {
+        if (
+          typeof x[pointIndex] !== "number" ||
+          typeof y[pointIndex] !== "number"
+        ) {
+          return;
+        }
+        const k = facetIndex.get(facetKeys[pointIndex]);
+        if (k === undefined) {
+          return;
+        }
+        const suffix = k === 0 ? "" : String(k + 1);
+        (layout.annotations as any[]).push({
+          x: x[pointIndex],
+          y: y[pointIndex],
+          text: annotationText[pointIndex],
+          visible: visible[pointIndex],
+          xref: `x${suffix}`,
+          yref: `y${suffix}`,
+          arrowhead: 0,
+          standoff: 4,
+          arrowcolor: "#888",
+          bordercolor: "#c7c7c7",
+          bgcolor: "#fff",
+        });
+      });
+    } else if (maxAnnotations > 0 && selected.size > maxAnnotations) {
+      (layout.annotations as any[]).push({
+        text: `(${selected.size} selected points)`,
+        xref: "paper",
+        yref: "paper",
+        x: 1,
+        y: 1,
+        showarrow: false,
+        bordercolor: "#c7c7c7",
+        bgcolor: "#fff",
+      });
+    }
+
+    const config: Partial<Config> = {
+      responsive: true,
+      displaylogo: false,
+      modeBarButtonsToRemove: ["lasso2d"],
+    };
+
+    Plotly.react(plot, plotlyData, layout as Partial<Layout>, config);
+
+    // Capture the master ranges Plotly computed on first render, so later
+    // re-reacts restore them rather than re-autoranging.
+    if (!axes.current.xaxis || !axes.current.yaxis) {
+      axes.current = {
+        xaxis: { range: (plot.layout as any).xaxis?.range, autorange: false },
+        yaxis: { range: (plot.layout as any).yaxis?.range, autorange: false },
+      };
+    }
+
+    // Convenience methods the plot controls call on the figure node (the
+    // modebar is hidden, so these are the only way to drive it). It's one
+    // figure with `matches`-shared axes, so dragmode/zoom act on the whole
+    // grid at once.
+    const getButton = (attr: string, val: string) =>
+      plot.querySelector(
+        `.modebar-btn[data-attr="${attr}"][data-val="${val}"]`
+      ) as HTMLAnchorElement | null;
+    const zoom = (val: "in" | "out" | "reset") =>
+      getButton("zoom", val)?.click();
+
+    plot.setDragmode = (nextDragmode) => {
+      const resetting =
+        dragmode !== nextDragmode &&
+        (nextDragmode === "select" || nextDragmode === "lasso");
+      if (resetting && onClickResetSelection) {
+        onClickResetSelection();
+      }
+      setDragmode(nextDragmode);
+    };
+    plot.resetZoom = () => zoom("reset");
+    plot.zoomIn = () => zoom("in");
+    plot.zoomOut = () => zoom("out");
+    plot.downloadImage = (options) => {
+      // First cut: plain figure export. Embedding the external legend (the
+      // single-panel plot's dummy-trace hack) is deferred.
+      Plotly.downloadImage(plot, options as any);
+    };
+    // Faceted: navigating-to-a-point and per-point annotations are off for
+    // now, so these are safe stubs that keep the controls from throwing.
+    plot.isPointInView = () => true;
+    plot.xValueMissing = (pointIndex: number) => x[pointIndex] === null;
+    plot.yValueMissing = (pointIndex: number) => y[pointIndex] === null;
+    plot.annotateSelected = () => {};
+    plot.removeAnnotations = () => {};
+
+    if (onLoad) {
+      onLoad(plot);
+    }
+
+    // Per-facet indicator shapes: the identity line (same in every panel) plus
+    // this panel's regression line, if one was fit (regressionLinesByFacet).
+    // The shared `extents` is identical across panels (ranges linked by
+    // `matches`); only the subplot refs and per-facet slope/intercept differ.
+    // Built here, injected after autorange settles (below).
+    const indicatorShapes: NonNullable<Layout["shapes"]> = [];
+    if (showIdentityLine || regressionLinesByFacet) {
+      for (let k = 0; k < facets.length; k += 1) {
+        const suffix = k === 0 ? "" : String(k + 1);
+        const facetLine = regressionLinesByFacet?.get(facets[k]) ?? null;
+        indicatorShapes.push(
+          ...(calcPlotIndicatorLineShapes(
+            showIdentityLine,
+            facetLine ? [facetLine] : null,
+            extents,
+            true,
+            { xref: `x${suffix}`, yref: `y${suffix}` }
+          ) ?? [])
+        );
+      }
+    }
+
+    const listeners: [string, (e: any) => void][] = [];
+    const on = (name: string, cb: (e: any) => void) => {
+      listeners.push([name, cb]);
+      plot.on(
+        name as Parameters<PlotlyHTMLElement["on"]>[0],
+        cb as Parameters<PlotlyHTMLElement["on"]>[1]
+      );
+    };
+
+    // Re-inject indicator shapes AFTER autorange has settled, so their
+    // over-length endpoints can't perturb the computed ranges. We then reset
+    // the layout's base shapes to the autoscale hack so it — not the
+    // over-length lines — feeds any later autorange.
+    //
+    // This must run on EVERY afterplot, not just the first: a later redraw
+    // (notably a window resize, which usePlotResizer services via
+    // Plotly.Plots.resize) repaints from those indicator-less base shapes and
+    // would otherwise drop the identity/regression lines. Re-asserting here
+    // puts them back; Plotly de-dupes the no-op repeats when nothing changed,
+    // so it doesn't loop. Mirrors PrototypeScatterPlot's handling.
+    on("plotly_afterplot", () => {
+      if (
+        indicatorShapes.length === 0 ||
+        (plot.layout as any).shapes === indicatorShapes
+      ) {
+        return;
+      }
+      Plotly.update(plot, {}, { shapes: indicatorShapes });
+      (plot.layout as any).shapes = calcAutoscaleShapes(
+        showIdentityLine,
+        extents
+      );
+    });
+
+    on("plotly_click", (e: PlotMouseEvent) => {
+      const pt = e.points[0];
+      if (!pt) {
+        return;
+      }
+      const native = e.event as MouseEvent;
+      const anyModifier = native.ctrlKey || native.metaKey || native.shiftKey;
+      const order = contOrderByCurve.get(pt.curveNumber as number);
+      const index = order
+        ? order[pt.pointIndex as number]
+        : (pt.pointIndex as number);
+      onClickPoint(index, anyModifier);
+    });
+
+    on("plotly_selecting", () => {
+      if (selected.size > 0) {
+        onClickResetSelection();
+      }
+    });
+
+    on("plotly_selected", (e: PlotSelectionEvent) => {
+      const points = (e?.points ?? [])
+        .filter(
+          (p) => p.data.hoverinfo !== "skip" && p.data.hoverinfo !== "none"
+        )
+        .map((p) => {
+          const order = contOrderByCurve.get(p.curveNumber as number);
+          return order
+            ? order[p.pointIndex as number]
+            : (p.pointIndex as number);
+        });
+      if (points.length > 0) {
+        onMultiselect(points);
+      }
+    });
+
+    on("plotly_deselect", () => {
+      onClickResetSelection();
+    });
+
+    on("plotly_relayout", () => {
+      axes.current = {
+        xaxis: { range: (plot.layout as any).xaxis?.range, autorange: false },
+        yaxis: { range: (plot.layout as any).yaxis?.range, autorange: false },
+      };
+    });
+
+    return () => {
+      listeners.forEach(([name, cb]) =>
+        // Plotly's HTMLElement type omits removeListener, but the graph div is
+        // an EventEmitter at runtime, so the method is present. Augment locally
+        // rather than reaching for Parameters<PlotlyHTMLElement["removeListener"]>,
+        // which can't index a property the type doesn't declare.
+        (plot as PlotlyHTMLElement & {
+          removeListener?: (
+            event: string,
+            callback: (...args: unknown[]) => void
+          ) => void;
+        }).removeListener?.(name, cb)
+      );
+    };
+  }, [
+    data,
+    xKey,
+    yKey,
+    xLabel,
+    yLabel,
+    facetKeys,
+    facetOrder,
+    height,
+    hoverTextKey,
+    annotationTextKey,
+    colorKey1,
+    colorKey2,
+    categoricalColorKey,
+    continuousColorKey,
+    contLegendKeys,
+    colorMap,
+    selectedPoints,
+    pointVisibility,
+    onClickPoint,
+    onMultiselect,
+    onClickResetSelection,
+    pointSize,
+    pointOpacity,
+    outlineWidth,
+    palette,
+    xAxisFontSize,
+    yAxisFontSize,
+    maxAnnotations,
+    showIdentityLine,
+    regressionLinesByFacet,
+    onLoad,
+    dragmode,
+    placeholderEmptyFacets,
+    Plotly,
+  ]);
+
+  return <div className={styles.ScatterPlot} ref={ref as any} />;
+}
+
+export default function LazySmallMultiplesScatter({
+  data,
+  ...otherProps
+}: Props) {
+  const PlotlyLoader = usePlotlyLoader();
+
+  return (
+    <PlotlyLoader version="module">
+      {(Plotly: PlotlyType) =>
+        data ? (
+          <SmallMultiplesScatter data={data} Plotly={Plotly} {...otherProps} />
+        ) : null
+      }
+    </PlotlyLoader>
+  );
+}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/plotUtils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/plotUtils.ts
@@ -1,11 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { Layout } from "plotly.js";
+import type { Layout, XAxisName, YAxisName } from "plotly.js";
 import {
+  ColorByValue,
+  DataExplorerExpansion,
   DataExplorerMetadata,
   DataExplorerPlotConfig,
   DataExplorerPlotResponse,
+  LinRegInfo,
   SliceQuery,
 } from "@depmap/types";
+import { linregress, pearsonr, spearmanr } from "@depmap/statistics";
 import wellKnownDatasets from "../../../../../constants/wellKnownDatasets";
 
 // HACK: Copied from the "depmap-shared" directory.
@@ -182,9 +186,162 @@ function nullifyUnplottableValues(
   return out;
 }
 
-export function findCategoricalSlice(data: DataExplorerPlotResponse | null) {
+// Returns the per-point categorical series that drives coloring (or, when
+// the caller is using it for the grouping seam, track assignment). When
+// `mode === "expansion"`, the source is `data.expansions[0]` — the per-cell
+// expansion label, e.g. one transcript label per (model, transcript) point.
+// When `mode` is anything else (or unset), the source is the same as before:
+// the categorical color dimension, falling back to color_property metadata.
+//
+// Throws when `mode === "expansion"` but the response has no expansions —
+// that's the runtime error that surfaces a config saying "use the expansion"
+// against data that doesn't have one.
+// The per-point facet-membership predicate shared by the faceted renderer
+// (which dots land in panel `facet`) and the per-facet regression fit (which
+// points the line is fit over), so the two can't drift — a line must be fit
+// over exactly the points its panel draws. Membership only: callers add their
+// own concerns (the renderer composes a color-group selector on top; the fit
+// adds finite-input hygiene).
+export function facetMaskFor(
+  facetKeys: (string | null)[],
+  facet: string,
+  x: (number | null)[],
+  y: (number | null)[],
+  visible: boolean[]
+) {
+  return (i: number) =>
+    visible[i] && facetKeys[i] === facet && x[i] !== null && y[i] !== null;
+}
+
+// Per-facet linear-regression stats (the LinRegInfo[] shape the regression
+// table consumes), grouped by group_by, computed from a materialized response.
+// The table's faceted counterpart to fetchLinearRegression's color-grouped fit
+// — same row shape, so reformatLinRegTable handles either. It lives here (not
+// in the services layer) because grouping needs findCategoricalSlice, which is
+// a component-layer concern; the table fetches `data` and calls this.
+//
+// It shares the facet-membership predicate (facetMaskFor) and the fit
+// (linregress) with the drawn per-facet lines, so the two agree on
+// slope/intercept given the same inputs. The lines fit over the hook's
+// nulled/legend-visible arrays while this fits over the raw response with
+// filter-visibility — the same lines-vs-table divergence the single-panel path
+// already has via fetchLinearRegression; grouping (the J2 requirement) matches.
+export function computeFacetedLinReg(
+  data: DataExplorerPlotResponse,
+  group_by: ColorByValue,
+  visible?: boolean[]
+): LinRegInfo[] {
+  const facetSlice = findCategoricalSlice(data, group_by);
+  const xs = data.dimensions?.x?.values;
+  const ys = data.dimensions?.y?.values;
+
+  if (!facetSlice || !xs || !ys) {
+    return [];
+  }
+
+  const facetKeys = facetSlice.values;
+  const vis = visible || xs.map(() => true);
+  const facets = [
+    ...new Set(facetKeys.filter((k): k is string => k !== null)),
+  ].sort();
+
+  return facets.map((facet) => {
+    const inFacet = facetMaskFor(facetKeys, facet, xs, ys, vis);
+    const x: number[] = [];
+    const y: number[] = [];
+
+    for (let i = 0; i < xs.length; i += 1) {
+      if (inFacet(i) && Number.isFinite(xs[i]) && Number.isFinite(ys[i])) {
+        x.push(xs[i] as number);
+        y.push(ys[i] as number);
+      }
+    }
+
+    const pearson = pearsonr(x, y);
+    const spearman = spearmanr(x, y);
+    const regression = linregress(x, y);
+
+    return {
+      group_label: facet,
+      number_of_points: x.length,
+      pearson: pearson.statistic,
+      spearman: spearman.statistic,
+      slope: regression.slope,
+      intercept: regression.intercept,
+      p_value: regression.pvalue,
+    };
+  });
+}
+
+// Single pooled fit over every visible point — the ungrouped analog of
+// computeFacetedLinReg, used by the regression table when an expanded plot
+// has no group_by. It mirrors the single pooled line the plot draws and,
+// like the faceted path, never calls fetchLinearRegression (which rejects
+// the "expansion" sentinel). group_label is null, which the table renders
+// the same way it renders the legacy ungrouped fit.
+export function computePooledLinReg(
+  data: DataExplorerPlotResponse,
+  visible?: boolean[]
+): LinRegInfo[] {
+  const xs = data.dimensions?.x?.values;
+  const ys = data.dimensions?.y?.values;
+
+  if (!xs || !ys) {
+    return [];
+  }
+
+  const vis = visible || xs.map(() => true);
+  const x: number[] = [];
+  const y: number[] = [];
+
+  for (let i = 0; i < xs.length; i += 1) {
+    if (vis[i] && Number.isFinite(xs[i]) && Number.isFinite(ys[i])) {
+      x.push(xs[i] as number);
+      y.push(ys[i] as number);
+    }
+  }
+
+  const pearson = pearsonr(x, y);
+  const spearman = spearmanr(x, y);
+  const regression = linregress(x, y);
+
+  return [
+    {
+      group_label: null,
+      number_of_points: x.length,
+      pearson: pearson.statistic,
+      spearman: spearman.statistic,
+      slope: regression.slope,
+      intercept: regression.intercept,
+      p_value: regression.pvalue,
+    },
+  ];
+}
+
+export function findCategoricalSlice(
+  data: DataExplorerPlotResponse | null,
+  mode?: ColorByValue
+) {
   if (!data) {
     return null;
+  }
+
+  if (mode === "expansion") {
+    const expansions = (data as { expansions?: DataExplorerExpansion[] })
+      .expansions;
+    if (!expansions || expansions.length === 0) {
+      throw new Error(
+        `mode "expansion" requires the response to have at least one ` +
+          `expansion, but data.expansions is empty or missing.`
+      );
+    }
+    const exp = expansions[0];
+    return {
+      label: exp.display_name || exp.slice_type,
+      dataset_id: undefined,
+      values: exp.labels.map((v) => v?.toString() || null),
+      value_type: "categorical" as const,
+    };
   }
 
   const colorDim = data.dimensions?.color;
@@ -256,7 +413,7 @@ export function formatDataForScatterPlot(
 
   const c1Values = data.filters?.color1?.values;
   const c2Values = data.filters?.color2?.values;
-  const catValues = findCategoricalSlice(data)?.values;
+  const catValues = findCategoricalSlice(data, color_by)?.values;
   const contSlice = findContinuousColorSlice(data);
   const contValues = nullifyUnplottableValues(
     contSlice?.values,
@@ -305,15 +462,7 @@ export function formatDataForScatterPlot(
 
     hoverText: data.index_ids.map((id: string, i: number) => {
       const label = data.index_labels[i];
-      const aliases: string[] = [];
       const colorInfo = [];
-
-      // Show the label prominently and the id as a secondary line when
-      // they differ. This is the desired behavior for every type where
-      // ids and labels are distinct (depmap_model, gene, compound_v2, etc).
-      if (id !== label) {
-        aliases.push(`<b>${label}</b>`);
-      }
 
       if (c1Values && c1Values[i] && color_by === "aggregated_slice") {
         colorInfo.push(data.filters.color1!.name);
@@ -335,19 +484,35 @@ export function formatDataForScatterPlot(
         );
       }
 
-      let primaryLine = label;
+      const hasExpansion =
+        typeof data === "object" &&
+        data !== null &&
+        "expansions" in data &&
+        (data as { expansions: ArrayLike<unknown> }).expansions.length > 0;
 
+      // Build the index section as: bold header (entity type) + bold
+      // label + plain id. The header anchors the section's identity;
+      // the label is the primary thing the user scans for; the id is
+      // identity for copy/lookup. When `display_name` is missing the
+      // header is skipped — falling back to `index_id_column` would
+      // print "depmap id" as a header, which reads as a column name
+      // rather than an entity type. The degraded form (bold label +
+      // plain id, no header) is honest about what we don't know.
+      const indexLines: string[] = [];
+      if (hasExpansion && data.index_display_name) {
+        indexLines.push(`<b>${data.index_display_name}</b>`);
+      }
+      indexLines.push(`<b>${label}</b>`);
       if (id !== label) {
-        primaryLine = data.index_id_column
-          ? `${data.index_id_column}: ${id}`
-          : id;
+        indexLines.push(id);
       }
 
-      const formattedLines =
-        aliases.length > 0
-          ? [...aliases, primaryLine, ...colorInfo]
-          : [`<b>${primaryLine}</b>`, ...colorInfo];
-
+      // Metadata is index-keyed (model-level for the gene/transcript
+      // case), so it belongs in the index section rather than floating
+      // at the bottom. In an expanded plot this puts it before the
+      // section break; in a non-expanded plot it lifts metadata above
+      // colorInfo, which reads more naturally — colorInfo describes the
+      // point's value and belongs last.
       Object.keys(data.metadata || {}).forEach((key) => {
         let { label: hoverLabel } = data.metadata[key]!;
         const { values, dataset_label } = data.metadata[key]!;
@@ -362,10 +527,34 @@ export function formatDataForScatterPlot(
         let val = values[i] != null ? values[i]!.toString() : "<b>N/A</b>";
         val = val.length > 40 ? `${val.substr(0, 40)}…` : val;
 
-        formattedLines.push(`${hoverLabel}: ${val}`);
+        indexLines.push(`${hoverLabel}: ${val}`);
       });
 
-      return formattedLines.join("<br>");
+      // Build expansion sections, one per expansion. Each mirrors the
+      // index pattern (bold header + bold label + plain id) and is
+      // preceded by a blank line so the section break is obvious. The
+      // header is skipped when `display_name` is missing for the same
+      // reason as in the index section: "transcript" (lowercase
+      // slice_type) reads as a machine name, not an entity label.
+      const expansionSections: string[] = [];
+      const expansions = (data as { expansions?: DataExplorerExpansion[] })
+        .expansions;
+      if (expansions) {
+        expansions.forEach((exp) => {
+          const expLabel = exp.labels[i];
+          const expId = exp.ids[i];
+          expansionSections.push(""); // blank line between sections
+          if (exp.display_name) {
+            expansionSections.push(`<b>${exp.display_name}</b>`);
+          }
+          expansionSections.push(`<b>${expLabel}</b>`);
+          if (expId !== expLabel) {
+            expansionSections.push(expId);
+          }
+        });
+      }
+
+      return [...indexLines, ...expansionSections, ...colorInfo].join("<br>");
     }),
 
     annotationText: data.index_ids.map((id: string, i: number) => {
@@ -380,10 +569,18 @@ export function formatDataForScatterPlot(
   };
 }
 
+// Waterfall's x-positions are reassigned to cluster bars by group. Today
+// that clustering uses `formatted.catColorData` (the color-side categorical),
+// because color and group were conflated. With the split, the clustering
+// uses `groupData` when supplied, falling back to `catColorData` for the
+// converged case. Similarly `sortedGroupKeys` replaces the historical
+// `sortedLegendKeys` parameter — its meaning was always "the order of
+// clusters along x" rather than "the legend display order."
 export function formatDataForWaterfall(
   data: DataExplorerPlotResponse | null,
   color_by: DataExplorerPlotConfig["color_by"],
-  sortedLegendKeys?: (string | symbol)[]
+  sortedGroupKeys?: (string | symbol)[],
+  groupData?: (string | null)[] | null
 ) {
   if (!data) {
     return null;
@@ -391,34 +588,94 @@ export function formatDataForWaterfall(
 
   const formatted = formatDataForScatterPlot(data, color_by);
 
-  if (!formatted || !sortedLegendKeys) {
+  if (!formatted || !sortedGroupKeys) {
     return formatted;
   }
 
-  // If the legend keys have been sorted, then we have to move around the x
-  // values to match.
-  let j = 0;
-  const x: number[] = [];
-  const catData = formatted.catColorData as string[];
-  const visible = data.filters?.visible?.values;
-  const domain = visible ? visible.filter(Boolean).length : catData.length;
-  const minLength = domain / sortedLegendKeys.length;
-  const groups: Record<string | symbol, { start: number; length: number }> = {};
+  // Clustering source: prefer the explicit groupData (group-side categorical)
+  // when supplied; otherwise reuse the color-side catColorData, matching
+  // pre-split behavior.
+  const clusterBy = (groupData ?? formatted.catColorData) as
+    | (string | null)[]
+    | null;
 
-  for (let i = 0; i < catData.length; i += 1) {
-    const category = catData[i] || LEGEND_OTHER;
-    groups[category] ||= { start: i, length: 0 };
-    groups[category].length++;
+  if (!clusterBy) {
+    return formatted;
   }
 
-  sortedLegendKeys.forEach((key) => {
-    const { start, length } = groups[key];
+  // Bucket each point's original index by its category. The previous
+  // implementation built `groups[category] = { start, length }` and
+  // assumed every category's points occupied a contiguous block in the
+  // input. That held for plain waterfall (rank-sorted upstream by
+  // fetchWaterfall, where same-color points end up adjacent) but
+  // breaks for the expanded path, where materialization is row-major
+  // over (logical_i, j) and category labels (e.g. transcript) cycle
+  // every M positions. The bucket structure makes the loop work
+  // regardless of input ordering.
+  //
+  // Note: `length` continues to include invisible points, matching
+  // the previous code's behavior of using `clusterBy.length` (not
+  // visible-count) for the per-category sum. The "leave a gap" logic
+  // below compares `length` to `minLength`, where `minLength` is
+  // computed against the visible domain — so small categories
+  // (visible or not) get extra padding around them. Preserving that
+  // as-is rather than reinterpreting.
+  const buckets: Record<string | symbol, number[]> = {};
+  for (let i = 0; i < clusterBy.length; i += 1) {
+    const category = clusterBy[i] || LEGEND_OTHER;
+    (buckets[category] ||= []).push(i);
+  }
+
+  // Within-cluster rank: sort each bucket's indices by their y value
+  // ascending so that the x positions assigned by the loop below
+  // produce the "snake going up" shape characteristic of a waterfall.
+  // Without this, indices are walked in materialization order, which
+  // for the expanded path is row-major over (logical_i, j) and has no
+  // relationship to the y value — producing a "flame" of intermixed
+  // values within each cluster.
+  //
+  // Nulls sort first (smallest x within their cluster), matching
+  // fetchWaterfall's global sort behavior. The comparator pulls them
+  // out before the numeric comparison so they end up at the low-x end
+  // regardless of where they'd otherwise land. Sort is stable, so ties
+  // (including the common "lots of points with value 0" case) preserve
+  // materialization order — keeps selection / hover behavior deterministic.
+  const yValues = data?.dimensions?.y?.values as (number | null)[] | undefined;
+  if (yValues) {
+    Object.values(buckets).forEach((indices) => {
+      indices.sort((a, b) => {
+        const va = yValues[a];
+        const vb = yValues[b];
+        if (va === vb) return 0;
+        if (va === null || va === undefined) return -1;
+        if (vb === null || vb === undefined) return 1;
+        return va < vb ? -1 : 1;
+      });
+    });
+  }
+
+  let j = 0;
+  const x: number[] = [];
+  const visible = data.filters?.visible?.values;
+  const domain = visible ? visible.filter(Boolean).length : clusterBy.length;
+  const minLength = domain / sortedGroupKeys.length;
+
+  sortedGroupKeys.forEach((key) => {
+    const indices = buckets[key];
+
+    // A category in sortedGroupKeys with no points in `clusterBy` is
+    // unusual but possible (legend key with no data). Skip cleanly.
+    if (!indices || indices.length === 0) {
+      return;
+    }
+
+    const length = indices.length;
 
     if (length < minLength && j > 0) {
       j += Math.floor(minLength - length / 2);
     }
 
-    for (let i = start; i < start + length; i += 1) {
+    for (const i of indices) {
       if (!visible || visible[i]) {
         x[i] = j;
         j++;
@@ -639,7 +896,8 @@ export function calcVisibility(
   data: DataExplorerPlotResponse | null,
   hiddenLegendValues: any,
   continuousBins: any,
-  hide_points?: boolean
+  hide_points?: boolean,
+  color_by?: ColorByValue
 ) {
   if (!data) {
     return null;
@@ -678,7 +936,7 @@ export function calcVisibility(
     });
   }
 
-  const catValues = findCategoricalSlice(data)?.values;
+  const catValues = findCategoricalSlice(data, color_by)?.values;
 
   if (catValues) {
     const hideOthers = hiddenLegendValues.has(LEGEND_OTHER);
@@ -738,8 +996,12 @@ export function calcVisibility(
   return visiblePoints;
 }
 
-export function getLegendKeysWithNoData(data: any, continuousBins: any) {
-  const catData = findCategoricalSlice(data);
+export function getLegendKeysWithNoData(
+  data: any,
+  continuousBins: any,
+  color_by?: ColorByValue
+) {
+  const catData = findCategoricalSlice(data, color_by);
   const visible = data?.filters?.visible;
 
   if (catData && visible) {
@@ -1035,7 +1297,7 @@ export function getColorMap(
 
   let colorMap: Map<LegendKey, string> = new Map();
 
-  const catSlice = findCategoricalSlice(data);
+  const catSlice = findCategoricalSlice(data, plotConfig.color_by);
   const contSlice = findContinuousColorSlice(data);
 
   if (catSlice) {
@@ -1392,11 +1654,50 @@ const sortLegendKeys = (
 const sortLegendKeys1D = (
   data: any,
   catData: any,
-  sort_by: string | undefined
+  sort_by: string | undefined,
+  includeEmpty = false
 ) => {
   const visibleValues = data.filters?.visible
     ? data.filters.visible.values
     : null;
+
+  if (includeEmpty) {
+    // Expanded plots keep a track for every windowed transcript, including
+    // ones the dataset doesn't measure (all-null), which sortLegendKeys would
+    // otherwise drop. Sort the *measured* transcripts normally — respecting
+    // sort_by — then fold the empty ones in: merged alphabetically for an
+    // alphabetical sort, or appended at the end for value-based sorts (an
+    // all-null group has no value to sort by). This preserves sort_by for the
+    // groups that have data while still surfacing the "(no data)" placeholders.
+    const sorted = sortLegendKeys(
+      data.dimensions.x.values,
+      visibleValues,
+      catData,
+      sort_by
+    );
+
+    const seen = new Set(sorted);
+    const empties: (string | symbol)[] = [];
+
+    for (let i = 0; i < catData.values.length; i += 1) {
+      const key = catData.values[i];
+
+      if (key !== null && !seen.has(key)) {
+        seen.add(key);
+        empties.push(key);
+      }
+    }
+
+    if (empties.length === 0) {
+      return sorted;
+    }
+
+    if (!sort_by || sort_by === "alphabetical") {
+      return [...sorted, ...empties].sort(compareLegendKeys);
+    }
+
+    return [...sorted, ...empties.sort(compareLegendKeys)];
+  }
 
   return sortLegendKeys(
     data.dimensions.x.values,
@@ -1465,19 +1766,52 @@ export function continuousValuesToLegendKeySeries(
   return [series, unusedKeys];
 }
 
-export function calcDensityStats(
+// Computes the per-point legend-key series for a single mode (color_by or
+// group_by). The same logic that calcDensityStats used to do inline; pulled
+// out so we can call it once for the coloring concern and (when modes
+// differ) again for the grouping concern.
+//
+// Each branch corresponds to a category of color/group source:
+//   - "custom"               → color1/color2 filter values
+//   - categorical fall-through → catData (mode-aware: expansion when applicable,
+//                                otherwise existing color-dim / color_property)
+//   - continuous fall-through  → contData (binned)
+//
+// The "custom" branch only fires when color1/color2 are actually present;
+// otherwise we fall through. That matches the existing auto-dispatch and
+// keeps callers that don't set mode explicitly behaving the same as today.
+function computeDensitySeriesForMode(
   data: any,
   continuousBins: any,
-  sort_by: string | undefined
-) {
+  sort_by: string | undefined,
+  mode: ColorByValue | undefined,
+  includeEmpty = false
+): {
+  series: any[] | null;
+  unusedKeys: Set<unknown>;
+  sortedKeys?: any[];
+} {
   const color1 = data?.filters?.color1;
   const color2 = data?.filters?.color2;
-  const catData = findCategoricalSlice(data);
-  const contData = findContinuousColorSlice(data);
   const visible = data?.filters?.visible;
 
-  if (color1 || color2) {
-    const out = [];
+  const catData = findCategoricalSlice(data, mode);
+
+  // Custom (color1/color2 filter) branch. It owns coloring when the mode is
+  // "custom"/unset, and also when an explicit non-"expansion" mode has no
+  // categorical source of its own — e.g. aggregated_slice/raw_slice with a
+  // color1/color2 filter but no color dimension. Without that fallback the
+  // color side returns no series at all, and the renderer then builds zero
+  // point traces (every point vanishes). We still never let filters override
+  // the "expansion" group side or a real categorical color dimension.
+  const useCustomColoring =
+    Boolean(color1 || color2) &&
+    (mode === "custom" ||
+      mode === undefined ||
+      (mode !== "expansion" && !catData));
+
+  if (useCustomColoring) {
+    const out: any[] = [];
     const len = (color1 || color2).values.length;
     const unusedKeys = new Set(
       color1 && color2 ? [LEGEND_BOTH, LEGEND_OTHER] : [LEGEND_OTHER]
@@ -1503,12 +1837,12 @@ export function calcDensityStats(
       }
     }
 
-    return [out, unusedKeys];
+    return { series: out, unusedKeys };
   }
 
   if (catData) {
     const counts: Record<string, number> = {};
-    const unusedKeys = new Set();
+    const unusedKeys = new Set<unknown>();
 
     if (visible) {
       for (let i = 0; i < catData.values.length; i += 1) {
@@ -1528,24 +1862,106 @@ export function calcDensityStats(
       });
     }
 
-    return [
-      catData.values.map((x: unknown) => (x === null ? LEGEND_OTHER : x)),
+    return {
+      series: catData.values.map((x: unknown) =>
+        x === null ? LEGEND_OTHER : x
+      ),
       unusedKeys,
-      sortLegendKeys1D(data, catData, sort_by),
-    ];
+      sortedKeys: sortLegendKeys1D(data, catData, sort_by, includeEmpty),
+    };
   }
 
-  if (contData) {
-    const [series, unusedKeys] = continuousValuesToLegendKeySeries(
-      contData.values,
-      continuousBins,
-      data.filters?.visible?.values
-    );
+  // Expansion is always categorical; if mode === "expansion" we never reach
+  // contData. Other modes can fall through to a continuous color source.
+  if (mode !== "expansion") {
+    const contData = findContinuousColorSlice(data);
+    if (contData) {
+      const [series, unusedKeys] = continuousValuesToLegendKeySeries(
+        contData.values,
+        continuousBins,
+        data.filters?.visible?.values
+      );
 
-    return [series, unusedKeys];
+      return { series, unusedKeys };
+    }
   }
 
-  return [null];
+  return { series: null, unusedKeys: new Set() };
+}
+
+// Returns the per-point series for both coloring and grouping, plus the
+// associated legend metadata. When `group_by` is unset (or equal to
+// `color_by`), the grouping arrays are the same references as the coloring
+// arrays — no extra work, no behavior change. When they differ, both arrays
+// are computed independently from the same response and the renderer is
+// expected to consume each for its respective role: colorData drives
+// bgcolor, groupData drives violin-track assignment.
+export function calcDensityStats(
+  data: any,
+  continuousBins: any,
+  sort_by: string | undefined,
+  color_by?: ColorByValue,
+  group_by?: ColorByValue,
+  isExpanded = false
+) {
+  const colorMode = color_by;
+
+  const colorSide = computeDensitySeriesForMode(
+    data,
+    continuousBins,
+    sort_by,
+    colorMode
+  );
+
+  // Expand-by world: group_by is fully decoupled from color_by. An unset
+  // group_by means "no grouping" — a single "all" track — NOT the legacy
+  // `group_by ?? color_by` inheritance. The fallback below survives only when
+  // there's no expansion (the ConfigurationPanel/legacy world), preserving
+  // existing behavior there. (Color still drives point color via colorSide.)
+  if (isExpanded && !group_by) {
+    return {
+      colorData: colorSide.series,
+      groupData: colorSide.series
+        ? colorSide.series.map(() => LEGEND_ALL)
+        : null,
+      unusedKeys: colorSide.unusedKeys as Set<LegendKey>,
+      sortedColorKeys: colorSide.sortedKeys,
+      sortedGroupKeys: [LEGEND_ALL],
+    };
+  }
+
+  const groupMode = group_by ?? color_by;
+
+  // Reuse colorSide when grouping mode matches the coloring mode. This is
+  // the common case (group_by unset, falling back to color_by), and
+  // skipping the second pass keeps the no-op fast.
+  //
+  // When expanded we must NOT reuse it even if the modes match: the group side
+  // needs every windowed transcript (incl. all-null ones the dataset doesn't
+  // measure) so each gets a track — a "(no data)" placeholder for the empties,
+  // keeping the page at its full window size. The color side stays as-is so
+  // the legend reflects only transcripts that actually have points.
+  const groupSide =
+    groupMode === colorMode && !isExpanded
+      ? colorSide
+      : computeDensitySeriesForMode(
+          data,
+          continuousBins,
+          sort_by,
+          groupMode,
+          isExpanded
+        );
+
+  return {
+    colorData: colorSide.series,
+    groupData: groupSide.series,
+    // computeDensitySeriesForMode types unusedKeys as Set<unknown>; narrow at
+    // this boundary, matching the `as Set<LegendKey>` casts used on the other
+    // unused-key paths in this file. Consumers expect Set<LegendKey>.
+    unusedKeys: colorSide.unusedKeys as Set<LegendKey>,
+    sortedColorKeys: colorSide.sortedKeys,
+    sortedGroupKeys: groupSide.sortedKeys,
+  };
 }
 
 export function isEveryValueNull(values: any[]) {
@@ -1787,9 +2203,17 @@ export function calcPlotIndicatorLineShapes(
     rangeX: number;
     rangeY: number;
   },
-  simulateInfiteLength?: boolean
+  simulateInfiteLength?: boolean,
+  // Subplot axis refs the shapes are drawn against. Defaults to the master
+  // "x"/"y" pair, so single-panel callers get byte-for-byte identical output.
+  // The faceted renderer passes one panel's pair (e.g. "x2"/"y2") to draw the
+  // same shapes inside that subplot; endpoints still span the matches-shared
+  // extents, so only the refs (and the per-facet slope/intercept) differ.
+  axisRefs: { xref: string; yref: string } = { xref: "x", yref: "y" }
 ) {
   const shapes: Layout["shapes"] = [];
+  const xref = axisRefs.xref as XAxisName;
+  const yref = axisRefs.yref as YAxisName;
   const extraLength = simulateInfiteLength
     ? Math.max(extents.rangeX, extents.rangeY) * 10
     : 0;
@@ -1807,8 +2231,8 @@ export function calcPlotIndicatorLineShapes(
   if (showIdentityLine) {
     const shape: Layout["shapes"][0] = {
       type: "line",
-      xref: "x",
-      yref: "y",
+      xref,
+      yref,
       x0: p0,
       x1: p1,
       y0: p0,
@@ -1830,8 +2254,8 @@ export function calcPlotIndicatorLineShapes(
       const shape: Layout["shapes"][0] = {
         layer: "above",
         type: "line",
-        xref: "x",
-        yref: "y",
+        xref,
+        yref,
         xanchor: 2,
         yanchor: 2,
         x0: p0,
@@ -1848,4 +2272,149 @@ export function calcPlotIndicatorLineShapes(
   }
 
   return shapes;
+}
+
+export interface SolidColorGroup {
+  color: string;
+  // Membership in this color group, by point index. Deliberately ignores point
+  // visibility, facet membership, and opposite-axis nulls — those masks belong
+  // to the renderer, not to the color semantics.
+  includes: (i: number) => boolean;
+}
+
+// Pure color-grouping seam shared by the scatter renderers (single-panel and
+// small multiples). Given the formatted color inputs, returns the solid-color
+// traces to draw, in paint order: index 0 is drawn first (on the bottom), so
+// the "other"/largest groups come first and the smallest categories end up on
+// top — preserving PrototypeScatterPlot's stacking.
+//
+// It does NOT handle continuous color: that's a single colorscale trace rather
+// than a set of solid groups, so the caller builds it directly. It also
+// deliberately omits the legacy ">75 categories -> one trace per color"
+// workaround; with faceting that would multiply trace count badly, and high
+// color cardinality is already past the readability cliff.
+// Orders point indices for a continuous color trace so that bins with the
+// fewest *visible* points draw last (on top) and null / "Other" points draw
+// first (on the bottom). This is the continuous analogue of the categorical
+// "fewest on top" stacking, shared by every renderer that paints continuous
+// color so they all stack identically. The returned array is the draw order
+// expressed as original point indices (i.e. contTraceIndex): build the trace by
+// mapping each per-point array through it, and map a click on the trace's Nth
+// point back to result[N]. Counts are visible-only, so hidden points never
+// affect the order.
+export function orderContinuousPointsByBin(
+  contColorData: (number | null)[],
+  contLegendKeys: LegendKey[],
+  colorMap: Map<LegendKey, string>,
+  visible: boolean[]
+): number[] {
+  const counts = categoricalDataToValueCounts(contLegendKeys, visible);
+
+  // Largest bins first → smaller bins land later in the trace (drawn on top).
+  // Keys absent from colorMap (e.g. LEGEND_OTHER for nulls) get index -1 and
+  // therefore sort to the very bottom, alongside the separate "other" trace.
+  const sortedBins = [...colorMap.keys()]
+    .sort((a, b) => {
+      const countA = counts.get(a) || 0;
+      const countB = counts.get(b) || 0;
+      if (countA === countB) {
+        return 0;
+      }
+      return countA < countB ? -1 : 1;
+    })
+    .reverse();
+
+  return contColorData
+    .map((value, origIndex) => ({ value, origIndex }))
+    .sort((a, b) => {
+      const binIndexA = sortedBins.indexOf(contLegendKeys[a.origIndex]);
+      const binIndexB = sortedBins.indexOf(contLegendKeys[b.origIndex]);
+
+      if (binIndexA !== binIndexB) {
+        return binIndexA - binIndexB;
+      }
+
+      if (a.value === b.value || a.value == null || b.value == null) {
+        return 0;
+      }
+
+      return a.value < b.value ? -1 : 1;
+    })
+    .map(({ origIndex }) => origIndex);
+}
+
+export function getSolidColorGroups(args: {
+  color1: (boolean | null)[] | null;
+  color2: (boolean | null)[] | null;
+  catColorData: (string | number | null)[] | null;
+  colorMap: Map<LegendKey, string>;
+  palette: DataExplorerColorPalette;
+  visible: boolean[];
+}): SolidColorGroup[] {
+  const { color1, color2, catColorData, colorMap, palette, visible } = args;
+
+  // Comparison mode: two boolean masks plus their overlap, with an "other"
+  // catch-all for points in neither.
+  if (color1 || color2) {
+    const groups: (SolidColorGroup & { count: number })[] = [];
+
+    if (color1) {
+      groups.push({
+        color: palette.compare1,
+        includes: (i) => Boolean(color1?.[i]) && !color2?.[i],
+        count: countExclusivelyTrueValues(color1, color2, visible),
+      });
+    }
+    if (color2) {
+      groups.push({
+        color: palette.compare2,
+        includes: (i) => Boolean(color2?.[i]) && !color1?.[i],
+        count: countExclusivelyTrueValues(color2, color1, visible),
+      });
+    }
+    if (color1 && color2) {
+      groups.push({
+        color: palette.compareBoth,
+        includes: (i) => Boolean(color1?.[i]) && Boolean(color2?.[i]),
+        count: countInclusivelyTrueValues(color1, color2, visible),
+      });
+    }
+
+    // Larger groups on the bottom (drawn first), smaller on top.
+    groups.sort((a, b) => (a.count < b.count ? 1 : -1));
+
+    return [
+      { color: palette.other, includes: (i) => !color1?.[i] && !color2?.[i] },
+      ...groups.map(({ color, includes }) => ({ color, includes })),
+    ];
+  }
+
+  // Categorical mode: one group per category value that has visible points,
+  // plus "other" for nulls.
+  if (catColorData) {
+    const counts = categoricalDataToValueCounts(
+      catColorData.map((v) => (v == null ? null : String(v))),
+      visible
+    );
+
+    const groups: SolidColorGroup[] = [...colorMap.keys()]
+      .filter((key): key is string => typeof key === "string")
+      .map((key) => ({ key, count: counts.get(key) || 0 }))
+      // Drop categories with no visible points; otherwise faceting multiplies
+      // empty traces by the facet count.
+      .filter(({ count }) => count > 0)
+      .sort((a, b) => (a.count < b.count ? 1 : -1))
+      .map(({ key }) => ({
+        color: colorMap.get(key)!,
+        includes: (i: number) => String(catColorData[i]) === key,
+      }));
+
+    return [
+      { color: palette.other, includes: (i) => catColorData[i] == null },
+      ...groups,
+    ];
+  }
+
+  // No color enabled: one group covering every point.
+  return [{ color: palette.all, includes: () => true }];
 }

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/useDensity1DPlotData.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/useDensity1DPlotData.ts
@@ -31,9 +31,18 @@ export interface Density1DPlotData {
     yLabel: string | null;
   } | null;
   continuousBins: ContinuousBins;
+  // colorData: drives point colors (bgcolor). Sourced from color_by.
   colorData: unknown;
+  // groupData: drives violin-track assignment. Sourced from group_by, or
+  // color_by when group_by is unset. Equal-by-reference to colorData when
+  // the modes match — the common case.
+  groupData: unknown;
   legendKeysWithNoData: Set<LegendKey> | null;
+  // sortedLegendKeys: order of legend entries (color side).
   sortedLegendKeys: LegendKey[] | undefined;
+  // sortedGroupKeys: order of violin tracks (group side). Same array as
+  // sortedLegendKeys when modes match.
+  sortedGroupKeys: LegendKey[] | undefined;
   legendState: ReturnType<typeof useLegendState>;
   colorMap: Map<LegendKey, string>;
   legendDisplayNames: Partial<Record<LegendKey, string>>;
@@ -66,11 +75,25 @@ export default function useDensity1DPlotData(
     [formattedData]
   );
 
-  const { sort_by } = plotConfig;
+  const { sort_by, color_by, group_by, expand_by } = plotConfig;
 
-  const [colorData, legendKeysWithNoData, sortedLegendKeys] = useMemo(
-    () => calcDensityStats(data, continuousBins, sort_by),
-    [data, continuousBins, sort_by]
+  const {
+    colorData,
+    groupData,
+    unusedKeys: legendKeysWithNoData,
+    sortedColorKeys: sortedLegendKeys,
+    sortedGroupKeys,
+  } = useMemo(
+    () =>
+      calcDensityStats(
+        data,
+        continuousBins,
+        sort_by,
+        color_by,
+        group_by,
+        Boolean(expand_by?.length)
+      ),
+    [data, continuousBins, sort_by, color_by, group_by, expand_by]
   );
 
   const legendState = useLegendState(plotConfig, legendKeysWithNoData);
@@ -116,17 +139,20 @@ export default function useDensity1DPlotData(
         data,
         hiddenLegendValues,
         continuousBins,
-        plotConfig.hide_points
+        plotConfig.hide_points,
+        plotConfig.color_by
       ),
-    [data, hiddenLegendValues, continuousBins, plotConfig.hide_points]
+    [data, hiddenLegendValues, continuousBins, plotConfig.hide_points, plotConfig.color_by]
   );
 
   return {
     formattedData,
     continuousBins,
     colorData,
+    groupData,
     legendKeysWithNoData,
     sortedLegendKeys,
+    sortedGroupKeys,
     legendState,
     colorMap,
     legendDisplayNames,

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/useScatterPlotData.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/useScatterPlotData.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import {
   DataExplorerPlotConfig,
   DataExplorerPlotResponse,
+  DataExplorerPlotResponseDimension,
   LinRegInfo,
 } from "@depmap/types";
 import {
@@ -10,6 +11,8 @@ import {
   categoryToDisplayName,
   continuousValuesToLegendKeySeries,
   ContinuousBins,
+  facetMaskFor,
+  findCategoricalSlice,
   formatDataForScatterPlot,
   getColorMap,
   getLegendKeysWithNoData,
@@ -20,6 +23,7 @@ import {
   RegressionLine,
   useLegendState,
 } from "./plotUtils";
+import { linregress } from "@depmap/statistics";
 
 type Palette = Parameters<typeof getColorMap>[2];
 
@@ -47,8 +51,25 @@ export interface ScatterPlotData {
   };
   pointVisibility: boolean[] | null;
   regressionLines: RegressionLine[] | null;
+  // Per-facet fits for the faceted renderer, keyed by facet label. null when
+  // not faceted (group_by unset); the single-panel path uses regressionLines.
+  regressionLinesByFacet: Map<string, RegressionLine> | null;
   showIdentityLine: boolean;
 }
+
+// Decides whether the x = y identity line is eligible to be drawn, given the
+// x and y dimensions of the response. The default rule is "same dataset on both
+// axes" (i.e. the axes are directly comparable). Injectable so a host can
+// override the eligibility rule — e.g. for expanded plots, where x and y are
+// intentionally different datasets but still comparable. See VisualizationPanel,
+// which supplies this and is the place to swap in a custom implementation.
+export type CanShowIdentityLine = (
+  xDim: DataExplorerPlotResponseDimension,
+  yDim: DataExplorerPlotResponseDimension
+) => boolean;
+
+export const defaultCanShowIdentityLine: CanShowIdentityLine = (xDim, yDim) =>
+  xDim.dataset_id === yDim.dataset_id;
 
 // Encapsulates the data-prep pipeline shared by DataExplorerScatterPlot and
 // any embedded/standalone scatter plot consumer. Returns everything needed to
@@ -58,7 +79,8 @@ export default function useScatterPlotData(
   data: DataExplorerPlotResponse | null,
   plotConfig: DataExplorerPlotConfig,
   linreg_by_group: LinRegInfo[] | null,
-  palette: Palette
+  palette: Palette,
+  canShowIdentityLine: CanShowIdentityLine = defaultCanShowIdentityLine
 ): ScatterPlotData {
   const formattedData = useMemo(
     () => formatDataForScatterPlot(data, plotConfig.color_by),
@@ -85,8 +107,8 @@ export default function useScatterPlotData(
   );
 
   const legendKeysWithNoData = useMemo(
-    () => getLegendKeysWithNoData(data, continuousBins),
-    [data, continuousBins]
+    () => getLegendKeysWithNoData(data, continuousBins, plotConfig.color_by),
+    [data, continuousBins, plotConfig.color_by]
   );
 
   const legendState = useLegendState(plotConfig, legendKeysWithNoData);
@@ -140,13 +162,61 @@ export default function useScatterPlotData(
   }, [colorMap, data, continuousBins, hiddenLegendValues]);
 
   const pointVisibility = useMemo(
-    () => calcVisibility(data, hiddenLegendValues, continuousBins),
-    [data, hiddenLegendValues, continuousBins]
+    () =>
+      calcVisibility(
+        data,
+        hiddenLegendValues,
+        continuousBins,
+        undefined,
+        plotConfig.color_by
+      ),
+    [data, hiddenLegendValues, continuousBins, plotConfig.color_by]
   );
 
   const regressionLines = useMemo(() => {
-    if (!linreg_by_group || !hiddenLegendValues) {
+    if (!hiddenLegendValues) {
       return null;
+    }
+
+    // Expanded single-panel: fetchLinearRegression is skipped when an axis
+    // carries the "expansion" sentinel, so there's no linreg_by_group. When
+    // ungrouped (group_by unset), fit one pooled line over all visible points
+    // from the response so the overall trend still shows instead of nothing.
+    if (!linreg_by_group) {
+      if (
+        !plotConfig.show_regression_line ||
+        plotConfig.group_by ||
+        !formattedData ||
+        !plotConfig.expand_by?.length
+      ) {
+        return null;
+      }
+
+      const x = formattedData.x;
+      const y = formattedData.y;
+      if (!x || !y) {
+        return null;
+      }
+
+      const visible = pointVisibility ?? x.map(() => true);
+      const fx: number[] = [];
+      const fy: number[] = [];
+      for (let i = 0; i < x.length; i += 1) {
+        if (visible[i] && Number.isFinite(x[i]) && Number.isFinite(y[i])) {
+          fx.push(x[i] as number);
+          fy.push(y[i] as number);
+        }
+      }
+
+      const { slope, intercept } = linregress(fx, fy);
+      return [
+        {
+          hidden: fx.length < 3 || !Number.isFinite(slope),
+          color: palette.other,
+          m: slope,
+          b: intercept,
+        },
+      ];
     }
 
     return linreg_by_group.map((linreg) => {
@@ -196,18 +266,96 @@ export default function useScatterPlotData(
   }, [
     colorMap,
     data?.dimensions?.color,
+    formattedData,
     hiddenLegendValues,
     linreg_by_group,
     palette,
+    plotConfig.expand_by,
+    plotConfig.group_by,
     plotConfig.show_regression_line,
+    pointVisibility,
   ]);
 
   const showIdentityLine = Boolean(
     data?.dimensions?.x &&
       data?.dimensions?.y &&
-      data.dimensions.x.dataset_id === data.dimensions.y.dataset_id &&
+      canShowIdentityLine(data.dimensions.x, data.dimensions.y) &&
       !plotConfig.hide_identity_line
   );
+
+  // Faceted regression: one fit per group_by group, computed here from the
+  // main response — which carries group_by's per-point values via
+  // findCategoricalSlice (including the expansion case fetchLinearRegression's
+  // side-fetch can't see). Single-panel keeps using linreg_by_group above.
+  // This is the group_by ?? color_by realization; since scatter only facets on
+  // a categorical group_by, the continuous-color carve-out never applies here.
+  // Fit over formattedData.x/y with the same facet mask the renderer draws, so
+  // each line is fit over exactly its panel's points.
+  const regressionLinesByFacet = useMemo(() => {
+    if (!plotConfig.group_by || !data || !formattedData) {
+      return null;
+    }
+
+    const facetSlice = findCategoricalSlice(data, plotConfig.group_by);
+    const x = formattedData.x;
+    const y = formattedData.y;
+    if (!facetSlice || !x || !y) {
+      return null;
+    }
+
+    const facetKeys = facetSlice.values;
+    const visible = pointVisibility ?? x.map(() => true);
+
+    // J4: a facet's line takes that facet's color only when group_by IS
+    // color_by (the panel is then monochromatic); otherwise neutral, since a
+    // facet spanning several colors has no single color to borrow.
+    const colorSlice = findCategoricalSlice(data, plotConfig.color_by);
+    const groupIsColor =
+      !!colorSlice &&
+      facetSlice.label === colorSlice.label &&
+      facetSlice.dataset_id === colorSlice.dataset_id;
+
+    const facets = Array.from(
+      new Set(facetKeys.filter((k): k is string => k !== null))
+    );
+    const lines = new Map<string, RegressionLine>();
+
+    facets.forEach((facet) => {
+      const inFacet = facetMaskFor(facetKeys, facet, x, y, visible);
+      const fx: number[] = [];
+      const fy: number[] = [];
+      for (let i = 0; i < x.length; i += 1) {
+        if (inFacet(i) && Number.isFinite(x[i]) && Number.isFinite(y[i])) {
+          fx.push(x[i] as number);
+          fy.push(y[i] as number);
+        }
+      }
+
+      const { slope, intercept } = linregress(fx, fy);
+      lines.set(facet, {
+        m: slope,
+        b: intercept,
+        hidden:
+          fx.length < 3 ||
+          !Number.isFinite(slope) ||
+          !plotConfig.show_regression_line,
+        color: groupIsColor
+          ? colorMap.get(facet as LegendKey) || palette.other
+          : "#333",
+      });
+    });
+
+    return lines;
+  }, [
+    data,
+    formattedData,
+    plotConfig.group_by,
+    plotConfig.color_by,
+    plotConfig.show_regression_line,
+    pointVisibility,
+    colorMap,
+    palette,
+  ]);
 
   return {
     formattedData,
@@ -219,6 +367,7 @@ export default function useScatterPlotData(
     legendForDownload,
     pointVisibility,
     regressionLines,
+    regressionLinesByFacet,
     showIdentityLine,
   };
 }

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/useWaterfallPlotData.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/useWaterfallPlotData.ts
@@ -56,8 +56,12 @@ export default function useWaterfallPlotData(
   plotConfig: DataExplorerPlotConfig,
   palette: Palette
 ): WaterfallPlotData {
+  // Color-side sorted keys: drive legend order and (via getColorMap) the
+  // colorMap iteration order, which the renderer uses for color trace
+  // construction. Mode-aware via color_by so "color by expansion" picks
+  // up expansion labels.
   const sortedLegendKeys = useMemo(() => {
-    const catData = findCategoricalSlice(data);
+    const catData = findCategoricalSlice(data, plotConfig.color_by);
 
     if (!catData || !data?.dimensions?.y) {
       return undefined;
@@ -66,11 +70,41 @@ export default function useWaterfallPlotData(
     return sortLegendKeysWaterfall(data, catData, plotConfig.sort_by) as
       | LegendKey[]
       | undefined;
-  }, [data, plotConfig.sort_by]);
+  }, [data, plotConfig.color_by, plotConfig.sort_by]);
+
+  // Group-side: drives x-position clustering in formatDataForWaterfall.
+  // When group_by is unset or matches color_by, fall back to the
+  // color-side outputs (no extra computation, no behavior change). When
+  // they diverge, compute a separate per-point series and sorted-key
+  // order from the group-side categorical slice.
+  const groupMode = plotConfig.group_by ?? plotConfig.color_by;
+  const groupSide = useMemo(() => {
+    if (groupMode === plotConfig.color_by) {
+      return { groupData: null, sortedGroupKeys: sortedLegendKeys };
+    }
+    const catData = findCategoricalSlice(data, groupMode);
+    if (!catData || !data?.dimensions?.y) {
+      return { groupData: null, sortedGroupKeys: undefined };
+    }
+    return {
+      groupData: catData.values,
+      sortedGroupKeys: sortLegendKeysWaterfall(
+        data,
+        catData,
+        plotConfig.sort_by
+      ) as LegendKey[] | undefined,
+    };
+  }, [data, groupMode, plotConfig.color_by, plotConfig.sort_by, sortedLegendKeys]);
 
   const formattedData = useMemo(
-    () => formatDataForWaterfall(data, plotConfig.color_by, sortedLegendKeys),
-    [data, plotConfig, sortedLegendKeys]
+    () =>
+      formatDataForWaterfall(
+        data,
+        plotConfig.color_by,
+        groupSide.sortedGroupKeys,
+        groupSide.groupData
+      ),
+    [data, plotConfig, groupSide]
   );
 
   const continuousBins: ContinuousBins = useMemo(
@@ -93,8 +127,8 @@ export default function useWaterfallPlotData(
   );
 
   const legendKeysWithNoData = useMemo(
-    () => getLegendKeysWithNoData(data, continuousBins),
-    [data, continuousBins]
+    () => getLegendKeysWithNoData(data, continuousBins, plotConfig.color_by),
+    [data, continuousBins, plotConfig.color_by]
   );
 
   const legendState = useLegendState(plotConfig, legendKeysWithNoData);
@@ -146,8 +180,15 @@ export default function useWaterfallPlotData(
   }, [colorMap, data, continuousBins, hiddenLegendValues]);
 
   const pointVisibility = useMemo(
-    () => calcVisibility(data, hiddenLegendValues, continuousBins),
-    [data, hiddenLegendValues, continuousBins]
+    () =>
+      calcVisibility(
+        data,
+        hiddenLegendValues,
+        continuousBins,
+        undefined,
+        plotConfig.color_by
+      ),
+    [data, hiddenLegendValues, continuousBins, plotConfig.color_by]
   );
 
   return {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/hooks/index.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useClickHandlers } from "./useClickHandlers";
 export { default as useContextBuilder } from "./useContextBuilder";
 export { default as usePlotData } from "./usePlotData";
+export { default as useSelection } from "./useSelection";

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/hooks/usePlotData.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/hooks/usePlotData.ts
@@ -6,6 +6,7 @@ import {
   ErrorTypeError,
   LinRegInfo,
 } from "@depmap/types";
+import { isExpansionDimension } from "../../../utils/misc";
 
 export default function usePlotData(plotConfig: DataExplorerPlotConfig | null) {
   const [data, setData] = useState<DataExplorerPlotResponse | null>(null);
@@ -51,7 +52,12 @@ export default function usePlotData(plotConfig: DataExplorerPlotConfig | null) {
         setHadError(false);
         let fetchedData: DataExplorerPlotResponse;
 
-        if (plotConfig.plot_type === "correlation_heatmap") {
+        if ("expand_by" in plotConfig) {
+          fetchedData =
+            plotConfig.plot_type === "waterfall"
+              ? await dataExplorerAPI.fetchExpandedWaterfall(plotConfig as any)
+              : await dataExplorerAPI.fetchExpandedPlot(plotConfig as any);
+        } else if (plotConfig.plot_type === "correlation_heatmap") {
           fetchedData = await dataExplorerAPI.fetchCorrelation(
             plotConfig.index_type,
             plotConfig.dimensions,
@@ -105,19 +111,28 @@ export default function usePlotData(plotConfig: DataExplorerPlotConfig | null) {
         plotConfig &&
         plotConfig.show_regression_line &&
         plotConfig.dimensions.x &&
-        plotConfig.dimensions.y
+        plotConfig.dimensions.y &&
+        // Expanded plots get their fit from the faceted regression path;
+        // fetchLinearRegression assumes one value per index entity, so skip it
+        // when any axis carries the "expansion" sentinel (it would otherwise
+        // throw at the aggregate materializer).
+        !Object.values(plotConfig.dimensions).some(isExpansionDimension)
       ) {
-        const fetchedData = await dataExplorerAPI.fetchLinearRegression(
-          plotConfig.index_type,
-          plotConfig.dimensions,
-          plotConfig.filters,
-          plotConfig.metadata
-        );
+        try {
+          const fetchedData = await dataExplorerAPI.fetchLinearRegression(
+            plotConfig.index_type,
+            plotConfig.dimensions,
+            plotConfig.filters,
+            plotConfig.metadata
+          );
 
-        // Double check that these match (the user could've tweaked the config
-        // while this request was still in flight).
-        if (plotConfig === fetchedPlotConfig) {
-          setLinRegInfoByGroup(fetchedData);
+          // Double check that these match (the user could've tweaked the config
+          // while this request was still in flight).
+          if (plotConfig === fetchedPlotConfig) {
+            setLinRegInfoByGroup(fetchedData);
+          }
+        } catch (e) {
+          window.console.error(e);
         }
       }
     })();

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/hooks/useSelection.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/hooks/useSelection.ts
@@ -1,0 +1,144 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  DataExplorerPlotResponse,
+  EntityRef,
+  EntityRefSet,
+  pairRef,
+  singleRef,
+} from "@depmap/types";
+
+// useSelection
+//
+// Owns plot selection state and the click/multiselect handlers. Encodes
+// each selected point as an EntityRef — `"single"` for plain plots,
+// `"pair"` for expanded plots — so that an expanded plot can distinguish
+// between (model, transcript_A) and (model, transcript_B) instead of
+// collapsing both to the model id.
+//
+// The pair-vs-single dispatch is based on `data.expansions`: when the
+// response carries at least one expansion, point identity is the pair;
+// otherwise it's the index id alone. Plot components consume this hook
+// uniformly and don't need to branch on expansion presence themselves.
+//
+// Selection state is `EntityRefSet | null`, where the `null` state is
+// meaningfully distinct from an empty set:
+//   - `null` — no selection mode active (the panel can show
+//     "set selection from a context"; the plot shows no selection
+//     overlay).
+//   - empty `EntityRefSet` — user is in a selection mode but has nothing
+//     currently selected (e.g. just cleared an explicit selection).
+//   - non-empty `EntityRefSet` — the obvious case.
+// Callers that need to dismiss the selection state entirely call
+// `clearSelection()`; callers that want an empty-but-active selection
+// pass `new EntityRefSet()` to `setSelection`.
+//
+// Behavior:
+//   - handleClickPoint(i, ctrl=false): replaces selection with just
+//     point i. Matches existing behavior across all three plot types.
+//   - handleClickPoint(i, ctrl=true): toggles point i in the existing
+//     selection (or starts a new selection containing i if `null`).
+//   - handleMultiselect(indices): replaces selection with the given
+//     points. No-op when indices is empty (matches existing behavior).
+//
+// What this hook deliberately doesn't do:
+//   - Label conversion. GeneTea and other consumers that want display
+//     labels rather than ids should derive them at the call site from
+//     `data` and `selection`. Selection identity is structural (ids);
+//     labels are presentation.
+//   - Panel rendering. The selection panel is its own component;
+//     this hook only provides the data it consumes.
+//   - Persistence. Selection is in-component state; if it ever needs
+//     to round-trip through URL or storage, EntityRefSet.toJSON /
+//     fromJSON are the right primitives but a different layer would
+//     drive them.
+export default function useSelection(
+  data: DataExplorerPlotResponse | null
+) {
+  const [selection, setSelection] = useState<EntityRefSet | null>(null);
+
+  const selectedPoints = useMemo(() => {
+    const out = new Set<number>();
+    if (!data?.index_ids || !selection) {
+      return out;
+    }
+
+    for (let i = 0; i < data.index_ids.length; i += 1) {
+      if (selection.has(refForPoint(data, i))) {
+        out.add(i);
+      }
+    }
+    return out;
+  }, [data, selection]);
+
+  const handleClickPoint = useCallback(
+    (pointIndex: number, ctrlKey: boolean) => {
+      if (!data) {
+        return;
+      }
+      const ref = refForPoint(data, pointIndex);
+
+      if (ctrlKey) {
+        // Toggle within the existing selection. If selection is null
+        // (the "no selection mode active" state), the toggle starts a
+        // new selection containing just this point — matching the
+        // pre-refactor behavior where ctrl-clicking from a null state
+        // initialized a Set.
+        setSelection((current) => {
+          const base = current ?? new EntityRefSet();
+          return base.has(ref) ? base.delete(ref) : base.add(ref);
+        });
+      } else {
+        // Replace selection with just this one point.
+        setSelection(new EntityRefSet([ref]));
+      }
+    },
+    [data]
+  );
+
+  const handleMultiselect = useCallback(
+    (pointIndices: number[]) => {
+      if (!data || pointIndices.length === 0) {
+        return;
+      }
+      const refs: EntityRef[] = pointIndices.map((i) => refForPoint(data, i));
+      setSelection(new EntityRefSet(refs));
+    },
+    [data]
+  );
+
+  const clearSelection = useCallback(() => {
+    setSelection(null);
+  }, []);
+
+  return {
+    selection,
+    selectedPoints,
+    handleClickPoint,
+    handleMultiselect,
+    setSelection,
+    clearSelection,
+  };
+}
+
+// Build the EntityRef for the point at `pointIndex` in `data`. Single-ref
+// for plain plots, pair-ref for expanded plots. The MVP "at most one
+// expansion" constraint lets us index `expansions[0]` safely; if/when
+// expand_by ever supports multiple expansions, EntityRef will need to
+// grow a third variant (or carry an array of expansion ids) and this
+// helper will follow.
+//
+// Structural cast on the expansion shape — keeps this module free of a
+// dependency on the deeper expanded-plot type machinery in
+// services/dataExplorerAPI. The same pattern is used elsewhere in the
+// renderer where we want a narrow, optional read on the expansion data.
+function refForPoint(
+  data: DataExplorerPlotResponse,
+  pointIndex: number
+): EntityRef {
+  const indexId = data.index_ids[pointIndex];
+  const expansions = (data as { expansions?: { ids: string[] }[] }).expansions;
+  if (expansions && expansions.length > 0) {
+    return pairRef(indexId, expansions[0].ids[pointIndex]);
+  }
+  return singleRef(indexId);
+}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/reducers/plotConfigReducer.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/reducers/plotConfigReducer.ts
@@ -10,6 +10,14 @@ import {
   PartialDataExplorerPlotConfig,
   SliceQuery,
 } from "@depmap/types";
+import { isExpansionDimension } from "../../../utils/misc";
+
+// Default fan-out bound seeded onto a new expansion when the caller doesn't
+// supply one. Kept here as the single source of that default. Set
+// conservatively: transcript-level data is heavy, and 9 renders as a tidy 3×3
+// small-multiples grid. A separate hard ceiling (MAX_EXPANSION_MEMBERS) is
+// enforced independently at the materializer.
+export const DEFAULT_EXPANSION_LIMIT = 9;
 
 export type PlotConfigReducerAction =
   | { type: "set_plot"; payload: PartialDataExplorerPlotConfig }
@@ -30,6 +38,10 @@ export type PlotConfigReducerAction =
       };
     }
   | { type: "select_color_by"; payload: DataExplorerPlotConfig["color_by"] }
+  | {
+      type: "select_group_by";
+      payload: DataExplorerPlotConfig["group_by"] | null;
+    }
   | { type: "select_sort_by"; payload: DataExplorerPlotConfig["sort_by"] }
   | {
       type: "select_color_property";
@@ -50,6 +62,29 @@ export type PlotConfigReducerAction =
         slice_label: string;
         slice_type: string;
         given_id: string;
+      };
+    }
+  | {
+      type: "select_expansion";
+      payload: {
+        // Which dimension reads the per-pair value (the expanding axis).
+        key: DimensionKey;
+        // The expansion to apply, or null to clear it. `limit` is optional in
+        // the payload; the reducer seeds DEFAULT_EXPANSION_LIMIT when absent.
+        expand_by: {
+          slice_type: string;
+          context: DataExplorerContextV2;
+          limit?: number;
+          // Pagination window start (0-based). Optional; the reducer defaults
+          // it to 0 when absent.
+          offset?: number;
+          // Dataset the reading axis reads its per-pair values from. Required:
+          // enabling repoints the axis at this expansion's slice_type, so the
+          // dataset must be named explicitly. Inheriting a dataset_id from a
+          // differently-shaped axis (e.g. a gene-level dataset under a
+          // transcript expansion) would silently read the wrong matrix.
+          dataset_id: string;
+        } | null;
       };
     }
   // Use this to dispatch multiple actions as if
@@ -101,6 +136,18 @@ const normalize = (plot: PartialDataExplorerPlotConfig) => {
 
   if (plot.plot_type !== "density_1d" && plot.plot_type !== "waterfall") {
     nextPlot = omit(nextPlot, "sort_by");
+  }
+
+  // Keep `expand_by` only while it's non-empty AND some dimension still carries
+  // the expansion sentinel. Overwriting the expanding axis with a plain
+  // dimension orphans the sentinel, so this drops `expand_by` on its own — no
+  // caller-side bookkeeping or action ordering required.
+  const hasExpansionAxis = Object.values(plot.dimensions ?? {}).some((dim) =>
+    isExpansionDimension(dim)
+  );
+
+  if (!plot.expand_by || plot.expand_by.length === 0 || !hasExpansionAxis) {
+    nextPlot = omit(nextPlot, "expand_by");
   }
 
   return nextPlot;
@@ -264,13 +311,13 @@ function plotConfigReducer(
     case "select_dimension": {
       const { key, dimension } = action.payload;
 
-      return {
+      return normalize({
         ...plot,
         dimensions: {
           ...plot.dimensions,
           [key]: dimension,
         },
-      };
+      });
     }
 
     case "select_filter": {
@@ -308,6 +355,22 @@ function plotConfigReducer(
         dimensions,
         filters: visibleFilter ? { visible: visibleFilter } : {},
         metadata: {},
+      });
+    }
+
+    case "select_group_by": {
+      // Unlike select_color_by, this does NOT reset filters/metadata/sort —
+      // group_by is an axis independent of color, so changing it must not
+      // clobber color's state. Clearing (null/undefined payload) omits the
+      // field entirely; the renderers' `group_by ?? color_by` coupling then
+      // takes over (group by color in the 1D plots, ungroup in scatter).
+      if (!action.payload) {
+        return normalize(omit(plot, "group_by"));
+      }
+
+      return normalize({
+        ...plot,
+        group_by: action.payload,
       });
     }
 
@@ -435,6 +498,58 @@ function plotConfigReducer(
           },
         },
       };
+    }
+
+    case "select_expansion": {
+      const { key, expand_by } = action.payload;
+
+      // Clear: drop the expansion and revert the reading axis off the sentinel.
+      // We don't stash the pre-expansion dimension, so this resets `aggregation`
+      // to a plain default rather than restoring prior state; `slice_type` and
+      // `context` are left as-is. normalize() strips the now-empty `expand_by`.
+      if (expand_by === null) {
+        const dimension = plot.dimensions?.[key];
+        const dimensions = { ...plot.dimensions };
+
+        if (dimension) {
+          dimensions[key] = { ...dimension, aggregation: "mean" };
+        }
+
+        return normalize({ ...plot, expand_by: [], dimensions });
+      }
+
+      // Enable: record the expansion (seeding a default limit) and reshape the
+      // reading axis so (a) fetchExpandedPlot routes it as the expanding axis —
+      // it matches on `axis_type: "aggregated_slice"` and `slice_type` equal to
+      // the expansion's — and (b) it carries the "expansion" sentinel on
+      // `aggregation`. plot_type is intentionally left untouched: expansion is
+      // about the point set, not how it's rendered (an expanded density_1d or
+      // waterfall is valid and already fetchable).
+      const { slice_type, context, limit, dataset_id, offset } = expand_by;
+      const existing = plot.dimensions?.[key];
+
+      return normalize({
+        ...plot,
+        expand_by: [
+          {
+            slice_type,
+            context,
+            limit: limit ?? DEFAULT_EXPANSION_LIMIT,
+            offset: offset ?? 0,
+          },
+        ],
+        dimensions: {
+          ...plot.dimensions,
+          [key]: {
+            ...existing,
+            axis_type: "aggregated_slice",
+            slice_type,
+            context,
+            dataset_id,
+            aggregation: "expansion",
+          },
+        },
+      });
     }
 
     case "batch": {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/styles/ConfigurationPanel.scss
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/styles/ConfigurationPanel.scss
@@ -20,7 +20,7 @@
 }
 
 .hr {
-  margin: 16px 0;
+  margin: 16px 0 12px 0;
   border-color: #ccc;
 }
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/styles/DataExplorer2.scss
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/styles/DataExplorer2.scss
@@ -204,6 +204,20 @@
   white-space: nowrap;
 }
 
+.pairsVirtualListItem {
+  overflow: hidden;
+
+  &[data-kind="header"] > div::before {
+    content: "•";
+    margin-right: 5px;
+  }
+
+  &[data-kind="member"] > div::before {
+    content: "◦";
+    margin-right: 5px;
+  }
+}
+
 .plotSelectionsButtons {
   display: flex;
   flex-direction: column;
@@ -219,6 +233,10 @@
     margin-top: 5px;
     margin-left: 2px;
   }
+}
+
+.seeTableButton {
+  margin-top: 10px;
 }
 
 .plotSelectionsContent {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/styles/ScatterPlot.scss
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/styles/ScatterPlot.scss
@@ -1,10 +1,3 @@
-// We use css to hide Plotly's toolbar (instead of configuring it not to have
-// one) so we can still dispatch clicks on its buttons (the only way to trigger
-// a zoom).
-.ScatterPlot :global .modebar {
-  display: none;
-}
-
 .ScatterPlot :global {
   .infolayer {
     -webkit-font-smoothing: subpixel-antialiased;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/utils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/utils.ts
@@ -322,6 +322,16 @@ function normalizePlot(plot: DataExplorerPlotConfig) {
       normalized.use_clustering = true;
     }
   } else {
+    // `color_by: "expansion"` colors points by their expansion member and is
+    // backed by `expand_by` (which rides through untouched in `rest`), not by a
+    // color dimension/filter/metadata. The branches below only re-add `color_by`
+    // when one of those backings is complete, so without this an expanded plot
+    // would silently lose its coloring on normalize. Preserve it whenever the
+    // plot is actually expanded.
+    if (color_by === "expansion" && Boolean(rest.expand_by?.length)) {
+      normalized.color_by = color_by;
+    }
+
     if ((color_by && filters?.color1) || filters?.color2) {
       normalized.color_by = color_by;
       normalized.filters = filters;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/AllSelectsContainer.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/AllSelectsContainer.tsx
@@ -56,7 +56,11 @@ function AllSelectsContainer({
   }
 
   return (
-    <div ref={div} className={cx(styles.DimensionSelect, className)}>
+    <div
+      ref={div}
+      data-dimension-select
+      className={cx(styles.DimensionSelect, className)}
+    >
       {children}
     </div>
   );

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/breadboxMethods.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/breadboxMethods.ts
@@ -27,14 +27,19 @@ import {
   serializeSliceQuery,
 } from "@depmap/selects";
 import { isContextAll } from "../../utils/context";
-import { isCompleteDimension, isSampleType, pluralize } from "../../utils/misc";
+import {
+  isCompleteDimension,
+  isExpansionDimension,
+  isSampleType,
+  pluralize,
+} from "../../utils/misc";
 import { MAX_PLOTTABLE_CATEGORIES } from "../../constants/plotConstants";
 import { fetchDatasetIdentifiers } from "./identifiers";
 import { getDimensionDataWithoutLabels } from "./helpers";
 
 type VarEqualityExpression = { "==": [{ var: string }, string] };
 
-async function fetchEntitiesLabel(dimensionType: string) {
+export async function fetchEntitiesLabel(dimensionType: string) {
   const dimensionTypes = await cached(breadboxAPI).getDimensionTypes();
   const dimType = dimensionTypes.find((t) => t.name === dimensionType);
 
@@ -43,7 +48,9 @@ async function fetchEntitiesLabel(dimensionType: string) {
     : "unknown entities";
 }
 
-async function fetchAxisLabel(dimension?: DataExplorerPlotConfigDimension) {
+export async function fetchAxisLabel(
+  dimension?: DataExplorerPlotConfigDimension
+) {
   if (!dimension || !isCompleteDimension(dimension)) {
     return "";
   }
@@ -93,7 +100,7 @@ async function fetchAxisLabel(dimension?: DataExplorerPlotConfigDimension) {
   return `${aggregation} ${units} of ${contextCount} ${context.name} ${entities}`;
 }
 
-async function fetchValueType(
+export async function fetchValueType(
   dimensionOrSliceQuery?: DataExplorerPlotConfigDimension | SliceQuery
 ) {
   if (
@@ -128,7 +135,7 @@ async function fetchValueType(
   return dataset.value_type;
 }
 
-async function fetchDatasetLabel(dataset_id?: string) {
+export async function fetchDatasetLabel(dataset_id?: string) {
   if (!dataset_id) {
     return "";
   }
@@ -159,7 +166,7 @@ const isPrimaryMetatadata = (dataset?: Dataset) => {
  * are added in priority order (user selections > extra metadata > context
  * vars) and later entries that match an already-tracked query are skipped.
  */
-function buildExtendedMetadata(
+export function buildExtendedMetadata(
   index_type: string,
   index_id_column?: string,
   metadata?: DataExplorerMetadata,
@@ -194,13 +201,13 @@ function buildExtendedMetadata(
     addIfNew("extra1", {
       dataset_id: "depmap_model_metadata",
       identifier_type: "column",
-      identifier: "OncotreePrimaryDisease",
+      identifier: "OncotreeLineage",
     });
 
     addIfNew("extra2", {
       dataset_id: "depmap_model_metadata",
       identifier_type: "column",
-      identifier: "OncotreeLineage",
+      identifier: "OncotreePrimaryDisease",
     });
   }
 
@@ -256,8 +263,9 @@ export async function fetchPlotDimensions(
   fetchDatasetLabel(dimensions.color?.dataset_id);
 
   const dimTypes = await cached(breadboxAPI).getDimensionTypes();
-  const index_id_column = dimTypes.find((t) => t.name === index_type)
-    ?.id_column;
+  const indexDimType = dimTypes.find((t) => t.name === index_type);
+  const index_id_column = indexDimType?.id_column;
+  const index_display_name = indexDimType?.display_name;
 
   const extendedMetadata = buildExtendedMetadata(
     index_type,
@@ -341,6 +349,16 @@ export async function fetchPlotDimensions(
 
   async function fetchAggregatedDimension(key: string) {
     const { aggregation, context, dataset_id, slice_type } = dimensions[key];
+
+    if (aggregation === "expansion") {
+      throw new Error(
+        `Dimension "${key}" carries the "expansion" sentinel on \`aggregation\`, ` +
+          `which is not a real aggregation — its per-pair values come from ` +
+          `fetchExpandedPlot, not from aggregating a slice. Expansion axes must ` +
+          `not be routed through the Breadbox aggregate path; this dimension was ` +
+          `mis-routed.`
+      );
+    }
 
     if (aggregation === "first" || aggregation === "correlation") {
       throw new Error(
@@ -493,6 +511,7 @@ export async function fetchPlotDimensions(
     const out = {
       index_type,
       index_id_column,
+      index_display_name,
       index_ids,
       index_labels,
       linreg_by_group: [],
@@ -784,6 +803,28 @@ export const fetchDatasetsByIndexType = memoize(async () => {
   return datasetsByIndexType;
 });
 
+// HACK (LEGACY-COMPUTATION): linear regression is a fetcher-resident
+// derivation, not a data fetch. It computes per-group least-squares fits
+// (plus Pearson/Spearman) over the materialized points. It lives here
+// because it once backed a dedicated Data Explorer endpoint; that backend
+// is gone but the computation stayed put wearing the endpoint's shape. It
+// is a function of DISPLAY state — it already groups by a categorical
+// source (color_property / categorical color dim / color1+color2 filters)
+// and already respects `visible[i]` — so it belongs in the
+// render/derivation layer, not the data layer.
+//
+// PLANNED EVOLUTION (small multiples): when scatter gains per-group small
+// multiples, this moves into the render layer as a fit recomputed per
+// panel from that panel's visible points. The only substantive change to
+// the grouping logic is swapping the category source from the
+// color-derived value seen below to `group_by ?? color_by` (categorical
+// only — a continuous color gradient is a within-panel attribute and must
+// continue to yield a single ungrouped line, never one line per bin). The
+// current single-line-per-color-group behavior is a reasonable interim:
+// in a single-panel scatter it reads as the overall trend. The legacy
+// single-line computation should also be retained as the basis for an
+// opt-in global reference line (one ungrouped fit, neutral color, drawn
+// over every panel) once small multiples exist.
 export const fetchLinearRegression = memoize(
   async (
     index_type: string,
@@ -791,6 +832,16 @@ export const fetchLinearRegression = memoize(
     filters?: DataExplorerFilters,
     metadata?: DataExplorerMetadata
   ) => {
+    if (Object.values(dimensions).some(isExpansionDimension)) {
+      throw new Error(
+        `fetchLinearRegression received a dimension carrying the "expansion" ` +
+          `sentinel. Its color-grouped fit assumes one value per index entity, ` +
+          `but an expansion axis is N×M (entity, member) pairs and is handled by ` +
+          `the faceted regression path. Expanded plots must not reach this ` +
+          `function — gate the caller on isExpansionDimension / expand_by.`
+      );
+    }
+
     const data = await fetchPlotDimensions(
       index_type,
       dimensions,
@@ -886,6 +937,20 @@ export const fetchLinearRegression = memoize(
   }
 );
 
+// HACK (LEGACY-COMPUTATION): the correlation matrix computed here (via
+// correlationMatrix, plus the optional clustering reordering) is a
+// fetcher-resident derivation, not a data fetch. Like the waterfall rank
+// and linear regression, it lives here because it once backed a dedicated
+// Data Explorer endpoint; that backend is gone but the computation stayed
+// put wearing the endpoint's shape. It belongs in the render/derivation
+// layer.
+//
+// Unlike the other two, this one is entangled with the broader
+// correlation_heatmap design, which is itself regretted (it abused shared
+// response fields by reinterpreting their semantics rather than
+// introducing named structural concepts — see the correlation_heatmap
+// plot_type). Don't extract this in isolation; it should move as part of
+// reworking correlation_heatmap, not before.
 const correlateDimension = memoize(
   async (
     dimension: DataExplorerPlotConfigDimension,
@@ -1064,12 +1129,14 @@ export async function fetchCorrelation(
     : [null];
 
   const dimTypes = await cached(breadboxAPI).getDimensionTypes();
-  const index_id_column = dimTypes.find((t) => t.name === index_type)
-    ?.id_column;
+  const indexDimType = dimTypes.find((t) => t.name === index_type);
+  const index_id_column = indexDimType?.id_column;
+  const index_display_name = indexDimType?.display_name;
 
   return {
     index_type,
     index_id_column,
+    index_display_name,
     index_ids: ids,
     index_labels: labels,
     dimensions: x2 ? { x, x2 } : { x },
@@ -1084,6 +1151,16 @@ export async function fetchWaterfall(
   filters?: DataExplorerFilters,
   metadata?: DataExplorerMetadata
 ): Promise<DataExplorerPlotResponse> {
+  // HACK (LEGACY-COMPUTATION): this entire function is a fetcher-resident
+  // derivation, not a data fetch. It sorts the index by (category, value),
+  // reprojects positions into a synthetic "rank" x dimension, and remaps
+  // the config's x onto y. None of that is identity or values — it's
+  // plottable geometry, and it depends on display concerns (sort order,
+  // grouping). It lives here because it once backed a dedicated Data
+  // Explorer endpoint; that backend is gone but the computation stayed put
+  // wearing the endpoint's shape. It belongs in the render/derivation
+  // layer. Fine to leave until something forces a change here; when that
+  // happens, prefer moving it out over extending it in place.
   const unsortedData = await fetchPlotDimensions(
     index_type,
     dimensions,
@@ -1199,6 +1276,7 @@ export async function fetchWaterfall(
   return {
     index_type,
     index_id_column: unsortedData.index_id_column,
+    index_display_name: unsortedData.index_display_name,
     index_ids: sortedIndexIds,
     index_labels: sortedLabels,
     dimensions: sortedDimensions,

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/expandedPlot.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/expandedPlot.ts
@@ -1,0 +1,868 @@
+import { breadboxAPI, cached } from "@depmap/api";
+import {
+  DataExplorerContextV2,
+  DataExplorerContextVariable,
+  DataExplorerExpandedPlotConfig,
+  DataExplorerExpandedPlotResponse,
+  DataExplorerPlotConfigDimension,
+  DataExplorerPlotResponse,
+  DataExplorerPlotResponseDimension,
+  FilterKey,
+  isValidSliceQuery,
+  SliceQuery,
+} from "@depmap/types";
+import {
+  buildDimTypeMap,
+  buildTablesByDim,
+  resolveDisplayLabel,
+} from "@depmap/selects";
+import { isCompleteDimension, isSampleType } from "../../utils/misc";
+import { MAX_PLOTTABLE_CATEGORIES } from "../../constants/plotConstants";
+import { fetchDatasetIdentifiers } from "./identifiers";
+import { getDimensionDataWithoutLabels } from "./helpers";
+import {
+  buildExtendedMetadata,
+  fetchAxisLabel,
+  fetchDatasetLabel,
+  fetchPlotDimensions,
+  fetchValueType,
+} from "./breadboxMethods";
+
+// ---------------------------------------------------------------------------
+// fetchExpandedPlot
+//
+// The materializer for the expansion feature. Sibling of fetchPlotDimensions
+// for plots where each data point represents a pair
+// (index_type × expand_by.slice_type) instead of a single index entity.
+// Primary use case: gene/transcript, where each (depmap_model, transcript)
+// cell gets its own point.
+//
+// Response is the existing DataExplorerPlotResponse shape with arrays widened
+// from length N to length N×M (index-major: model_1×{t_1..t_M},
+// model_2×{t_1..t_M}, …), plus a new top-level `expansions` field carrying
+// the per-cell expansion ids and labels as parallel arrays.
+//
+// All internal keying is by id. Pair keys are derived from
+// `(index_id, expansion_id)`. Labels are projected from ids at the very end
+// using the same reverse-map pattern fetchPlotDimensions uses.
+//
+// Scope boundaries (deliberate, tracked):
+//   - At most one expansion today; 2+ is rejected. The slot type is already an
+//     array (DataExplorerExpandBy[]), and datasets like drug-dose-replicate
+//     would naturally want N×M×P; whether a comprehensible UX exists for that
+//     is an open question, so multi-expansion is deferred pending
+//     investigation rather than ruled in or out.
+//   - Broadcast (non-expanded) dimensions must use axis_type
+//     "aggregated_slice". A raw_slice broadcast path is not yet implemented.
+//   - Metadata handling duplicates fetchPlotDimensions' loop rather than
+//     factoring out a shared helper. Extracting one is a tracked cleanup.
+// ---------------------------------------------------------------------------
+
+// Hard ceiling on expansion members, enforced at materialization regardless of
+// the per-plot `expand_by.limit`. A safety backstop so an over-large limit (or
+// a hand-crafted config) can't fan a plot out far enough to wedge the browser.
+// Matches the conservative default; 9 is a tidy 3×3 small-multiples grid.
+export const MAX_EXPANSION_MEMBERS = 16;
+
+// ---------------------------------------------------------------------------
+// fetchExpandedPlot
+// ---------------------------------------------------------------------------
+
+export async function fetchExpandedPlot(
+  config: DataExplorerExpandedPlotConfig
+): Promise<DataExplorerExpandedPlotResponse> {
+  const { index_type, dimensions, expand_by, filters, metadata } = config;
+
+  // Zero-expansion case: degenerate to the non-expanded fetcher and tag on
+  // an empty `expansions` array. Lets callers avoid special-casing the
+  // "I might or might not expand" decision at the call site.
+  if (expand_by.length === 0) {
+    const base = await fetchPlotDimensions(
+      index_type,
+      dimensions,
+      filters,
+      metadata
+    );
+    return { ...base, expansions: [] };
+  }
+
+  if (expand_by.length > 1) {
+    throw new Error(
+      `fetchExpandedPlot currently supports at most one expansion; ` +
+        `got ${expand_by.length}. Multi-expansion is deferred.`
+    );
+  }
+
+  const [exp] = expand_by;
+
+  // Pre-fetch (cached postJson) data we'll need below, in parallel.
+  cached(breadboxAPI).getDimensionTypes();
+  cached(breadboxAPI).getDatasets();
+  fetchDatasetLabel(dimensions.x?.dataset_id);
+  fetchDatasetLabel(dimensions.y?.dataset_id);
+  fetchDatasetLabel(dimensions.color?.dataset_id);
+
+  const dimTypes = await cached(breadboxAPI).getDimensionTypes();
+  const indexDimType = dimTypes.find((t) => t.name === index_type);
+  const expansionDimType = dimTypes.find((t) => t.name === exp.slice_type);
+  const index_id_column = indexDimType?.id_column;
+  const index_display_name = indexDimType?.display_name;
+  const expansion_id_column = expansionDimType?.id_column;
+  const expansion_display_name = expansionDimType?.display_name;
+
+  // Resolve the expansion list once. For gene/transcript this is e.g.
+  // "transcripts of CD44" → ids + labels of length M.
+  const { ids: allExpIds, labels: allExpLabels } = await cached(
+    breadboxAPI
+  ).evaluateContext(exp.context);
+
+  if (allExpIds.length === 0) {
+    throw new Error(
+      `Expansion context "${exp.context.name}" produced no ` +
+        `${exp.slice_type} identifiers.`
+    );
+  }
+
+  // Enforce the expansion bound *before* anything downstream, so we only query
+  // Breadbox for the members we keep. `exp.limit` is the per-plot cap (UI-
+  // seeded); MAX_EXPANSION_MEMBERS is the hard ceiling that holds regardless.
+  // Truncation is arbitrary (first-N in context order) for now; selecting the
+  // "most interesting" members is a planned follow-up.
+  const totalExpansionMembers = allExpIds.length;
+  const expansionCap = Math.min(exp.limit, MAX_EXPANSION_MEMBERS);
+  const expansionTruncated = totalExpansionMembers > expansionCap;
+  // Pagination window: members [offset, offset + cap) in context order. The
+  // offset is clamped defensively so a stale/out-of-range config can't slice
+  // past the end; the UI only ever sends page-aligned offsets.
+  const expansionOffset = Math.min(
+    Math.max(0, exp.offset ?? 0),
+    Math.max(0, totalExpansionMembers - 1)
+  );
+  const expIds = allExpIds.slice(
+    expansionOffset,
+    expansionOffset + expansionCap
+  );
+  const expLabels = allExpLabels.slice(
+    expansionOffset,
+    expansionOffset + expansionCap
+  );
+
+  // Map from expansion id to its display label, for use during materialization.
+  const expIdToLabel: Record<string, string> = {};
+  for (let j = 0; j < expIds.length; j += 1) {
+    expIdToLabel[expIds[j]] = expLabels[j];
+  }
+
+  const extendedMetadata = buildExtendedMetadata(
+    index_type,
+    index_id_column,
+    metadata,
+    filters
+  );
+
+  const dimensionKeys = Object.keys(dimensions).filter((k) =>
+    isCompleteDimension(dimensions[k])
+  );
+
+  const filterKeys = Object.keys(filters || {}) as FilterKey[];
+  const metadataKeys = Object.keys(extendedMetadata);
+
+  // A dimension expands when its slice_type matches the expansion's, AND
+  // it's an aggregated_slice (i.e. its context resolves to many ids that
+  // we'd normally aggregate). A raw_slice transcript dimension picks one
+  // specific transcript and is broadcast like any other singleton value.
+  const isExpanding = (k: string) =>
+    dimensions[k].axis_type === "aggregated_slice" &&
+    dimensions[k].slice_type === exp.slice_type;
+
+  const expandedKeys = dimensionKeys.filter(isExpanding);
+  const broadcastKeys = dimensionKeys.filter((k) => !isExpanding(k));
+
+  // Shared state. Same pattern as fetchPlotDimensions: every fetcher
+  // populates these; the canonical index is derived from them at the end.
+  // Both are keyed/valued by ids throughout — the labels are looked up at
+  // materialization via labelToIdMapping's inverse.
+  const uniqueLabels = new Set<string>();
+  const labelToIdMapping: Record<string, string> = {};
+
+  // ------------------------------------------------------------------
+  // Expanded dimension fetcher.
+  // Pulls a matrix slice over the resolved expansion ids WITHOUT
+  // aggregating, and returns values keyed by [indexId][expansionId].
+  // ------------------------------------------------------------------
+  async function fetchExpandedDimension(key: string) {
+    const dim = dimensions[key];
+    const { dataset_id, slice_type } = dim;
+
+    const sliceIsSampleType = await isSampleType(slice_type);
+    const indexIdentifiers = await fetchDatasetIdentifiers(
+      index_type,
+      dataset_id
+    );
+
+    const response = await cached(breadboxAPI).getMatrixDatasetData(
+      dataset_id,
+      {
+        sample_identifier: "id",
+        feature_identifier: "id",
+        samples: sliceIsSampleType ? expIds : null,
+        features: sliceIsSampleType ? null : expIds,
+      }
+    );
+
+    // Matrix responses are always Record<feature_id, Record<sample_id, value>>:
+    //   - expansion-on-feature-axis: response[expId][indexId]
+    //   - expansion-on-sample-axis:  response[indexId][expId]
+    const lookup = (indexId: string, expId: string): number | null => {
+      if (sliceIsSampleType) {
+        return response[indexId]?.[expId] ?? null;
+      }
+      return response[expId]?.[indexId] ?? null;
+    };
+
+    const indexed_values: Record<string, Record<string, number | null>> = {};
+
+    indexIdentifiers.forEach(({ id, label }) => {
+      uniqueLabels.add(label);
+      labelToIdMapping[label] = id;
+
+      const inner: Record<string, number | null> = {};
+      for (let j = 0; j < expIds.length; j += 1) {
+        inner[expIds[j]] = lookup(id, expIds[j]);
+      }
+      indexed_values[id] = inner;
+    });
+
+    return {
+      property: "dimensions" as const,
+      kind: "expanded" as const,
+      key,
+      indexed_values,
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Broadcast (non-expanded) dimension fetcher.
+  //
+  // For broadcast dimensions every (index, expansion) point shares the
+  // same value at a given index, so the fetcher only needs to produce
+  // one value per index id. The materialization loop later replicates
+  // each value M times to fill the N×M shape.
+  //
+  // Today two `axis_type` values reach this path:
+  //   - "raw_slice":        a single named column from the dataset
+  //                         (e.g. one gene's expression). Mirrors
+  //                         fetchRawDimension in breadboxMethods.ts.
+  //   - "aggregated_slice": a context resolved against a slice and
+  //                         reduced to one value per index entity.
+  //                         Mirrors fetchAggregatedDimension.
+  //
+  // The structure parallels fetchPlotDimensions's raw_slice /
+  // aggregated_slice dispatch, but the helpers here are scoped to the
+  // expanded path so they can pick up its shared state (uniqueLabels,
+  // labelToIdMapping) without that being a contract on the upstream
+  // helpers.
+  // ------------------------------------------------------------------
+  async function fetchBroadcastDimension(key: string) {
+    const dim = dimensions[key];
+
+    // Each helper returns the per-id values; the wrapper handles the
+    // shared label-side-effect and the response envelope so that the
+    // two paths can never silently diverge on the post-fetch shape.
+    const { indexIdentifiers, indexed_values } =
+      dim.axis_type === "raw_slice"
+        ? await fetchBroadcastRawSliceValues(dim)
+        : await fetchBroadcastAggregatedSliceValues(dim);
+
+    // Side effect: register this dimension's labels into the shared
+    // logical-index map. Done here (after the fetch) so both helpers
+    // contribute consistently without each having to remember to do
+    // it. Same writes the expanded-dimension fetcher performs.
+    indexIdentifiers.forEach(({ id, label }) => {
+      uniqueLabels.add(label);
+      labelToIdMapping[label] = id;
+    });
+
+    return {
+      property: "dimensions" as const,
+      kind: "broadcast" as const,
+      key,
+      indexed_values,
+    };
+  }
+
+  // Raw-slice broadcast helper. Pulls a single named column from the
+  // dataset via `getDimensionDataWithoutLabels`, then keys the result
+  // by index id. Caching: prefer this primitive over a filtered
+  // tabular fetch because Breadbox's slice fetches cache cleanly today
+  // while the tabular fetcher doesn't yet register cacheable slices.
+  async function fetchBroadcastRawSliceValues(
+    dim: DataExplorerPlotConfigDimension
+  ): Promise<{
+    indexIdentifiers: { id: string; label: string }[];
+    indexed_values: Record<string, number | string | string[] | null>;
+  }> {
+    const { context, dataset_id, slice_type } = dim;
+
+    const indexIdentifiers = await fetchDatasetIdentifiers(
+      index_type,
+      dataset_id
+    );
+
+    // Mirror fetchRawDimension's expression decoding. The dim's
+    // context for raw_slice is always a single equality:
+    //   { "==": [{ var: "..." }, identifier] }
+    // identifier_type tells Breadbox which axis the identifier names.
+    // For raw_slice the slice is on the "other" axis from the index —
+    // so when slice_type is sample-typed, the identifier picks out a
+    // sample column; otherwise it picks out a feature column.
+    type VarEqualityExpression = {
+      "==": [{ var: string }, string];
+    };
+    const [variable, identifier] = (context.expr as VarEqualityExpression)[
+      "=="
+    ];
+
+    const sliceTypeIsSampleType = await isSampleType(slice_type);
+    // De-nested from a nested ternary (no-nested-ternary). entity_label on a
+    // non-depmap_model slice reads as a *label*; everything else as an *id*.
+    const isEntityLabel =
+      variable.var === "entity_label" && slice_type !== "depmap_model";
+    const labelIdentifierType = sliceTypeIsSampleType
+      ? "sample_label"
+      : "feature_label";
+    const idIdentifierType = sliceTypeIsSampleType ? "sample_id" : "feature_id";
+    const identifier_type = isEntityLabel
+      ? labelIdentifierType
+      : idIdentifierType;
+
+    const { ids, values } = await getDimensionDataWithoutLabels({
+      dataset_id,
+      identifier,
+      identifier_type,
+    });
+
+    const indexed_values: Record<
+      string,
+      number | string | string[] | null
+    > = {};
+    for (let i = 0; i < ids.length; i += 1) {
+      indexed_values[ids[i]] = values[i];
+    }
+
+    return { indexIdentifiers, indexed_values };
+  }
+
+  // Aggregated-slice broadcast helper. Resolves the context to a set
+  // of slice-axis ids, then asks Breadbox to aggregate the matrix
+  // along the slice axis into one value per index entity.
+  async function fetchBroadcastAggregatedSliceValues(
+    dim: DataExplorerPlotConfigDimension
+  ): Promise<{
+    indexIdentifiers: { id: string; label: string }[];
+    indexed_values: Record<string, number | null>;
+  }> {
+    const { dataset_id, slice_type, context } = dim;
+
+    const { aggregation } = dim;
+    if (aggregation === "expansion") {
+      throw new Error(
+        `A dimension carrying the "expansion" sentinel on \`aggregation\` reached ` +
+          `fetchBroadcastAggregatedSliceValues. "expansion" is not a real ` +
+          `aggregation — expansion axes are materialized per-pair elsewhere in ` +
+          `fetchExpandedPlot and must not be broadcast through the Breadbox ` +
+          `aggregate path.`
+      );
+    }
+    if (aggregation === "first" || aggregation === "correlation") {
+      throw new Error(
+        `aggregation "${aggregation}" is not supported by Breadbox.`
+      );
+    }
+
+    const aggregate_by = (await isSampleType(slice_type))
+      ? "samples"
+      : "features";
+
+    let ctxIds: string[] = [];
+    try {
+      const result = await cached(breadboxAPI).evaluateContext(
+        (context as unknown) as DataExplorerContextV2
+      );
+      ctxIds = result.ids;
+    } catch (e) {
+      window.dispatchEvent(
+        new CustomEvent("dx2_context_eval_failed", { detail: context })
+      );
+      throw e;
+    }
+
+    const indexIdentifiers = await fetchDatasetIdentifiers(
+      index_type,
+      dataset_id
+    );
+
+    const response = await cached(breadboxAPI).getMatrixDatasetData(
+      dataset_id,
+      {
+        sample_identifier: "id",
+        feature_identifier: "id",
+        samples: aggregate_by === "samples" ? ctxIds : null,
+        features: aggregate_by === "features" ? ctxIds : null,
+        aggregate: { aggregate_by, aggregation },
+      }
+    );
+
+    const indexed_values: Record<string, number | null> = {};
+    indexIdentifiers.forEach(({ id }) => {
+      indexed_values[id] = response[aggregation]?.[id] ?? null;
+    });
+
+    return { indexIdentifiers, indexed_values };
+  }
+
+  // ------------------------------------------------------------------
+  // Filter fetcher (broadcast).
+  // ------------------------------------------------------------------
+  async function fetchFilterValues(filterKey: FilterKey) {
+    const filter = (filters![filterKey] as unknown) as DataExplorerContextV2;
+
+    try {
+      const result = await cached(breadboxAPI).evaluateContext(filter);
+
+      const indexed_values: Record<string, true> = {};
+      for (let i = 0; i < result.ids.length; i += 1) {
+        indexed_values[result.ids[i]] = true;
+      }
+
+      return {
+        property: "filters" as const,
+        key: filterKey,
+        name: filter.name,
+        indexed_values,
+      };
+    } catch (e) {
+      window.dispatchEvent(
+        new CustomEvent("dx2_context_eval_failed", { detail: filter })
+      );
+      throw e;
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Metadata fetcher (broadcast). Mirrors the metadata branch of
+  // fetchPlotDimensions: fetch via getDimensionDataWithoutLabels, derive
+  // value_type, run the isBinaryish coercion, then return N-keyed values.
+  // The color_property continuous→color promotion is applied during
+  // materialization (after we know N).
+  // ------------------------------------------------------------------
+  async function fetchMetadataValues(metadataKey: string) {
+    const sliceQuery = extendedMetadata[metadataKey] as SliceQuery;
+    const data = await getDimensionDataWithoutLabels(sliceQuery);
+    let value_type = await fetchValueType(sliceQuery);
+
+    const indexed_values: Record<string, string | number | null> = {};
+    const distinct = new Set<unknown>();
+
+    for (let i = 0; i < data.values.length; i += 1) {
+      const id = data.ids[i];
+      const v = data.values[i];
+      indexed_values[id] = v as string | number | null;
+
+      if (v) {
+        if (Array.isArray(v)) {
+          v.forEach((vv) => distinct.add(vv));
+        } else {
+          distinct.add(v);
+        }
+      }
+    }
+
+    if (
+      value_type !== "continuous" &&
+      metadataKey === "color_property" &&
+      distinct.size > MAX_PLOTTABLE_CATEGORIES
+    ) {
+      window.console.error(extendedMetadata[metadataKey]);
+      throw new Error("Too many distinct categorical values to plot!");
+    }
+
+    const isBinaryish =
+      distinct.size <= 3 &&
+      [...distinct].every((n) => n === 0 || n === 1 || n === 2);
+    if (isBinaryish) {
+      value_type = "categorical";
+    }
+
+    return {
+      property: "metadata" as const,
+      key: metadataKey,
+      sliceQuery,
+      value_type,
+      indexed_values,
+    };
+  }
+
+  // ------------------------------------------------------------------
+  // Fire all fetches concurrently.
+  // ------------------------------------------------------------------
+  const [
+    expandedResults,
+    broadcastResults,
+    filterResults,
+    metadataResults,
+  ] = await Promise.all([
+    Promise.all(expandedKeys.map(fetchExpandedDimension)),
+    Promise.all(broadcastKeys.map(fetchBroadcastDimension)),
+    Promise.all(filterKeys.map(fetchFilterValues)),
+    Promise.all(metadataKeys.map(fetchMetadataValues)),
+  ]);
+
+  // ------------------------------------------------------------------
+  // Build the canonical index (index-major cross product).
+  //
+  // Identity is `index_ids` (the post-refactor contract); labels are
+  // derived in lockstep via labelToIdMapping's inverse. Inside this
+  // loop, index_ids[i*M+j] is the same for all j (model repeats), and
+  // expansion ids[i*M+j] is the same for all i (transcripts cycle).
+  // ------------------------------------------------------------------
+  const logicalLabels = [...uniqueLabels];
+  const logicalIds = logicalLabels.map((label) => labelToIdMapping[label]);
+
+  const N = logicalIds.length;
+  const M = expIds.length;
+  const NM = N * M;
+
+  const index_ids: string[] = new Array(NM);
+  const index_labels: string[] = new Array(NM);
+  const expansionIdsFlat: string[] = new Array(NM);
+  const expansionLabelsFlat: string[] = new Array(NM);
+
+  for (let i = 0; i < N; i += 1) {
+    for (let j = 0; j < M; j += 1) {
+      const flat = i * M + j;
+      index_ids[flat] = logicalIds[i];
+      index_labels[flat] = logicalLabels[i];
+      expansionIdsFlat[flat] = expIds[j];
+      expansionLabelsFlat[flat] = expLabels[j];
+    }
+  }
+
+  // ------------------------------------------------------------------
+  // Materialize.
+  // ------------------------------------------------------------------
+  const out: DataExplorerExpandedPlotResponse = {
+    index_type,
+    index_id_column,
+    index_display_name,
+    index_ids,
+    index_labels,
+    dimensions: {} as DataExplorerExpandedPlotResponse["dimensions"],
+    filters: {} as DataExplorerExpandedPlotResponse["filters"],
+    metadata: {} as DataExplorerExpandedPlotResponse["metadata"],
+    expansions: [
+      {
+        slice_type: exp.slice_type,
+        id_column: expansion_id_column,
+        display_name: expansion_display_name,
+        ids: expansionIdsFlat,
+        labels: expansionLabelsFlat,
+        total_available: totalExpansionMembers,
+        truncated: expansionTruncated,
+      },
+    ],
+  };
+
+  const datasets = await cached(breadboxAPI).getDatasets();
+  const dimTypeMap = buildDimTypeMap(dimTypes);
+  const tablesByDim = buildTablesByDim(datasets);
+
+  // Build per-metadata-key id→label maps for id-based slice queries.
+  // Same pattern as fetchPlotDimensions; lets resolveDisplayLabel show
+  // the leaf entity's human label instead of a bare id.
+  const metadataIdToLabel: Record<
+    string,
+    Record<string, string> | undefined
+  > = {};
+  await Promise.all(
+    Object.entries(extendedMetadata).map(async ([key, entry]) => {
+      if (!isValidSliceQuery(entry as SliceQuery)) return;
+      const sq = entry as SliceQuery;
+      if (
+        sq.identifier_type !== "feature_id" &&
+        sq.identifier_type !== "sample_id"
+      ) {
+        return;
+      }
+      const dataset = datasets.find(
+        (d) => d.id === sq.dataset_id || d.given_id === sq.dataset_id
+      );
+      if (!dataset || dataset.format !== "matrix_dataset") return;
+      const dimTypeName =
+        sq.identifier_type === "feature_id"
+          ? dataset.feature_type_name
+          : dataset.sample_type_name;
+      if (!dimTypeName) return;
+      const identifiers = await cached(breadboxAPI).getDimensionTypeIdentifiers(
+        dimTypeName
+      );
+      metadataIdToLabel[key] = Object.fromEntries(
+        identifiers.map(({ id, label }) => [id, label])
+      );
+    })
+  );
+
+  // --- Expanded dimensions: pair-keyed lookup ---
+  await Promise.all(
+    expandedResults.map(async (r) => {
+      const dim = dimensions[r.key];
+      const ds = datasets.find(
+        (d) => d.id === dim.dataset_id || d.given_id === dim.dataset_id
+      );
+      const [units, value_type, dataset_label] = await Promise.all([
+        (async () => {
+          const u = ds && "units" in ds ? ds.units : "";
+          return u === "unitless" ? "" : u;
+        })(),
+        fetchValueType(dim),
+        fetchDatasetLabel(dim.dataset_id),
+      ]);
+
+      // The value axis describes the MEASUREMENT, not the selection.
+      // Each point is a specific (index, expansion) value — e.g. one
+      // (model, transcript) expression — not an aggregate over the
+      // expansion, so the axis names the kind of value, never the
+      // expansion's context. The expansion's identity lives on the
+      // expansion axis (hover today; per-panel labels under small
+      // multiples), which is also why this scales cleanly to M > 1:
+      // the value axis stays a single measurement name no matter how
+      // many expansion dimensions there are, rather than trying to
+      // enumerate selections it can't coherently fit.
+      //
+      // Prefer the dataset's `data_type` as a concise measurement name
+      // ("Expression"); fall back to the dataset display name when
+      // data_type is absent so the label is never empty. Units in
+      // parens, matching the convention used elsewhere in this file.
+      const measurement = ds?.data_type || dataset_label || "";
+      const axis_label = measurement + (units ? ` (${units})` : "");
+
+      const values: (number | null)[] = new Array(NM);
+      for (let i = 0; i < N; i += 1) {
+        const inner = r.indexed_values[logicalIds[i]] || {};
+        for (let j = 0; j < M; j += 1) {
+          values[i * M + j] = inner[expIds[j]] ?? null;
+        }
+      }
+
+      out.dimensions[r.key as keyof DataExplorerPlotResponse["dimensions"]] = {
+        slice_type: dim.slice_type,
+        dataset_id: dim.dataset_id,
+        axis_label,
+        dataset_label,
+        // fetchValueType widens to `string | null` (it also serves non-matrix
+        // col_type lookups); narrow back to the response union here, as the
+        // metadata branch below already does.
+        value_type: value_type as DataExplorerPlotResponseDimension["value_type"],
+        values: values as number[],
+      };
+    })
+  );
+
+  // --- Broadcast dimensions: id-keyed lookup, replicated M times ---
+  await Promise.all(
+    broadcastResults.map(async (r) => {
+      const dim = dimensions[r.key];
+      const [axis_label, value_type, dataset_label] = await Promise.all([
+        fetchAxisLabel(dim),
+        fetchValueType(dim),
+        fetchDatasetLabel(dim.dataset_id),
+      ]);
+
+      // Broadcast values can now be non-numeric — raw_slice can carry
+      // strings or string arrays (e.g. for categorical columns). For
+      // numeric value_types this is still effectively `(number | null)[]`;
+      // the wider type accommodates the categorical/text cases without
+      // forcing every consumer of the response to handle them yet. The
+      // downstream renderer's expectations are unchanged for now —
+      // when something hands a string-valued raw_slice to a scatter's
+      // x or y, that's a config-level mistake we'll catch with a
+      // separate, more informative error than letting it silently
+      // fall through.
+      type BroadcastValue = number | string | string[] | null;
+      const values: BroadcastValue[] = new Array(NM);
+      for (let i = 0; i < N; i += 1) {
+        const v: BroadcastValue = r.indexed_values[logicalIds[i]] ?? null;
+        for (let j = 0; j < M; j += 1) {
+          values[i * M + j] = v;
+        }
+      }
+
+      // color dim isBinaryish coercion (matches fetchPlotDimensions).
+      let vt = value_type;
+      if (r.key === "color") {
+        const distinct = new Set(values.filter((v) => v != null));
+        const isBinaryish =
+          distinct.size <= 3 &&
+          [...distinct].every((n) => n === 0 || n === 1 || n === 2);
+        if (isBinaryish) vt = "categorical";
+      }
+
+      out.dimensions[r.key as keyof DataExplorerPlotResponse["dimensions"]] = {
+        slice_type: dim.slice_type,
+        dataset_id: dim.dataset_id,
+        axis_label,
+        dataset_label,
+        value_type: vt as DataExplorerPlotResponseDimension["value_type"],
+        // Cast through. The response type today narrows values to
+        // number[]; widening that union is a separate, larger change
+        // that would touch every downstream consumer.
+        values: values as number[],
+      };
+    })
+  );
+
+  // --- Filters: boolean per logical id, replicated M times ---
+  for (const r of filterResults) {
+    const values = new Array<boolean>(NM);
+    for (let i = 0; i < N; i += 1) {
+      const v = r.indexed_values[logicalIds[i]] ?? false;
+      for (let j = 0; j < M; j += 1) {
+        values[i * M + j] = v;
+      }
+    }
+    out.filters[r.key] = { name: r.name, values };
+  }
+
+  // --- Metadata: scalar per logical id, replicated M times ---
+  for (const r of metadataResults) {
+    const dataset = datasets.find(
+      (d) =>
+        d.id === r.sliceQuery.dataset_id ||
+        d.given_id === r.sliceQuery.dataset_id
+    );
+    const units = dataset && "units" in dataset ? dataset.units : undefined;
+    // Flattened from a nested ternary (no-nested-ternary). Both original arms
+    // returned `dataset.name`, so the label is the dataset name whenever it's a
+    // non-tabular dataset OR a tabular one that isn't the index's own metadata
+    // table; otherwise undefined.
+    const dataset_label =
+      dataset &&
+      (dataset.format !== "tabular_dataset" ||
+        dataset.given_id !== `${index_type}_metadata`)
+        ? dataset.name
+        : undefined;
+
+    const values: (string | number | null)[] = new Array(NM);
+    for (let i = 0; i < N; i += 1) {
+      const v = r.indexed_values[logicalIds[i]] ?? null;
+      for (let j = 0; j < M; j += 1) {
+        values[i * M + j] = v;
+      }
+    }
+
+    const label = resolveDisplayLabel(
+      (r.sliceQuery as unknown) as DataExplorerContextVariable,
+      index_type,
+      tablesByDim,
+      dimTypeMap,
+      metadataIdToLabel[r.key]
+    );
+
+    // "I never imagined there would be continuous metadata" promotion,
+    // mirrored from fetchPlotDimensions. In an expanded plot this means
+    // color is model-keyed (broadcasts across all M transcripts per
+    // model), which is the right behavior.
+    if (r.key === "color_property" && r.value_type === "continuous") {
+      out.dimensions.color = ({
+        axis_label: label,
+        dataset_id: r.sliceQuery.dataset_id,
+        dataset_label,
+        slice_type: null,
+        values,
+        value_type: r.value_type,
+      } as unknown) as DataExplorerPlotResponseDimension;
+      continue;
+    }
+
+    out.metadata[r.key] = {
+      label,
+      sliceQuery: r.sliceQuery,
+      // The metadata value_type union excludes "list_strings"; cast through.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      value_type: r.value_type as any,
+      units,
+      dataset_label,
+      values,
+    };
+  }
+
+  return out;
+}
+
+// Expanded waterfall fetcher. Parallels fetchWaterfall's relationship to
+// fetchPlotDimensions: the underlying expanded fetcher is plot-type-agnostic
+// (it just materializes N×M points across an index and an expansion), and
+// this wrapper applies the waterfall-specific shape transformation that
+// `formatDataForWaterfall` and PrototypeScatterPlot both depend on.
+//
+// The transformation:
+//   - the plot config's `x` dimension (the per-point value being plotted)
+//     is remapped onto `dimensions.y`. The renderer reads `data.y` for
+//     bar height; without this remap, `dimensions.y` is undefined,
+//     `formattedData.y` becomes null, and PrototypeScatterPlot's `y[i]`
+//     dereferences crash.
+//   - `dimensions.x` is replaced with a filler rank array of length N×M.
+//     `formatDataForWaterfall` builds the real x positions afterward via
+//     its clustering loop; this placeholder exists so that the response's
+//     shape — every parallel array sized to N×M — stays consistent and
+//     downstream `nullifyUnplottableValues` calls produce a parallel-length
+//     output. The values themselves never reach the renderer; the loop
+//     overwrites them.
+//
+// Notably absent: the sort-by-rank step that fetchWaterfall does. That
+// step is plot-config-time ordering of the data; in the expanded case
+// the materialization loop has already determined order (row-major over
+// (logical_i, j)), and the visual clustering happens later in
+// formatDataForWaterfall. Sorting here would scramble the index↔expansion
+// pairing.
+//
+// This wrapper is a deliberate adapter — it exists because the renderer
+// assumes a 2D scatter response, and `formatDataForWaterfall` trusts that
+// assumption. Both are downstream of the same architectural limitation; the
+// wrapper can be retired once the renderer no longer requires that shape.
+export async function fetchExpandedWaterfall(
+  plotConfig: DataExplorerExpandedPlotConfig
+): Promise<DataExplorerExpandedPlotResponse> {
+  const expanded = await fetchExpandedPlot(plotConfig);
+  const NM = expanded.index_ids.length;
+
+  const valueDim = expanded.dimensions.x;
+  if (!valueDim) {
+    // Defensive — every plot config we currently expect here has an x.
+    // If something unexpected slips through, surface it rather than
+    // produce a silently-wrong response.
+    throw new Error(
+      "fetchExpandedWaterfall: expected expanded response to carry an `x` dimension"
+    );
+  }
+
+  return {
+    ...expanded,
+    dimensions: {
+      ...expanded.dimensions,
+      // Filler rank array, overwritten by formatDataForWaterfall's
+      // clustering loop. Carries valueDim's metadata for consistency
+      // (slice_type, dataset_id) so any code that introspects it
+      // doesn't see undefined fields.
+      x: {
+        ...valueDim,
+        axis_label: "Rank",
+        dataset_label: "",
+        value_type: "continuous",
+        values: Array.from({ length: NM }, (_, i) => i),
+      },
+      // The value-bearing dimension, lifted from x.
+      y: valueDim,
+    },
+  };
+}

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/index.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/index.ts
@@ -1,12 +1,16 @@
 import * as identifiers from "./identifiers";
 import * as variables from "./variables";
 import * as breadboxMethods from "./breadboxMethods";
+import * as expandedPlot from "./expandedPlot";
 
 export const dataExplorerAPI = {
   ...identifiers,
   ...variables,
   ...breadboxMethods,
+  ...expandedPlot,
 };
+
+export type { DataExplorerExpandBy } from "@depmap/types";
 
 type Api = typeof dataExplorerAPI;
 

--- a/frontend/packages/@depmap/data-explorer-2/src/utils/misc.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/misc.ts
@@ -134,6 +134,24 @@ export const isPartialSliceId = (value: string | null) => {
   return Boolean(value?.startsWith("slice/") && value?.endsWith("/"));
 };
 
+// Identity predicate for the expansion sentinel. `aggregation === "expansion"`
+// is not a real aggregation — its per-pair values come from fetchExpandedPlot,
+// not from aggregating a slice. The sentinel rides on `aggregation` to keep
+// that field's always-present invariant without a structural redesign. This is
+// the one canonical place that knows the sentinel's name; prefer it over
+// re-deriving `aggregation === "expansion"` inline. (The two materializer
+// guards must stay inline so the compiler narrows `aggregation`; everything
+// else asking "is this the expansion axis?" should call this.)
+export function isExpansionDimension(
+  dimension:
+    | PartialDataExplorerPlotConfigDimension
+    | PartialDataExplorerPlotConfigDimensionV2
+    | null
+    | undefined
+): boolean {
+  return dimension?.aggregation === "expansion";
+}
+
 // A more aggressive version of encodeURIComponent() to match this:
 // https://github.com/broadinstitute/depmap-portal/blob/a2e2cc9/portal-backend/depmap/vector_catalog/models.py#L358
 export const urlLibEncode = (s: string) => {

--- a/frontend/packages/@depmap/types/index.ts
+++ b/frontend/packages/@depmap/types/index.ts
@@ -87,6 +87,13 @@ export type {
 } from "./src/predictability";
 
 export type * from "./src/data-explorer-2";
+export {
+  EntityRefSet,
+  entityRefKey,
+  singleRef,
+  pairRef,
+} from "./src/EntityRef";
+export type { EntityRef } from "./src/EntityRef";
 export type * from "./src/interactive";
 export type * from "./src/cell-line";
 export type * from "./src/compounds";

--- a/frontend/packages/@depmap/types/src/EntityRef.ts
+++ b/frontend/packages/@depmap/types/src/EntityRef.ts
@@ -1,0 +1,179 @@
+// EntityRef and EntityRefSet
+//
+// A reference to a thing on the plot, with enough information to identify
+// it uniquely. Two flavors today:
+//   - "single": one index entity (e.g. one cell line, one gene). The
+//     plot's identity per-point is just the index id.
+//   - "pair":   an (index, expansion) pair (e.g. (cell line, transcript)).
+//     The plot is "expanded" by a second axis, and a point's identity
+//     requires both ids.
+//
+// The discriminated union — rather than `{ indexId; expansionId? }` with
+// expansionId optional — is deliberate. Consumers handling a reference
+// must decide whether they handle the pair case or only the single case;
+// the type system enforces that decision rather than letting it be a
+// runtime-only "is expansionId undefined" check that's easy to forget.
+//
+// This type lives in @depmap/types because the pair concept is expected
+// to be reused across multiple places — not only selection, but anywhere
+// the application needs to talk about "the thing at this position in an
+// expanded plot." Keep this module narrow: structural ids only, no
+// display labels or other ephemeral data. If you want to carry a label
+// alongside a ref, wrap it (e.g. `{ ref: EntityRef; label: string }`)
+// rather than widening this type.
+//
+// Serialization: EntityRef is a plain object; serialization is JSON-safe
+// without custom hooks. EntityRefSet is a class for membership semantics
+// (see below), but it exposes toJSON()/fromJSON() so it can round-trip
+// through URL state, localStorage, or any structured-clone boundary that
+// might appear later.
+export type EntityRef =
+  | { kind: "single"; indexId: string }
+  | { kind: "pair"; indexId: string; expansionId: string };
+
+// Stable string key for an EntityRef. Used internally as the Map key in
+// EntityRefSet and exposed for any consumer that needs a primitive key
+// (e.g. React list keys, debug logs). Two refs with the same key are the
+// same ref; the key is total and injective over the type.
+//
+// The encoding uses ASCII unit separator (\x1f) — a control character
+// that doesn't appear in any reasonable identifier — so the
+// (indexId, expansionId) split is unambiguous. The "kind" discriminator
+// is included so a single ref with indexId "foo" never collides with a
+// pair ref whose indexId happens to start with "foo" and has an empty
+// expansionId (which shouldn't be constructable anyway, but defending
+// against impossible states is cheap and the key is internal).
+export function entityRefKey(ref: EntityRef): string {
+  return ref.kind === "single"
+    ? `s\x1f${ref.indexId}`
+    : `p\x1f${ref.indexId}\x1f${ref.expansionId}`;
+}
+
+// Construction helpers — readability sugar at call sites, and a single
+// place to evolve the shape if the discriminated union ever gains a
+// third variant.
+export function singleRef(indexId: string): EntityRef {
+  return { kind: "single", indexId };
+}
+
+export function pairRef(indexId: string, expansionId: string): EntityRef {
+  return { kind: "pair", indexId, expansionId };
+}
+
+// EntityRefSet
+//
+// Set semantics over EntityRefs. Uses a Map<key, ref> internally; the
+// derived string key gives reliable membership and dedup that
+// Set<object> can't provide (Set uses reference identity for objects,
+// which breaks for refs constructed at different call sites).
+//
+// The class wraps the Map rather than extending it because the public
+// API is narrower than Map's: consumers should not see the key encoding
+// or be tempted to use Map operations that bypass the EntityRef
+// abstraction. Methods named after their Set analogues (.has, .add,
+// .delete, .size, .forEach, [Symbol.iterator]) so this is roughly
+// drop-in for the Set<string> it replaces.
+//
+// Instances are immutable from the consumer's perspective: .add and
+// .delete return new sets rather than mutating in place. This is
+// deliberate — it matches React's expectations for state updates
+// (referential change signals a render), and it avoids the bug class
+// where shared selection state is silently mutated. The cost is one
+// Map allocation per change, which is negligible at any realistic
+// selection size.
+export class EntityRefSet {
+  // Map<entityRefKey, ref>. Private; consumers go through the methods.
+  private readonly entries: Map<string, EntityRef>;
+
+  constructor(entries?: Iterable<EntityRef>) {
+    this.entries = new Map();
+    if (entries) {
+      for (const ref of entries) {
+        this.entries.set(entityRefKey(ref), ref);
+      }
+    }
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  has(ref: EntityRef): boolean {
+    return this.entries.has(entityRefKey(ref));
+  }
+
+  // Returns a new set with `ref` added. If `ref` is already present (by
+  // entityRefKey equality), returns this same set instance unchanged —
+  // gives React a referential no-op to short-circuit re-renders.
+  add(ref: EntityRef): EntityRefSet {
+    const key = entityRefKey(ref);
+    if (this.entries.has(key)) {
+      return this;
+    }
+    const next = new EntityRefSet(this.entries.values());
+    next.entries.set(key, ref);
+    return next;
+  }
+
+  // Returns a new set with `ref` removed. If `ref` was not present,
+  // returns this same instance unchanged (same rationale as `add`).
+  delete(ref: EntityRef): EntityRefSet {
+    const key = entityRefKey(ref);
+    if (!this.entries.has(key)) {
+      return this;
+    }
+    const next = new EntityRefSet(this.entries.values());
+    next.entries.delete(key);
+    return next;
+  }
+
+  // Returns a new empty set instance. Provided for API symmetry — clearing
+  // a selection is a common operation and `new EntityRefSet()` at every
+  // call site is noisier than `.clear()`.
+  clear(): EntityRefSet {
+    return this.size === 0 ? this : new EntityRefSet();
+  }
+
+  forEach(cb: (ref: EntityRef) => void): void {
+    this.entries.forEach((ref) => cb(ref));
+  }
+
+  // Spread- and for…of-friendly iteration over the refs themselves,
+  // not the internal keys.
+  [Symbol.iterator](): IterableIterator<EntityRef> {
+    return this.entries.values();
+  }
+
+  // Convenience: most call sites need to bulk-construct from an array
+  // of either kind of id. Provided here so callers don't reach for
+  // `new EntityRefSet([...].map(singleRef))` everywhere.
+  static fromIndexIds(indexIds: Iterable<string>): EntityRefSet {
+    const refs: EntityRef[] = [];
+    for (const id of indexIds) {
+      refs.push({ kind: "single", indexId: id });
+    }
+    return new EntityRefSet(refs);
+  }
+
+  static fromPairs(
+    pairs: Iterable<{ indexId: string; expansionId: string }>
+  ): EntityRefSet {
+    const refs: EntityRef[] = [];
+    for (const { indexId, expansionId } of pairs) {
+      refs.push({ kind: "pair", indexId, expansionId });
+    }
+    return new EntityRefSet(refs);
+  }
+
+  // Serialization. EntityRefSet is a class, so JSON.stringify on it
+  // produces an empty object by default. These methods make the
+  // round-trip explicit and total. Format is the array of refs, which
+  // is the minimum needed to reconstruct.
+  toJSON(): EntityRef[] {
+    return [...this.entries.values()];
+  }
+
+  static fromJSON(refs: EntityRef[]): EntityRefSet {
+    return new EntityRefSet(refs);
+  }
+}

--- a/frontend/packages/@depmap/types/src/data-explorer-2.ts
+++ b/frontend/packages/@depmap/types/src/data-explorer-2.ts
@@ -18,7 +18,8 @@ export type ColorByValue =
   | "raw_slice"
   | "aggregated_slice"
   | "property"
-  | "custom";
+  | "custom"
+  | "expansion";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type DataExplorerContextExpression = Record<string, any> | boolean;
@@ -39,6 +40,14 @@ export type DataExplorerContextV2 = {
 
 export type DataExplorerAnonymousContext = Omit<DataExplorerContext, "name">;
 
+// Despite its name, `aggregation` is really a resolution-mode discriminator:
+// how an axis turns a slice_type into per-index values. Most members are true
+// statistical aggregations, but "first" (take-first selection) and
+// "correlation" (a correlation_heatmap mode) are not, and "expansion" (below)
+// is the third non-aggregation. The Breadbox boundary rejects all three
+// non-aggregations explicitly. A future rename to something more general
+// (e.g. `processor`/`mapping`), with translation for old saved plots, is
+// possible; until then this is the deliberate, documented home for all of them.
 export type DataExplorerAggregation =
   | "first"
   | "correlation"
@@ -46,7 +55,15 @@ export type DataExplorerAggregation =
   | "median"
   | "25%tile"
   | "75%tile"
-  | "stddev";
+  | "stddev"
+  // Sentinel — NOT a real aggregation; if anything, the opposite. It marks an
+  // axis whose per-pair values come from an expansion (fetchExpandedPlot), not
+  // from aggregating a slice. It rides on the required `aggregation` field to
+  // preserve that field's always-present invariant without restructuring the
+  // dimension type. Identity check: `dim.aggregation === "expansion"` (see
+  // isExpansionDimension). It must NEVER reach Breadbox: the materializer
+  // guards and the getMatrixDatasetData trap enforce that.
+  | "expansion";
 
 export type DimensionKey = "x" | "y" | "color";
 export type FilterKey =
@@ -92,6 +109,80 @@ export interface DataExplorerPlotResponseDimension {
   value_type: "continuous" | "text" | "categorical" | "list_strings";
 }
 
+// A single expansion: fans each index entity out into one point per member of
+// `context` (e.g. depmap_model × transcript). `expand_by` is a plot-level
+// concept (not a per-axis flag) by design. The count is currently capped at
+// one by the materializer; the type is an array to leave room for
+// multi-expansion, which is deferred (see fetchExpandedPlot's header). `limit`
+// bounds the fan-out for browser safety and keeps the plot self-describing;
+// the UI seeds a default and a separate hard ceiling is enforced at the
+// materializer. The axis that *reads* each per-pair value is the one carrying
+// the "expansion" sentinel on `aggregation`.
+export interface DataExplorerExpandBy {
+  slice_type: string;
+  context: DataExplorerContextV2;
+  limit: number;
+  // Pagination window start, in context order (0-based; defaults to 0). With
+  // `limit` as the page size, the fetcher materializes members
+  // [offset, offset + min(limit, MAX_EXPANSION_MEMBERS)). Interim: this is a
+  // contiguous-range stopgap that will be retired once the user can select an
+  // explicit member subset (at which point `context` becomes that subset and
+  // `offset` goes away).
+  offset?: number;
+}
+
+export interface DataExplorerExpandedPlotConfig {
+  index_type: string;
+  dimensions: Record<string, DataExplorerPlotConfigDimension>;
+  expand_by: DataExplorerExpandBy[]; // length 0 or 1 today (one expansion)
+  filters?: DataExplorerFilters;
+  metadata?: DataExplorerMetadata;
+}
+
+export interface DataExplorerExpansion {
+  // Identity. The "points-index" — i.e. the per-cell entity id for this
+  // expansion axis. Parallel to the response's index_ids.
+  ids: string[];
+
+  // Human-readable display labels, parallel to `ids`.
+  labels: string[];
+
+  // The dimension type's id column name from Breadbox
+  // (e.g. "ensembl_transcript_id"). Mirrors `index_id_column` at the
+  // expansion level. Used to make bare ids legible in hover text.
+  id_column?: string;
+
+  // The dimension type's human-readable display name from Breadbox
+  // (e.g. "Transcript", "Gene"). Mirrors `index_display_name` at the
+  // expansion level. Preferred over `slice_type` as a prefix in
+  // display contexts because slice_type is a machine-readable name
+  // ("transcript") while display_name is the curated label
+  // ("Transcript").
+  display_name?: string;
+
+  // The slice_type this expansion is over (e.g. "transcript").
+  slice_type: string;
+
+  // Number of distinct expansion members the context yielded *before* the
+  // limit/ceiling was applied. `ids`/`labels` reflect the (possibly truncated)
+  // shown set, so the UI can surface "showing K of total_available".
+  total_available?: number;
+
+  // True when members were dropped to satisfy the cap (i.e. total_available
+  // exceeded min(expand_by.limit, MAX_EXPANSION_MEMBERS)). Truncation is
+  // currently arbitrary (first-N in context order); a "most interesting
+  // members" selection is a planned follow-up.
+  truncated?: boolean;
+}
+
+export interface DataExplorerExpandedPlotResponse
+  extends DataExplorerPlotResponse {
+  // Parallel to index_ids/index_labels. Length 0 or 1 today (one expansion).
+  // Each entry's `ids`/`labels` arrays have the same N×M length as
+  // index_ids/index_labels.
+  expansions: DataExplorerExpansion[];
+}
+
 // A DataExplorerPlotConfig is an object with all the configurable parameters
 // used to generate a plot. Note that some properties only make sense with
 // certain plot types (but encoding that in type system would be much more
@@ -100,7 +191,23 @@ export interface DataExplorerPlotConfig {
   plot_type: DataExplorerPlotType;
   index_type: string;
   dimensions: Partial<Record<DimensionKey, DataExplorerPlotConfigDimension>>;
+
+  // At most one expansion (see DataExplorerExpandBy). When present, the plot's
+  // point set fans from N index entities to N×M (entity, expansion-member)
+  // pairs. Absent or empty means an ordinary single-axis plot.
+  expand_by?: DataExplorerExpandBy[];
   color_by?: ColorByValue;
+
+  // `group_by` controls which per-point categorical drives spatial
+  // grouping (violin tracks in density_1d, x-position clustering in
+  // waterfall) — separately from `color_by`, which drives point colors.
+  // When unset, falls back to `color_by`, so existing configs preserve
+  // the historical conflation. Set explicitly when you want grouping
+  // and coloring to use different sources (e.g. group by lineage,
+  // color by transcript). Renderers that don't yet honor `group_by`
+  // simply ignore it.
+  group_by?: ColorByValue;
+
   filters?: DataExplorerFilters;
   metadata?: DataExplorerMetadata;
 
@@ -136,6 +243,12 @@ export interface DataExplorerPlotResponse {
   // text. Optional because some legacy code paths construct responses
   // without consulting Breadbox.
   index_id_column?: string;
+
+  // The dimension type's human-readable display name from Breadbox
+  // (e.g. "Cell Line", "Gene"). Preferred over `index_id_column` as a
+  // prefix in display contexts because it's uniformly legible across
+  // types. Optional for the same reason as `index_id_column`.
+  index_display_name?: string;
 
   // Real, stable identifiers from Breadbox. Use this for identity:
   // joins, lookups, selection state, filters, URL state, anything

--- a/frontend/packages/portal-frontend/src/apps/transcriptExplorer.tsx
+++ b/frontend/packages/portal-frontend/src/apps/transcriptExplorer.tsx
@@ -1,0 +1,43 @@
+import "src/public-path";
+import React from "react";
+import ReactDOM from "react-dom";
+import {
+  DataExplorerSettingsProvider,
+  PlotlyLoaderProvider,
+} from "@depmap/data-explorer-2";
+import ErrorBoundary from "src/common/components/ErrorBoundary";
+import PlotlyLoader from "src/plot/components/PlotlyLoader";
+import TranscriptExplorer from "src/transcriptExplorer/components";
+
+import "react-bootstrap-typeahead/css/Typeahead.css";
+import "src/common/styles/typeahead_fix.scss";
+
+const container = document.getElementById("react-root");
+const dataElement = document.getElementById("transcript-explorer-data");
+if (!dataElement || !dataElement.textContent) {
+  throw new Error(
+    `Expected a DOM element like <script type="application/json">{ ... }</script>'`
+  );
+}
+
+const { feedbackUrl, contactEmail, tutorialLink } = JSON.parse(
+  dataElement.textContent
+);
+
+const App = () => {
+  return (
+    <ErrorBoundary>
+      <PlotlyLoaderProvider PlotlyLoader={PlotlyLoader}>
+        <DataExplorerSettingsProvider>
+          <TranscriptExplorer
+            feedbackUrl={feedbackUrl}
+            contactEmail={contactEmail}
+            tutorialLink={tutorialLink}
+          />
+        </DataExplorerSettingsProvider>
+      </PlotlyLoaderProvider>
+    </ErrorBoundary>
+  );
+};
+
+ReactDOM.render(<App />, container);

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/MainContent.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/MainContent.tsx
@@ -1,0 +1,113 @@
+import React, { useCallback, useEffect, useRef, useReducer } from "react";
+import {
+  DataExplorerPlotConfig,
+  PartialDataExplorerPlotConfig,
+} from "@depmap/types";
+import plotConfigReducer, {
+  PlotConfigReducerAction,
+} from "@depmap/data-explorer-2/src/components/DataExplorerPage/reducers/plotConfigReducer";
+import {
+  plotsAreEquivalentWhenSerialized,
+  plotToQueryString,
+  readPlotFromQueryString,
+} from "@depmap/data-explorer-2/src/components/DataExplorerPage/utils";
+import { isCompletePlot } from "@depmap/data-explorer-2/src/components/DataExplorerPage/validation";
+import useContextBuilder from "@depmap/data-explorer-2/src/components/DataExplorerPage/hooks/useContextBuilder";
+import VisualizationPanel from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/VisualizationPanel";
+import {
+  logDirectPlotChange,
+  logReducerTransform,
+} from "@depmap/data-explorer-2/src/components/DataExplorerPage/debug";
+import TranscriptConfigPanel from "./TranscriptConfigPanel";
+import styles from "@depmap/data-explorer-2/src/components/DataExplorerPage/styles/DataExplorer2.scss";
+import { canShowIdentityLine, EMPTY_TRANSCRIPT_PLOT } from "./utils";
+
+interface Props {
+  initialPlot: PartialDataExplorerPlotConfig;
+  feedbackUrl: string | null;
+  contactEmail: string;
+  tutorialLink: string;
+}
+
+const NOOP = () => {};
+
+function MainContent({
+  initialPlot,
+  feedbackUrl,
+  contactEmail,
+  tutorialLink,
+}: Props) {
+  const reactKey = useRef(0);
+  const [plot, dispatchPlotAction] = useReducer(plotConfigReducer, initialPlot);
+
+  const setPlot = (nextPlot: DataExplorerPlotConfig) =>
+    dispatchPlotAction({ type: "set_plot", payload: nextPlot });
+
+  const dispatchPlotActionAndUpdateHistory = useCallback(
+    async (action: PlotConfigReducerAction) => {
+      dispatchPlotAction(action);
+      const nextPlot = plotConfigReducer(plot, action);
+      logReducerTransform(action, plot, nextPlot);
+
+      if (isCompletePlot(nextPlot)) {
+        const prevPlot = await readPlotFromQueryString();
+
+        if (!plotsAreEquivalentWhenSerialized(prevPlot, nextPlot)) {
+          const queryString = await plotToQueryString(nextPlot);
+          window.history.pushState(null, "", queryString);
+        }
+      }
+    },
+    [plot]
+  );
+
+  useEffect(() => {
+    const onPopState = () => {
+      readPlotFromQueryString().then((nextPlot) => {
+        if (nextPlot === EMPTY_TRANSCRIPT_PLOT) {
+          reactKey.current++;
+        }
+
+        setPlot(nextPlot);
+        logDirectPlotChange("onPopState", plot, nextPlot);
+      });
+    };
+
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [plot]);
+
+  const {
+    ContextBuilder,
+    onClickSaveAsContext,
+    onClickCreateContext,
+  } = useContextBuilder(plot as DataExplorerPlotConfig, setPlot);
+
+  return (
+    <>
+      <main className={styles.DataExplorer2}>
+        <TranscriptConfigPanel
+          plot={plot}
+          dispatch={dispatchPlotActionAndUpdateHistory}
+          onClickCreateContext={onClickCreateContext}
+          onClickSaveAsContext={onClickSaveAsContext}
+        />
+        <VisualizationPanel
+          plotConfig={isCompletePlot(plot) ? plot : null}
+          isInitialPageLoad={false}
+          onClickVisualizeSelected={NOOP}
+          onClickSaveSelectionAsContext={NOOP}
+          onClickColorByContext={NOOP}
+          onClickShowDensityFallback={NOOP}
+          feedbackUrl={feedbackUrl}
+          contactEmail={contactEmail}
+          tutorialLink={tutorialLink}
+          canShowIdentityLine={canShowIdentityLine}
+        />
+        <ContextBuilder />
+      </main>
+    </>
+  );
+}
+
+export default MainContent;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/DataExplorerLinks/LinksContent.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/DataExplorerLinks/LinksContent.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import {
+  DataExplorerContextV2,
+  PartialDataExplorerPlotConfig,
+} from "@depmap/types";
+import { isCompletePlot } from "@depmap/data-explorer-2/src/components/DataExplorerPage/validation";
+import useContextResult from "../useContextResult";
+import useAvailableTranscriptIds from "../useAvailableTranscriptIds";
+import toUnexpandedPlotLink from "./toUnexpandedPlotLink";
+
+interface Props {
+  plot: PartialDataExplorerPlotConfig;
+  expansionAxis: "x" | "y";
+}
+
+function LinksContent({ plot, expansionAxis }: Props) {
+  const expansionDim = plot.dimensions?.[expansionAxis];
+
+  const { result, isLoading } = useContextResult(
+    expansionDim?.context as DataExplorerContextV2 | undefined
+  );
+
+  // Availability: the expansion context resolves against transcript_metadata —
+  // every transcript of the gene — but the chosen dataset may not measure all
+  // of them. A transcript with no data shows as "(no data)" text instead of a
+  // link that would open an empty plot.
+  const availableIds = useAvailableTranscriptIds(plot, expansionAxis);
+
+  if (isLoading) {
+    return <div>Loading ...</div>;
+  }
+
+  if (!isCompletePlot(plot)) {
+    return (
+      <div>
+        Choose a gene and links to individual transcript will appear here.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <p>Click a transcript to see its individual plot in Data Explorer.</p>
+      <ul>
+        {result &&
+          result.ids.map((id, index) => {
+            const label = result.labels[index];
+            // While the feature list is still loading (availableIds === null)
+            // assume available, so links don't flash to "(no data)" and back.
+            const hasData = !availableIds || availableIds.has(id);
+
+            return (
+              <li key={id}>
+                {hasData ? (
+                  <a
+                    href={toUnexpandedPlotLink(plot, expansionAxis, id, label)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {label}
+                  </a>
+                ) : (
+                  <span style={{ color: "#999" }}>{label} (no data)</span>
+                )}
+              </li>
+            );
+          })}
+      </ul>
+    </div>
+  );
+}
+
+export default LinksContent;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/DataExplorerLinks/index.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/DataExplorerLinks/index.tsx
@@ -1,0 +1,33 @@
+import React, { useRef } from "react";
+import { PartialDataExplorerPlotConfig } from "@depmap/types";
+import Section from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/Section";
+import LinksContent from "./LinksContent";
+
+interface Props {
+  plot: PartialDataExplorerPlotConfig;
+  expansionAxis: "x" | "y";
+}
+
+function DataExplorerLinks({ plot, expansionAxis }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  return (
+    <Section
+      title="Data Explorer Links"
+      defaultOpen={false}
+      innerRef={ref}
+      onOpen={() => {
+        setTimeout(() => {
+          ref.current?.scrollIntoView({
+            behavior: "smooth",
+            block: "nearest",
+          });
+        });
+      }}
+    >
+      <LinksContent plot={plot} expansionAxis={expansionAxis} />
+    </Section>
+  );
+}
+
+export default DataExplorerLinks;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/DataExplorerLinks/toUnexpandedPlotLink.ts
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/DataExplorerLinks/toUnexpandedPlotLink.ts
@@ -1,0 +1,49 @@
+import omit from "lodash.omit";
+import { toPortalLink } from "@depmap/globals";
+import { DataExplorerPlotConfig } from "@depmap/types";
+
+function toUnexpandedPlotLink(
+  plot: DataExplorerPlotConfig,
+  expansionAxis: "x" | "y",
+  transcriptId: string,
+  transcriptLabel: string
+) {
+  let nextPlot = omit(plot, "expand_by", "group_by");
+
+  if (nextPlot.color_by === "expansion") {
+    nextPlot = omit(nextPlot, "color_by");
+  }
+
+  nextPlot.dimensions = (() => {
+    const out: DataExplorerPlotConfig["dimensions"] = {};
+
+    for (const [key, dim] of Object.entries(plot.dimensions)) {
+      let nextDim = dim;
+
+      if (key === expansionAxis) {
+        nextDim = {
+          ...nextDim,
+          axis_type: "raw_slice",
+          aggregation: "first",
+          context: {
+            name: transcriptLabel,
+            dimension_type: "transcript",
+            expr: { "==": [{ var: "given_id" }, transcriptId] },
+            vars: {},
+          },
+        };
+      }
+
+      out[key as "x" | "y"] = nextDim;
+    }
+
+    return out;
+  })();
+
+  const json = JSON.stringify(nextPlot);
+  const base64 = btoa(json);
+
+  return toPortalLink(`/data_explorer_2?plot=${base64}`);
+}
+
+export default toUnexpandedPlotLink;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/PlotTypeSelect.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/PlotTypeSelect.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { PlotConfigSelect } from "@depmap/data-explorer-2";
+
+interface Props {
+  value: string | null;
+  onChange: (nextValue: string) => void;
+}
+
+function PlotTypeSelect({ value, onChange }: Props) {
+  return (
+    <PlotConfigSelect
+      show
+      enable
+      label="Plot Type"
+      inlineLabel
+      placeholder="Select type…"
+      value={value}
+      onChange={(nextValue) => onChange(nextValue as string)}
+      options={{
+        density_1d: "Density 1D",
+        waterfall: "Waterfall",
+        scatter: "Scatter plot",
+      }}
+    />
+  );
+}
+
+export default PlotTypeSelect;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TableViews/TableViewsContent.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TableViews/TableViewsContent.tsx
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from "react";
+import { breadboxAPI, cached } from "@depmap/api";
+import { Button } from "react-bootstrap";
+import {
+  DataExplorerContextV2,
+  DataExplorerPlotConfig,
+  SliceQuery,
+} from "@depmap/types";
+import useContextResult from "../useContextResult";
+import useAvailableTranscriptIds from "../useAvailableTranscriptIds";
+import showGeneTranscriptTable from "./showGeneTranscriptTable";
+import showModelTranscriptTable from "./showModelTranscriptTable";
+import styles from "../../../styles/TranscriptPlotConfig.scss";
+
+interface Props {
+  plot: DataExplorerPlotConfig;
+  expansionAxis: "x" | "y";
+}
+
+function TableViewsContent({ plot, expansionAxis }: Props) {
+  const expansionDim = plot.dimensions[expansionAxis];
+
+  const { result, isLoading } = useContextResult(
+    expansionDim!.context as DataExplorerContextV2
+  );
+
+  const availableIds = useAvailableTranscriptIds(plot, expansionAxis);
+  const [datasetName, setDatasetName] = useState("");
+
+  useEffect(() => {
+    cached(breadboxAPI)
+      .getDataset(expansionDim!.dataset_id)
+      .then((d) => setDatasetName(d.name));
+  }, [expansionDim]);
+
+  if (isLoading || !result || !availableIds || !datasetName) {
+    return <div>Loading...</div>;
+  }
+
+  const geneSymbol = plot.dimensions[expansionAxis]?.context.name as string;
+
+  const slices = result.ids
+    .filter((id) => availableIds.has(id))
+    .map((identifier) => ({
+      identifier,
+      identifier_type: "feature_id",
+      dataset_id: expansionDim!.dataset_id,
+    })) as SliceQuery[];
+
+  const otherDim = plot.dimensions[expansionAxis === "x" ? "y" : "x"];
+
+  if (otherDim) {
+    const context = otherDim.context as DataExplorerContextV2;
+    let slice = Object.values(context.vars)[0] as SliceQuery;
+
+    if (Object.keys(context.vars)[0] === "symbol") {
+      slice = {
+        dataset_id: "expression",
+        identifier_type: "feature_label",
+        identifier: context.name,
+      };
+    }
+
+    if (!slice) {
+      slice = {
+        dataset_id: otherDim.dataset_id,
+        identifier_type: "feature_id",
+        identifier: (context.expr as Record<"==", [unknown, string]>)["=="][1],
+      };
+    }
+
+    slices.unshift(slice);
+  }
+
+  return (
+    <div className={styles.TableViewsContent}>
+      <Button
+        bsStyle="info"
+        onClick={() =>
+          showModelTranscriptTable(geneSymbol, datasetName, slices)
+        }
+      >
+        <span>Model/Transcript table</span>{" "}
+        <span className="glyphicon glyphicon-new-window" />
+      </Button>
+      <Button onClick={() => showGeneTranscriptTable(geneSymbol)}>
+        <span>Gene/Transcript table</span>{" "}
+        <span className="glyphicon glyphicon-new-window" />
+      </Button>
+    </div>
+  );
+}
+
+export default TableViewsContent;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TableViews/index.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TableViews/index.tsx
@@ -1,0 +1,38 @@
+import React, { useRef } from "react";
+import { PartialDataExplorerPlotConfig } from "@depmap/types";
+import Section from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/Section";
+import { isCompletePlot } from "@depmap/data-explorer-2/src/components/DataExplorerPage/validation";
+import TableViewsContent from "./TableViewsContent";
+
+interface Props {
+  plot: PartialDataExplorerPlotConfig;
+  expansionAxis: "x" | "y";
+}
+
+function TableViews({ plot, expansionAxis }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  return (
+    <Section
+      title="Table Views"
+      defaultOpen={false}
+      innerRef={ref}
+      onOpen={() => {
+        setTimeout(() => {
+          ref.current?.scrollIntoView({
+            behavior: "smooth",
+            block: "nearest",
+          });
+        }, 100);
+      }}
+    >
+      {isCompletePlot(plot) ? (
+        <TableViewsContent plot={plot} expansionAxis={expansionAxis} />
+      ) : (
+        <div>Choose a gene and links to tables will appear here.</div>
+      )}
+    </Section>
+  );
+}
+
+export default TableViews;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TableViews/showGeneTranscriptTable.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TableViews/showGeneTranscriptTable.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { PlotlyLoaderProvider } from "@depmap/data-explorer-2";
+import SliceTable from "@depmap/slice-table";
+import { showInfoModal } from "@depmap/common-components";
+import PlotlyLoader from "src/plot/components/PlotlyLoader";
+import styles from "../../../styles/TranscriptPlotConfig.scss";
+
+function showGeneTranscriptTable(geneSymbol: string) {
+  const title = `Transcript table for gene ${geneSymbol}`;
+
+  showInfoModal({
+    title,
+    modalProps: { className: styles.modal, bsSize: "large" },
+    content: (
+      <PlotlyLoaderProvider PlotlyLoader={PlotlyLoader}>
+        <div className={styles.tableContainer}>
+          <SliceTable
+            index_type_name="transcript"
+            downloadFilename={title}
+            renderCustomActions={() => {
+              return (
+                <div className={styles.geneAnnotationNote}>
+                  <div>
+                    ⬅ <b>Note</b>:
+                  </div>
+                  <div>
+                    <span>
+                      Adding gene-level annotations is currently broken 😢
+                    </span>
+                    <span> </span>
+                    <span>But you can still add data columns.</span>
+                  </div>
+                </div>
+              );
+            }}
+            getInitialState={() => ({
+              initialSlices: [
+                {
+                  dataset_id: "transcript_metadata",
+                  identifier: "Gene",
+                  identifier_type: "column",
+                },
+                {
+                  dataset_id: "transcript_metadata",
+                  identifier: "Transcript",
+                  identifier_type: "column",
+                },
+              ],
+            })}
+            implicitFilter={({ getValue }) =>
+              geneSymbol ===
+              getValue({
+                dataset_id: "transcript_metadata",
+                identifier: "Gene",
+                identifier_type: "column",
+              })
+            }
+          />
+        </div>
+      </PlotlyLoaderProvider>
+    ),
+  });
+}
+
+export default showGeneTranscriptTable;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TableViews/showModelTranscriptTable.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TableViews/showModelTranscriptTable.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { showInfoModal } from "@depmap/common-components";
+import { PlotlyLoaderProvider } from "@depmap/data-explorer-2";
+import SliceTable from "@depmap/slice-table";
+import { SliceQuery } from "@depmap/types";
+import PlotlyLoader from "src/plot/components/PlotlyLoader";
+import styles from "../../../styles/TranscriptPlotConfig.scss";
+
+function showModelTranscriptTable(
+  geneSymbol: string,
+  datasetName: string,
+  transcriptSlices: SliceQuery[]
+) {
+  const title = `Model/Transcript table for gene ${geneSymbol} and ${datasetName}`;
+
+  showInfoModal({
+    title,
+    modalProps: { className: styles.modal, bsSize: "large" },
+    content: (
+      <PlotlyLoaderProvider PlotlyLoader={PlotlyLoader}>
+        <div className={styles.tableContainer}>
+          <SliceTable
+            index_type_name="depmap_model"
+            getInitialState={() => ({ initialSlices: transcriptSlices })}
+            downloadFilename={title}
+          />
+        </div>
+      </PlotlyLoaderProvider>
+    ),
+  });
+}
+
+export default showModelTranscriptTable;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptExpansionSelect/GeneSelect.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptExpansionSelect/GeneSelect.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import { breadboxAPI, cached } from "@depmap/api";
+import { PlotConfigSelect } from "@depmap/data-explorer-2";
+import HelpTip from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/HelpTip";
+import styles from "../../../styles/TranscriptPlotConfig.scss";
+
+interface Props {
+  value: string | null;
+  onChange: (nextValue: string | null) => void;
+}
+
+function GeneSelect({ value, onChange }: Props) {
+  const [options, setOptions] = useState<any[]>([]);
+
+  useEffect(() => {
+    cached(breadboxAPI)
+      .getTabularDatasetData("transcript_metadata", {
+        columns: ["Gene"],
+      })
+      .then((result) => {
+        const indexedValues = (result as any).Gene;
+        const uniqueVals = new Set(Object.values(indexedValues));
+        const sorted = [...uniqueVals].sort();
+        const opts = sorted.map((label) => ({ label, value: label }));
+        setOptions(opts);
+      });
+  }, []);
+
+  return (
+    <PlotConfigSelect
+      show
+      className={styles.geneSelect}
+      enable={options.length > 0}
+      label={
+        <span>
+          See Transcripts for Gene
+          <HelpTip id="temp-transcripts-by-gene" />
+        </span>
+      }
+      placeholder="Choose a gene…"
+      value={value}
+      options={options}
+      onChange={onChange}
+    />
+  );
+}
+export default GeneSelect;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptExpansionSelect/TranscriptDatasetSelect.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptExpansionSelect/TranscriptDatasetSelect.tsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from "react";
+import { breadboxAPI, cached } from "@depmap/api";
+import { PlotConfigSelect } from "@depmap/data-explorer-2";
+import styles from "../../../styles/TranscriptPlotConfig.scss";
+
+interface Props {
+  value: string | null;
+  onChange: any;
+}
+
+function TranscriptDatasetSelect({ value, onChange }: Props) {
+  const [options, setOptions] = useState<Record<string, string> | null>(null);
+  const isLoading = options === null;
+
+  useEffect(() => {
+    cached(breadboxAPI)
+      .getDatasets()
+      .then((datasets) => {
+        const nextOpts: Record<string, string> = {};
+
+        datasets
+          .filter((d) => {
+            return (
+              d.format === "matrix_dataset" &&
+              d.feature_type_name === "transcript"
+            );
+          })
+          .forEach((d) => {
+            nextOpts[d.given_id || d.id] = d.name;
+          });
+
+        setOptions(nextOpts);
+      });
+  }, []);
+
+  return (
+    <div className={styles.TranscriptDatasetSelect}>
+      <PlotConfigSelect
+        show
+        // isClearable
+        value={value}
+        data-version-select
+        options={options || {}}
+        onChange={onChange}
+        enable={!isLoading}
+        label="Data Version"
+        isLoading={isLoading}
+        placeholder={isLoading ? "Loading…" : "Select data version…"}
+      />
+    </div>
+  );
+}
+
+export default TranscriptDatasetSelect;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptExpansionSelect/TranscriptMaxToShowSelect.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptExpansionSelect/TranscriptMaxToShowSelect.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { PlotConfigSelect } from "@depmap/data-explorer-2";
+import { MAX_EXPANSION_MEMBERS } from "@depmap/data-explorer-2/src/services/dataExplorerAPI/expandedPlot";
+
+interface Props {
+  show: boolean;
+  value: number;
+  onChange: (nextLimit: number) => void;
+}
+
+// Curated page-size choices, capped at the hard ceiling so the dropdown can
+// never offer more than the fetcher will materialize.
+const PAGE_SIZE_CHOICES = [6, 9, 12, 16];
+
+function TranscriptMaxToShowSelect({ show, value, onChange }: Props) {
+  const options: Record<string, string> = {};
+
+  PAGE_SIZE_CHOICES.filter((n) => n <= MAX_EXPANSION_MEMBERS).forEach((n) => {
+    options[String(n)] = String(n);
+  });
+
+  return (
+    <PlotConfigSelect
+      show={show}
+      enable
+      label="Max transcripts to show"
+      placeholder="Choose…"
+      options={options}
+      value={String(value)}
+      onChange={(next) => onChange(Number(next))}
+    />
+  );
+}
+
+export default TranscriptMaxToShowSelect;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptExpansionSelect/TranscriptPaginationSelect.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptExpansionSelect/TranscriptPaginationSelect.tsx
@@ -1,0 +1,72 @@
+import React from "react";
+import { PlotConfigSelect } from "@depmap/data-explorer-2";
+import { DataExplorerContextV2 } from "@depmap/types";
+import HelpTip from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/HelpTip";
+import useContextResult from "../useContextResult";
+
+interface Props {
+  context?: DataExplorerContextV2 | null;
+  offset: number;
+  pageSize: number;
+  onChange: (nextOffset: number) => void;
+}
+
+// Interim pagination: walk the gene's full transcript set (resolved from the
+// expansion context) in page-aligned windows of `pageSize`. The options read
+// "1 - 9", "10 - 18", …; the selected value also shows the total, e.g.
+// "1 - 9 of 40". This is a contiguous-range stopgap that will be retired once
+// the user can pick an explicit member subset.
+function TranscriptPaginationSelect({
+  context = null,
+  offset,
+  pageSize,
+  onChange,
+}: Props) {
+  const { isLoading, result } = useContextResult(context);
+  const total = result?.ids.length || 0;
+
+  const options: { value: string; label: string }[] = [];
+
+  for (let start = 0; start < total; start += pageSize) {
+    const end = Math.min(start + pageSize, total);
+    let label = `${start + 1} - ${end}`;
+
+    if (start + 1 === end) {
+      label = `${end}`;
+    }
+
+    options.push({ value: String(start), label });
+  }
+
+  const currentStart = Math.min(Math.max(0, offset), total);
+  const currentEnd = Math.min(currentStart + pageSize, total);
+  let currentLabel = `${currentStart + 1} - ${currentEnd}`;
+
+  if (currentStart + 1 === currentEnd) {
+    currentLabel = `${currentEnd}`;
+  }
+
+  const displayValue = {
+    value: String(currentStart),
+    label: `${currentLabel} of ${total}`,
+  };
+
+  return (
+    <PlotConfigSelect
+      show={!isLoading && total > pageSize}
+      enable
+      label={
+        <span>
+          Showing transcripts
+          <HelpTip id="temp-pagination-help" />
+        </span>
+      }
+      placeholder="Select subset…"
+      options={options}
+      value={displayValue}
+      onChange={(value) => onChange(Number(value))}
+    />
+  );
+}
+
+export default TranscriptPaginationSelect;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptExpansionSelect/actionCreators.ts
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptExpansionSelect/actionCreators.ts
@@ -1,0 +1,80 @@
+import { makeSetExpansionAction, SHORT_READ_DATASET } from "../../utils";
+import { PlotConfigReducerAction } from "@depmap/data-explorer-2/src/components/DataExplorerPage/reducers/plotConfigReducer";
+
+export const makeGeneOnChangeHandler = (
+  expansionAxis: "x" | "y",
+  currentDatasetId: string | null,
+  limit: number,
+  dispatch: (action: PlotConfigReducerAction) => void
+) => {
+  return (nextGene: string | null) => {
+    // Changing the gene changes the transcript set, so preserve the page
+    // size but reset pagination to the first window.
+    dispatch(
+      makeSetExpansionAction(
+        expansionAxis,
+        nextGene,
+        currentDatasetId || SHORT_READ_DATASET,
+        limit,
+        0
+      )
+    );
+  };
+};
+
+export const makeDatasetOnChangeHandler = (
+  expansionAxis: "x" | "y",
+  currentGene: string | null,
+  limit: number,
+  dispatch: (action: PlotConfigReducerAction) => void
+) => {
+  return (nextDatasetId: string | null) => {
+    // Changing the dataset changes the transcript set, so preserve the page
+    // size but reset pagination to the first window.
+    dispatch(
+      makeSetExpansionAction(
+        expansionAxis,
+        currentGene,
+        nextDatasetId,
+        limit,
+        0
+      )
+    );
+  };
+};
+
+// Pagination: preserve the gene/dataset/page-size and move the window start.
+export const makePaginationOnChangeHandler = (
+  expansionAxis: "x" | "y",
+  geneSymbol: string | null,
+  datasetId: string | null,
+  limit: number,
+  dispatch: (action: PlotConfigReducerAction) => void
+) => {
+  return (nextOffset: number) => {
+    dispatch(
+      makeSetExpansionAction(
+        expansionAxis,
+        geneSymbol,
+        datasetId,
+        limit,
+        nextOffset
+      )
+    );
+  };
+};
+
+// "Max transcripts to show": set the page size and reset pagination to the
+// first window (a stale offset under a new page size would be confusing).
+export const makeMaxToShowOnChangeHandler = (
+  expansionAxis: "x" | "y",
+  geneSymbol: string | null,
+  datasetId: string | null,
+  dispatch: (action: PlotConfigReducerAction) => void
+) => {
+  return (nextLimit: number) => {
+    dispatch(
+      makeSetExpansionAction(expansionAxis, geneSymbol, datasetId, nextLimit, 0)
+    );
+  };
+};

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptExpansionSelect/index.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptExpansionSelect/index.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { DataExplorerPlotConfigDimensionV2 } from "@depmap/types";
+import { PlotConfigReducerAction } from "@depmap/data-explorer-2/src/components/DataExplorerPage/reducers/plotConfigReducer";
+import {
+  makeDatasetOnChangeHandler,
+  makeGeneOnChangeHandler,
+  makePaginationOnChangeHandler,
+} from "./actionCreators";
+import GeneSelect from "./GeneSelect";
+import TranscriptDatasetSelect from "./TranscriptDatasetSelect";
+import TranscriptPaginationSelect from "./TranscriptPaginationSelect";
+import styles from "../../../styles/TranscriptPlotConfig.scss";
+
+interface Props {
+  geneSymbol: string | null;
+  expansionAxis: "x" | "y";
+  dimension: Partial<DataExplorerPlotConfigDimensionV2>;
+  limit: number;
+  offset: number;
+  dispatch: (action: PlotConfigReducerAction) => void;
+}
+
+function TranscriptExpansionSelect({
+  geneSymbol,
+  expansionAxis,
+  dimension,
+  limit,
+  offset,
+  dispatch,
+}: Props) {
+  const datasetId = dimension.dataset_id || null;
+
+  return (
+    <div className={styles.TranscriptExpansionSelect}>
+      <GeneSelect
+        value={geneSymbol}
+        onChange={makeGeneOnChangeHandler(
+          expansionAxis,
+          datasetId,
+          limit,
+          dispatch
+        )}
+      />
+      <TranscriptDatasetSelect
+        value={datasetId}
+        onChange={makeDatasetOnChangeHandler(
+          expansionAxis,
+          geneSymbol,
+          limit,
+          dispatch
+        )}
+      />
+      <TranscriptPaginationSelect
+        context={dimension.context}
+        offset={offset}
+        pageSize={limit}
+        onChange={makePaginationOnChangeHandler(
+          expansionAxis,
+          geneSymbol,
+          datasetId,
+          limit,
+          dispatch
+        )}
+      />
+    </div>
+  );
+}
+
+export default TranscriptExpansionSelect;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptPlotConfig.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptPlotConfig.tsx
@@ -1,0 +1,227 @@
+import React from "react";
+import { Button } from "react-bootstrap";
+import { DimensionSelectV2 } from "@depmap/data-explorer-2";
+import Section from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/Section";
+import {
+  ContextPath,
+  DataExplorerPlotType,
+  DataExplorerContextV2,
+  DataExplorerPlotConfigDimensionV2,
+  DimensionKey,
+  PartialDataExplorerPlotConfig,
+} from "@depmap/types";
+import { PlotConfigReducerAction } from "@depmap/data-explorer-2/src/components/DataExplorerPage/reducers/plotConfigReducer";
+import PlotTypeSelect from "./PlotTypeSelect";
+import TranscriptExpansionSelect from "./TranscriptExpansionSelect";
+import { DEFAULT_MAX_TRANSCRIPTS } from "../utils";
+import styles from "../../styles/TranscriptPlotConfig.scss";
+
+interface Props {
+  plot: PartialDataExplorerPlotConfig;
+  dispatch: (action: PlotConfigReducerAction) => void;
+  onClickMakeScatter: () => void;
+  onClickSwapAxisConfigs: () => void;
+  onClickCreateContext: (path: ContextPath) => void;
+  onClickSaveAsContext: (
+    contextToEdit: DataExplorerContextV2,
+    pathToSave: ContextPath
+  ) => void;
+}
+
+function getGeneSymbol(
+  plot: PartialDataExplorerPlotConfig,
+  expansionAxis: "x" | "y"
+) {
+  if (!plot?.dimensions?.[expansionAxis]) {
+    return null;
+  }
+
+  const dimension = plot.dimensions[expansionAxis];
+  return dimension?.context?.name || null;
+}
+
+const getAxisLabel = (plot_type: string | undefined, axis: string) => {
+  if (axis === "y" || plot_type === "waterfall") {
+    return "Y Axis";
+  }
+  if (axis === "x" && plot_type === "scatter") {
+    return "X Axis";
+  }
+
+  return "Axis";
+};
+
+const MakeScatterButton = ({
+  onClickMakeScatter,
+}: {
+  onClickMakeScatter: () => void;
+}) => {
+  return (
+    <Button className={styles.makeScatterButton} onClick={onClickMakeScatter}>
+      <span>scatter</span>
+      <i className="glyphicon glyphicon-arrow-right" />
+    </Button>
+  );
+};
+
+const SwapAxesButton = ({
+  onClickSwapAxisConfigs,
+}: {
+  onClickSwapAxisConfigs: () => void;
+}) => {
+  return (
+    <Button className={styles.swapAxesButton} onClick={onClickSwapAxisConfigs}>
+      <span>swap</span>
+      <i className="glyphicon glyphicon-transfer" />
+    </Button>
+  );
+};
+
+function TranscriptPlotConfig({
+  plot,
+  dispatch,
+  onClickMakeScatter,
+  onClickSwapAxisConfigs,
+  onClickCreateContext,
+  onClickSaveAsContext,
+}: Props) {
+  const expansionAxis =
+    plot.dimensions?.y?.aggregation === "expansion" ? "y" : "x";
+
+  const expansion = plot.expand_by?.[0];
+
+  return (
+    <div className={styles.TranscriptPlotConfig}>
+      <Section title="Transcript Explorer" defaultOpen>
+        <PlotTypeSelect
+          value={plot.plot_type || null}
+          onChange={(nextPlotType) => {
+            if (nextPlotType === plot.plot_type) {
+              return;
+            }
+
+            // If the expansion axis moved to y, we need to put it back on x.
+            const copyExpansion =
+              expansionAxis === "y"
+                ? {
+                    type: "select_dimension",
+                    payload: {
+                      key: "x",
+                      dimension: plot.dimensions!.y,
+                    },
+                  }
+                : null;
+
+            const setPlotType = {
+              type: "select_plot_type",
+              payload: nextPlotType as DataExplorerPlotType,
+            } as any;
+
+            // HACK: We'll make sure the regerssion line stays enabled for
+            // the demo.
+            const setShowRegressionLine = {
+              type: "select_show_regression_line",
+              payload: true,
+            };
+
+            const sortByAlpha =
+              plot.plot_type === "scatter" && nextPlotType !== "scatter"
+                ? {
+                    type: "select_sort_by",
+                    payload: "alphabetical",
+                  }
+                : null;
+
+            dispatch({
+              type: "batch",
+              payload: [
+                copyExpansion,
+                setPlotType,
+                setShowRegressionLine,
+                sortByAlpha,
+              ].filter(Boolean),
+            });
+          }}
+        />
+        <hr className={styles.hr} />
+        <div className={styles.dimensions}>
+          {(["x", "y"] as DimensionKey[])
+            .filter((key) => plot.dimensions?.[key])
+            .map((key) => {
+              const showMakeScatterButton =
+                key === "x" &&
+                plot.dimensions?.x?.dataset_id &&
+                plot.dimensions?.x?.context &&
+                plot.plot_type !== "scatter" &&
+                plot.plot_type !== "correlation_heatmap";
+
+              const showSwapButton =
+                key === "x" && plot.plot_type === "scatter";
+
+              const dimension = plot.dimensions![
+                key
+              ] as Partial<DataExplorerPlotConfigDimensionV2>;
+
+              const path: ContextPath = ["dimensions", key, "context"];
+
+              return (
+                <div key={key}>
+                  <label>{getAxisLabel(plot.plot_type, key)}</label>
+                  {showMakeScatterButton && (
+                    <MakeScatterButton
+                      onClickMakeScatter={onClickMakeScatter}
+                    />
+                  )}
+                  {showSwapButton && (
+                    <SwapAxesButton
+                      onClickSwapAxisConfigs={onClickSwapAxisConfigs}
+                    />
+                  )}
+                  {key === expansionAxis ? (
+                    <TranscriptExpansionSelect
+                      key={key}
+                      geneSymbol={getGeneSymbol(plot, key)}
+                      expansionAxis={expansionAxis}
+                      dimension={dimension}
+                      limit={expansion?.limit ?? DEFAULT_MAX_TRANSCRIPTS}
+                      offset={expansion?.offset ?? 0}
+                      dispatch={dispatch}
+                    />
+                  ) : (
+                    <DimensionSelectV2
+                      index_type={plot.index_type as string}
+                      allowNullFeatureType
+                      value={
+                        (dimension as DataExplorerPlotConfigDimensionV2) || null
+                      }
+                      onChange={(nextDimension) => {
+                        dispatch({
+                          type: "select_dimension",
+                          payload: { key, dimension: nextDimension },
+                        });
+                      }}
+                      mode={
+                        plot.plot_type === "correlation_heatmap"
+                          ? "context-only"
+                          : "entity-or-context"
+                      }
+                      includeAllInContextOptions={
+                        plot.plot_type !== "correlation_heatmap"
+                      }
+                      onClickCreateContext={() => onClickCreateContext(path)}
+                      onClickSaveAsContext={() => {
+                        const context = dimension.context;
+                        onClickSaveAsContext(context!, path);
+                      }}
+                    />
+                  )}
+                </div>
+              );
+            })}
+        </div>
+      </Section>
+    </div>
+  );
+}
+
+export default TranscriptPlotConfig;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptViewOptions/TranscriptColorByTypeSelect.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptViewOptions/TranscriptColorByTypeSelect.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useRef, useState } from "react";
+import { breadboxAPI, cached } from "@depmap/api";
+import { PlotConfigSelect } from "@depmap/data-explorer-2";
+import { ColorByValue, DataExplorerPlotConfig } from "@depmap/types";
+import { getDimensionTypeLabel } from "@depmap/data-explorer-2/src/utils/misc";
+import styles from "../../../styles/TranscriptPlotConfig.scss";
+
+interface Props {
+  enable: boolean;
+  value: string | null;
+  index_type: string;
+  onChange: (nextValue: DataExplorerPlotConfig["color_by"]) => void;
+}
+
+function TranscriptColorByTypeSelect({
+  enable,
+  value,
+  index_type,
+  onChange,
+}: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [indexTypeLabel, setSliceTypeLabel] = useState(
+    getDimensionTypeLabel(index_type)
+  );
+  useEffect(() => {
+    (async () => {
+      cached(breadboxAPI)
+        .getDimensionTypes()
+        .then(() => {
+          setTimeout(() => {
+            setSliceTypeLabel(getDimensionTypeLabel(index_type));
+          });
+        });
+    })();
+  }, [index_type]);
+
+  const options: Partial<Record<ColorByValue, string>> = {
+    raw_slice: indexTypeLabel,
+  };
+
+  options.aggregated_slice = `${indexTypeLabel} Context`;
+  options.property = `${indexTypeLabel} Annotation`;
+  options.custom = "Dataset";
+  options.expansion = "Transcript";
+
+  return (
+    <div ref={ref} className={styles.colorBySelector}>
+      <PlotConfigSelect
+        show
+        isClearable
+        label="Color by"
+        placeholder="Choose type…"
+        options={options}
+        enable={enable}
+        value={value}
+        onChange={(nextValue) => {
+          onChange(nextValue as DataExplorerPlotConfig["color_by"]);
+
+          setTimeout(() => {
+            ref.current?.parentElement?.scrollIntoView({
+              behavior: "smooth",
+              block: "nearest",
+            });
+          }, 0);
+        }}
+      />
+    </div>
+  );
+}
+
+export default TranscriptColorByTypeSelect;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptViewOptions/TranscriptColorByViewOptions.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptViewOptions/TranscriptColorByViewOptions.tsx
@@ -1,0 +1,172 @@
+import React from "react";
+import {
+  ContextSelectorV2,
+  useDataExplorerSettings,
+} from "@depmap/data-explorer-2";
+import { ContextPath, DataExplorerContextV2, FilterKey } from "@depmap/types";
+import DimensionSliceSelect from "@depmap/data-explorer-2/src/components/DimensionSelectV2/DimensionSliceSelect";
+import { PlotConfigReducerAction } from "@depmap/data-explorer-2/src/components/DataExplorerPage/reducers/plotConfigReducer";
+import { ColorByDimensionSelect } from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/selectors";
+import ColorByAnnotationSelect from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/ColorByAnnotationSelect";
+import TranscriptColorByTypeSelect from "./TranscriptColorByTypeSelect";
+import styles from "../../../styles/TranscriptPlotConfig.scss";
+
+interface Props {
+  show: boolean;
+  plot: any;
+  dispatch: (action: PlotConfigReducerAction) => void;
+  onClickCreateContext: (pathToCreate: ContextPath) => void;
+  onClickSaveAsContext: (
+    contextToEdit: DataExplorerContextV2,
+    pathToSave: ContextPath
+  ) => void;
+}
+
+function TranscriptColorByViewOptions({
+  show,
+  plot,
+  dispatch,
+  onClickCreateContext,
+  onClickSaveAsContext,
+}: Props) {
+  const { plotStyles } = useDataExplorerSettings();
+  const { palette } = plotStyles;
+
+  if (!show) {
+    return null;
+  }
+
+  const {
+    index_type,
+    plot_type,
+    color_by,
+    sort_by,
+    dimensions,
+    filters,
+    metadata,
+  } = plot;
+
+  const dataset_id =
+    dimensions?.x?.dataset_id || dimensions?.y?.dataset_id || null;
+
+  return (
+    <div className={styles.TranscriptColorByViewOptions}>
+      <TranscriptColorByTypeSelect
+        enable={Boolean(index_type)}
+        value={color_by || null}
+        index_type={index_type as string}
+        onChange={(nextColorBy) =>
+          dispatch({
+            type: "select_color_by",
+            payload: nextColorBy,
+          })
+        }
+      />
+      <div className={styles.colorByContext}>
+        {(["color1", "color2"] as FilterKey[]).map((filterKey) => (
+          <React.Fragment key={filterKey}>
+            <DimensionSliceSelect
+              show={color_by === "raw_slice"}
+              units={null}
+              isUnknownDataset={false}
+              isLoading={false}
+              dataType={null}
+              dataset_id={dataset_id}
+              index_type={null}
+              slice_type={index_type as string}
+              value={filters?.[filterKey]}
+              onChange={(filter) => {
+                dispatch({
+                  type: "select_filter",
+                  payload: {
+                    key: filterKey,
+                    filter: (filter as unknown) as DataExplorerContextV2,
+                  },
+                });
+              }}
+              swatchColor={
+                filterKey === "color1" ? palette.compare1 : palette.compare2
+              }
+            />
+            <ContextSelectorV2
+              show={color_by === "aggregated_slice"}
+              enable={color_by === "aggregated_slice"}
+              value={filters?.[filterKey]}
+              dimension_type={index_type}
+              swatchColor={
+                filterKey === "color1" ? palette.compare1 : palette.compare2
+              }
+              onClickCreateContext={() => {
+                onClickCreateContext(["filters", filterKey]);
+              }}
+              onClickSaveAsContext={() =>
+                onClickSaveAsContext(filters[filterKey], ["filters", filterKey])
+              }
+              onChange={(filter) => {
+                dispatch({
+                  type: "select_filter",
+                  payload: { key: filterKey, filter },
+                });
+              }}
+            />
+          </React.Fragment>
+        ))}
+      </div>
+      <ColorByAnnotationSelect
+        show={color_by === "property"}
+        dimension_type={index_type as string}
+        value={metadata?.color_property}
+        onChange={(sliceQuery) => {
+          dispatch({
+            type: "select_color_property",
+            payload: sliceQuery,
+          });
+        }}
+        onConvertToColorContext={(context) => {
+          dispatch({
+            type: "batch",
+            payload: [
+              { type: "select_color_by", payload: "aggregated_slice" },
+              {
+                type: "select_filter",
+                payload: {
+                  key: "color1" as FilterKey,
+                  filter: (context as unknown) as DataExplorerContextV2,
+                },
+              },
+            ],
+          });
+        }}
+      />
+      {color_by === "custom" && (
+        <ColorByDimensionSelect
+          plot_type={plot_type}
+          index_type={plot.index_type || null}
+          value={dimensions.color || null}
+          onChange={(dimension) => {
+            dispatch({
+              type: "select_dimension",
+              payload: { key: "color", dimension },
+            });
+          }}
+          onClickCreateContext={() => {
+            const path: ContextPath = ["dimensions", "color", "context"];
+            onClickCreateContext(path);
+          }}
+          onClickSaveAsContext={() => {
+            const path: ContextPath = ["dimensions", "color", "context"];
+            const context = plot.dimensions.color.context;
+            onClickSaveAsContext(context, path);
+          }}
+          // FIXME: A secondary SortBySelector appears when the selected matrix
+          // has categorical values. But "sort by" really belongs with "Group
+          // by" and not "Color by".
+          sortByValue={sort_by}
+          onChangeSortBy={() => {}}
+        />
+      )}
+    </div>
+  );
+}
+
+export default TranscriptColorByViewOptions;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptViewOptions/TranscriptGroupByTypeSelect.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptViewOptions/TranscriptGroupByTypeSelect.tsx
@@ -1,0 +1,62 @@
+import React, { useRef } from "react";
+import { PlotConfigSelect } from "@depmap/data-explorer-2";
+import { ColorByValue, DataExplorerPlotConfig } from "@depmap/types";
+import styles from "../../../styles/TranscriptPlotConfig.scss";
+
+// `group_by` currently reuses ColorByValue. The honest answer to the old
+// "are they the same?" question is no: the renderers only honor a subset of
+// these values as a distinct grouping (today just "expansion"), so a narrower
+// GroupByValue in @depmap/types is the right model. That's deferred along with
+// the rest of the independent group axis (see DEFERRED-GROUP-BY-MODES below);
+// until then this alias keeps the one wired value type-checking.
+type GroupByValue = ColorByValue;
+
+interface Props {
+  enable: boolean;
+  value: string | null;
+  onChange: (nextValue: DataExplorerPlotConfig["group_by"] | null) => void;
+}
+
+function TranscriptGroupByTypeSelect({ enable, value, onChange }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  // HACK (DEFERRED-GROUP-BY-MODES): "expansion" (Transcript) is the only
+  // wired group_by value — the renderers special-case it
+  // (findCategoricalSlice reads data.expansions[0]) and the fetcher attaches
+  // it. The other color_by-shaped modes
+  // (raw_slice/aggregated_slice/property/custom) need an independent group
+  // source plumbed through the fetcher + findCategoricalSlice plus a group
+  // dimension/filters/metadata — a full mirror of color_by — and are
+  // deferred. The select is clearable: clearing unsets group_by, which (via
+  // the existing `group_by ?? color_by` coupling) groups by color_by in the
+  // 1D plots and ungroups entirely in scatter.
+  const options: Partial<Record<GroupByValue, string>> = {
+    expansion: "Transcript",
+  };
+
+  return (
+    <div ref={ref} className={styles.colorBySelector}>
+      <PlotConfigSelect
+        show
+        isClearable
+        label="Group by"
+        placeholder="Choose type…"
+        options={options}
+        enable={enable}
+        value={value}
+        onChange={(nextValue) => {
+          onChange(nextValue as DataExplorerPlotConfig["group_by"] | null);
+
+          setTimeout(() => {
+            ref.current?.parentElement?.scrollIntoView({
+              behavior: "smooth",
+              block: "nearest",
+            });
+          }, 0);
+        }}
+      />
+    </div>
+  );
+}
+
+export default TranscriptGroupByTypeSelect;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptViewOptions/TranscriptGroupByViewOptions.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptViewOptions/TranscriptGroupByViewOptions.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { ContextPath, DataExplorerContextV2 } from "@depmap/types";
+import { PlotConfigReducerAction } from "@depmap/data-explorer-2/src/components/DataExplorerPage/reducers/plotConfigReducer";
+import { SortBySelector } from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/selectors";
+import TranscriptGroupByTypeSelect from "./TranscriptGroupByTypeSelect";
+import styles from "../../../styles/TranscriptPlotConfig.scss";
+
+// HACK (DEFERRED-GROUP-BY-MODES): the only wired group_by value is "expansion"
+// (Transcript), so this panel offers just that — clearable, which hands
+// grouping back to color_by via the pre-existing `group_by ?? color_by`
+// coupling. The property and custom modes (their ColorByAnnotation/
+// ColorByDimension selects, select_group_property, and a `group`
+// dimension/group1 filter) are deferred until group_by is an axis independent
+// of color_by. onClickCreateContext/onClickSaveAsContext stay on Props for
+// when those branches return.
+
+interface Props {
+  show: boolean;
+  plot: any;
+  dispatch: (action: PlotConfigReducerAction) => void;
+  // eslint-disable-next-line
+  onClickCreateContext: (pathToCreate: ContextPath) => void;
+  // eslint-disable-next-line
+  onClickSaveAsContext: (
+    contextToEdit: DataExplorerContextV2,
+    pathToSave: ContextPath
+  ) => void;
+}
+
+function TranscriptGroupByViewOptions({ show, plot, dispatch }: Props) {
+  if (!show) {
+    return null;
+  }
+
+  const { index_type, group_by, sort_by, plot_type } = plot;
+
+  return (
+    <div className={styles.TranscriptGroupByViewOptions}>
+      <TranscriptGroupByTypeSelect
+        enable={Boolean(index_type)}
+        value={group_by || null}
+        onChange={(nextGroupBy) =>
+          dispatch({
+            type: "select_group_by",
+            payload: nextGroupBy,
+          })
+        }
+      />
+      <SortBySelector
+        show={
+          group_by === "expansion" &&
+          ["density_1d", "waterfall"].includes(plot_type)
+        }
+        enable
+        value={sort_by}
+        onChange={(next_sort_by) => {
+          dispatch({
+            type: "select_sort_by",
+            payload: next_sort_by,
+          });
+        }}
+      />
+    </div>
+  );
+}
+
+export default TranscriptGroupByViewOptions;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptViewOptions/index.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptViewOptions/index.tsx
@@ -1,0 +1,130 @@
+import React, { useRef } from "react";
+import {
+  ContextPath,
+  DataExplorerContextV2,
+  PartialDataExplorerPlotConfig,
+} from "@depmap/types";
+import { PlotConfigReducerAction } from "@depmap/data-explorer-2/src/components/DataExplorerPage/reducers/plotConfigReducer";
+import HelpTip from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/HelpTip";
+import Section from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/Section";
+import {
+  ShowIdentityLineCheckbox,
+  ShowPointsCheckbox,
+} from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/selectors";
+import FilterViewOptions from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/FilterViewOptions";
+import { canShowIdentityLine, DEFAULT_MAX_TRANSCRIPTS } from "../../utils";
+import TranscriptMaxToShowSelect from "../TranscriptExpansionSelect/TranscriptMaxToShowSelect";
+import { makeMaxToShowOnChangeHandler } from "../TranscriptExpansionSelect/actionCreators";
+import TranscriptColorByViewOptions from "./TranscriptColorByViewOptions";
+import TranscriptGroupByViewOptions from "./TranscriptGroupByViewOptions";
+import styles from "../../../styles/TranscriptPlotConfig.scss";
+
+interface Props {
+  plot: PartialDataExplorerPlotConfig;
+  dispatch: (action: PlotConfigReducerAction) => void;
+  onClickCreateContext: (pathToCreate: ContextPath) => void;
+  onClickSaveAsContext: (
+    contextToEdit: DataExplorerContextV2,
+    pathToSave: ContextPath
+  ) => void;
+}
+
+function TranscriptViewOptions({
+  plot,
+  dispatch,
+  onClickCreateContext,
+  onClickSaveAsContext,
+}: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const expansionAxis =
+    plot.dimensions?.y?.aggregation === "expansion" ? "y" : "x";
+  const expansionDim = plot.dimensions?.[expansionAxis];
+  const geneSymbol = expansionDim?.context?.name || null;
+  const datasetId = expansionDim?.dataset_id || null;
+  const maxToShow = plot.expand_by?.[0]?.limit ?? DEFAULT_MAX_TRANSCRIPTS;
+
+  return (
+    <Section
+      title="View Options"
+      defaultOpen
+      innerRef={ref}
+      onOpen={() => {
+        setTimeout(() => {
+          ref.current?.scrollIntoView({
+            behavior: "smooth",
+            block: "nearest",
+          });
+        });
+      }}
+    >
+      <ShowPointsCheckbox
+        show={plot.plot_type === "density_1d"}
+        value={!plot.hide_points}
+        onChange={(show_points: boolean) => {
+          dispatch({
+            type: "select_hide_points",
+            payload: !show_points,
+          });
+        }}
+      />
+      <ShowIdentityLineCheckbox
+        show={
+          plot.plot_type === "scatter" &&
+          canShowIdentityLine(plot.dimensions?.x, plot.dimensions?.y)
+        }
+        value={!plot.hide_identity_line}
+        onChange={(showIdentityLine: boolean) => {
+          dispatch({
+            type: "select_hide_identity_line",
+            payload: !showIdentityLine,
+          });
+        }}
+      />
+      <div className={styles.filterAndMax}>
+        <FilterViewOptions
+          plot={plot}
+          dispatch={dispatch}
+          filterKeys={["visible"]}
+          labels={[
+            <span key={0}>
+              Filter
+              <HelpTip id="filter-help" />
+            </span>,
+          ]}
+          onClickCreateContext={onClickCreateContext}
+          onClickSaveAsContext={onClickSaveAsContext}
+        />
+        <TranscriptMaxToShowSelect
+          show={Boolean(geneSymbol)}
+          value={maxToShow}
+          onChange={makeMaxToShowOnChangeHandler(
+            expansionAxis,
+            geneSymbol,
+            datasetId,
+            dispatch
+          )}
+        />
+      </div>
+      <hr className={styles.hr} />
+      <div className={styles.colorAndGroupBy}>
+        <TranscriptColorByViewOptions
+          show
+          plot={plot}
+          dispatch={dispatch}
+          onClickCreateContext={onClickCreateContext}
+          onClickSaveAsContext={onClickSaveAsContext}
+        />
+        <TranscriptGroupByViewOptions
+          show
+          plot={plot}
+          dispatch={dispatch}
+          onClickCreateContext={onClickCreateContext}
+          onClickSaveAsContext={onClickSaveAsContext}
+        />
+      </div>
+    </Section>
+  );
+}
+
+export default TranscriptViewOptions;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/index.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/index.tsx
@@ -1,0 +1,128 @@
+import React from "react";
+import {
+  ContextPath,
+  DataExplorerContextV2,
+  PartialDataExplorerPlotConfig,
+} from "@depmap/types";
+import { PlotConfigReducerAction } from "@depmap/data-explorer-2/src/components/DataExplorerPage/reducers/plotConfigReducer";
+import LinearRegressionInfo from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/LinearRegressionInfo/index";
+import { makeSetExpansionAction, DEFAULT_MAX_TRANSCRIPTS } from "../utils";
+import TranscriptPlotConfig from "./TranscriptPlotConfig";
+import TranscriptViewOptions from "./TranscriptViewOptions";
+import DataExplorerLinks from "./DataExplorerLinks";
+import TableViews from "./TableViews";
+import styles from "@depmap/data-explorer-2/src/components/DataExplorerPage/styles/ConfigurationPanel.scss";
+
+interface Props {
+  plot: PartialDataExplorerPlotConfig;
+  dispatch: (action: PlotConfigReducerAction) => void;
+  onClickCreateContext: (path: ContextPath) => void;
+  onClickSaveAsContext: (
+    contextToEdit: DataExplorerContextV2,
+    pathToSave: ContextPath
+  ) => void;
+}
+
+function TranscriptConfigPanel({
+  plot,
+  dispatch,
+  onClickCreateContext,
+  onClickSaveAsContext,
+}: Props) {
+  const expansionAxis =
+    plot.dimensions?.y?.aggregation === "expansion" ? "y" : "x";
+
+  return (
+    <div className={styles.ConfigurationPanel}>
+      <TranscriptPlotConfig
+        plot={plot}
+        dispatch={dispatch}
+        onClickCreateContext={onClickCreateContext}
+        onClickSaveAsContext={onClickSaveAsContext}
+        onClickMakeScatter={() => {
+          const setScatter = { type: "select_plot_type", payload: "scatter" };
+          const geneSymbol = plot.dimensions!.x!.context!.name;
+
+          const setRegLine = {
+            type: "select_show_regression_line",
+            payload: true,
+          };
+
+          const makeY = {
+            type: "select_dimension",
+            payload: {
+              key: "y",
+              dimension: {
+                axis_type: "raw_slice",
+                aggregation: "first",
+                slice_type: "gene",
+                dataset_id: "expression",
+                context: {
+                  dimension_type: "gene",
+                  name: geneSymbol,
+                  expr: { "==": [{ var: "entity_label" }, geneSymbol] },
+                  vars: {
+                    symbol: {
+                      dataset_id: "gene_metadata",
+                      identifier_type: "column",
+                      identifier: "label",
+                    },
+                  },
+                },
+              },
+            },
+          } as any;
+
+          dispatch({ type: "batch", payload: [setScatter, makeY, setRegLine] });
+        }}
+        onClickSwapAxisConfigs={() => {
+          const geneSymbol = plot.dimensions?.[expansionAxis]?.context?.name;
+          const dataset_id = plot.dimensions?.[expansionAxis]?.dataset_id;
+
+          if (!geneSymbol || !dataset_id) {
+            return;
+          }
+
+          const nextExpansionAxis = expansionAxis === "x" ? "y" : "x";
+
+          // Same gene and dataset — only the axis changes — so the transcript
+          // set is identical; preserve both the page size and the window.
+          const expansion = plot.expand_by?.[0];
+
+          const setExpansion = makeSetExpansionAction(
+            nextExpansionAxis,
+            geneSymbol,
+            dataset_id,
+            expansion?.limit ?? DEFAULT_MAX_TRANSCRIPTS,
+            expansion?.offset ?? 0
+          ) as any;
+
+          const setOtherAxis = {
+            type: "select_dimension",
+            payload: {
+              key: expansionAxis,
+              dimension: plot.dimensions![nextExpansionAxis],
+            },
+          };
+
+          dispatch({ type: "batch", payload: [setExpansion, setOtherAxis] });
+        }}
+      />
+      <TranscriptViewOptions
+        plot={plot}
+        dispatch={dispatch}
+        onClickCreateContext={onClickCreateContext}
+        onClickSaveAsContext={onClickSaveAsContext}
+      />
+      <TableViews plot={plot} expansionAxis={expansionAxis} />
+      <DataExplorerLinks plot={plot} expansionAxis={expansionAxis} />
+      <LinearRegressionInfo
+        show={plot.plot_type === "scatter"}
+        plot={plot}
+        dispatch={dispatch}
+      />
+    </div>
+  );
+}
+
+export default TranscriptConfigPanel;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/useAvailableTranscriptIds.ts
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/useAvailableTranscriptIds.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import { PartialDataExplorerPlotConfig } from "@depmap/types";
+import { fetchDatasetIdentifiers } from "@depmap/data-explorer-2/src/services/dataExplorerAPI/identifiers";
+
+// useAvailableTranscriptIds
+//
+// Returns the set of feature ids the expansion's dataset actually measures, so
+// callers can tell which transcripts have data — vs. ones that exist in
+// transcript_metadata (and so appear in the expansion context) but are missing
+// from the chosen dataset. Returns null while the fetch is in flight or before
+// an expansion is configured; callers should treat null as "not yet known"
+// (i.e. optimistically available) rather than "nothing available".
+//
+// Inputs are resolved from the plot the way the rest of the expansion code
+// does: dataset_id lives on the expansion *dimension* (the select_expansion
+// reducer relocates it there), while slice_type lives on expand_by.
+export default function useAvailableTranscriptIds(
+  plot: PartialDataExplorerPlotConfig,
+  expansionAxis: "x" | "y"
+): Set<string> | null {
+  const datasetId = plot.dimensions?.[expansionAxis]?.dataset_id ?? null;
+  const sliceType = plot.expand_by?.[0]?.slice_type ?? null;
+
+  const [availableIds, setAvailableIds] = useState<Set<string> | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setAvailableIds(null);
+
+    if (datasetId && sliceType) {
+      fetchDatasetIdentifiers(sliceType, datasetId).then((features) => {
+        if (!cancelled) {
+          setAvailableIds(new Set(features.map((f) => f.id)));
+        }
+      });
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [datasetId, sliceType]);
+
+  return availableIds;
+}

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/useContextResult.ts
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/useContextResult.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from "react";
+import { breadboxAPI, cached, BreadboxApiResponse } from "@depmap/api";
+import { DataExplorerContextV2 } from "@depmap/types";
+
+function useContextResult(context?: DataExplorerContextV2 | null) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [result, setResult] = useState<
+    BreadboxApiResponse["evaluateContext"] | null
+  >(null);
+
+  useEffect(() => {
+    if (context) {
+      setIsLoading(true);
+
+      cached(breadboxAPI)
+        .evaluateContext(context)
+        .then((nextResult) => {
+          setResult(nextResult);
+          setIsLoading(false);
+        });
+    } else {
+      setResult(null);
+      setIsLoading(false);
+    }
+  }, [context]);
+
+  return { isLoading, result };
+}
+
+export default useContextResult;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/index.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/index.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from "react";
+import { PartialDataExplorerPlotConfig } from "@depmap/types";
+import {
+  DEFAULT_EMPTY_PLOT,
+  readPlotFromQueryString,
+} from "@depmap/data-explorer-2/src/components/DataExplorerPage/utils";
+import SpinnerOverlay from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/SpinnerOverlay";
+import { EMPTY_TRANSCRIPT_PLOT, focusWhenElementReady } from "./utils";
+import MainContent from "./MainContent";
+import styles from "../styles/TranscriptPlotConfig.scss";
+
+interface Props {
+  feedbackUrl: string | null;
+  contactEmail: string;
+  tutorialLink: string;
+}
+
+function TranscriptExplorerPage({
+  feedbackUrl,
+  contactEmail,
+  tutorialLink,
+}: Props) {
+  const [
+    initialPlot,
+    setInitialPlot,
+  ] = useState<PartialDataExplorerPlotConfig | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        let plot = await readPlotFromQueryString();
+
+        if (plot === DEFAULT_EMPTY_PLOT) {
+          plot = EMPTY_TRANSCRIPT_PLOT;
+          focusWhenElementReady(`.${styles.geneSelect} input`);
+        }
+
+        setInitialPlot(plot);
+      } catch (e) {
+        window.console.error(e);
+        setError(true);
+      }
+    })();
+  }, []);
+
+  return initialPlot ? (
+    <MainContent
+      initialPlot={initialPlot}
+      feedbackUrl={feedbackUrl}
+      contactEmail={contactEmail}
+      tutorialLink={tutorialLink}
+    />
+  ) : (
+    <div className={styles.initialLoadingSpinner}>
+      {!error && <SpinnerOverlay />}
+      {error && (
+        <div className={styles.initialLoadError}>
+          <h1>Sorry, an error occurred</h1>
+          <p>There was an error loading this plot.</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default TranscriptExplorerPage;

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/utils.ts
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/utils.ts
@@ -1,0 +1,128 @@
+import { DataExplorerPlotConfig } from "@depmap/types";
+import { PlotConfigReducerAction } from "@depmap/data-explorer-2/src/components/DataExplorerPage/reducers/plotConfigReducer";
+
+export const SHORT_READ_DATASET =
+  "OmicsExpressionTranscriptTPMLogp1_MC_HumanAllGenes";
+
+export const LONG_READ_DATASET =
+  "OmicsLongReadExpressionTranscriptLogp1HumanAllGenes";
+
+// Default page size ("Max transcripts to show"). Mirrors the platform's
+// DEFAULT_EXPANSION_LIMIT; the hard ceiling is MAX_EXPANSION_MEMBERS.
+export const DEFAULT_MAX_TRANSCRIPTS = 9;
+
+export const EMPTY_TRANSCRIPT_PLOT: DataExplorerPlotConfig = {
+  plot_type: "density_1d",
+  index_type: "depmap_model",
+  dimensions: {
+    x: { dataset_id: SHORT_READ_DATASET },
+  } as DataExplorerPlotConfig["dimensions"],
+  color_by: "expansion",
+  group_by: "expansion",
+  sort_by: "alphabetical",
+  show_regression_line: true,
+};
+
+export function makeSetExpansionAction(
+  expansionAxis: "x" | "y",
+  geneSymbol: string | null,
+  dataset_id: string | null,
+  limit: number = DEFAULT_MAX_TRANSCRIPTS,
+  offset: number = 0
+) {
+  if (!geneSymbol || !dataset_id) {
+    return {
+      type: "batch",
+      payload: [
+        {
+          type: "select_expansion",
+          payload: { key: expansionAxis, expand_by: null },
+        },
+        {
+          type: "select_dimension",
+          payload: { key: expansionAxis, dimension: {} },
+        },
+      ],
+    } as PlotConfigReducerAction;
+  }
+
+  return {
+    type: "select_expansion",
+    payload: {
+      key: expansionAxis,
+      expand_by: {
+        slice_type: "transcript",
+        dataset_id,
+        limit,
+        offset,
+        context: {
+          name: geneSymbol,
+          dimension_type: "transcript",
+          expr: { "==": [{ var: "gene" }, geneSymbol] },
+          vars: {
+            gene: {
+              dataset_id: "transcript_metadata",
+              identifier: "Gene",
+              identifier_type: "column" as const,
+              source: "property" as const,
+            },
+          },
+        },
+      },
+    },
+  } as PlotConfigReducerAction;
+}
+
+export function canShowIdentityLine(
+  xDim?: { dataset_id?: string | undefined },
+  yDim?: { dataset_id?: string | undefined }
+) {
+  if (!xDim || !yDim) {
+    return false;
+  }
+
+  const equivalentDatasets: (string | undefined)[] = [
+    "expression",
+    SHORT_READ_DATASET,
+    LONG_READ_DATASET,
+  ];
+
+  return (
+    equivalentDatasets.includes(xDim.dataset_id) &&
+    equivalentDatasets.includes(yDim.dataset_id)
+  );
+}
+
+export function focusWhenElementReady(selector: string): void {
+  const tryFocus = (): boolean => {
+    const element = document.querySelector<HTMLElement>(selector);
+
+    if (element && !(element as HTMLInputElement).disabled) {
+      element.focus();
+      return true;
+    }
+
+    return false;
+  };
+
+  // Immediate success case
+  if (tryFocus()) {
+    return;
+  }
+
+  // Watch for either:
+  // - the element being added
+  // - the element's disabled attribute changing
+  const observer = new MutationObserver(() => {
+    if (tryFocus()) {
+      observer.disconnect(); // one-shot
+    }
+  });
+
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["disabled"],
+  });
+}

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/styles/TranscriptPlotConfig.scss
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/styles/TranscriptPlotConfig.scss
@@ -1,0 +1,166 @@
+.initialLoadingSpinner {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: calc(100vh - 52px);
+}
+
+.initialLoadError {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  height: 100%;
+  margin-top: 4px;
+}
+
+.hr {
+  margin: 16px 0 12px 0;
+  border-color: #ccc;
+}
+
+.dimensions {
+  display: flex;
+  gap: 16px;
+  margin-bottom: 4px;
+}
+
+.makeScatterButton {
+  margin-left: 41px;
+  height: 20px;
+  padding: 0 4px !important;
+  color: #666;
+  position: relative;
+  top: -2px;
+
+  span {
+    position: relative;
+    top: -2px;
+  }
+
+  i {
+    position: relative;
+    top: -1px;
+    margin-left: 5px;
+    font-size: 11px;
+  }
+}
+
+.swapAxesButton {
+  margin-left: 31px;
+  width: 65px;
+  height: 20px;
+  padding: 0 !important;
+  color: #666;
+  position: relative;
+  top: -2px;
+
+  span {
+    position: relative;
+    top: -2px;
+  }
+
+  i {
+    position: relative;
+    top: 2px;
+    margin-left: 5px;
+  }
+}
+
+.TranscriptExpansionSelect {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+// Don't remove this class! It's used by some JavaScript to focus the element.
+.geneSelect {
+  border: inherit;
+}
+
+.filterAndMax {
+  display: flex;
+  gap: 14px;
+}
+
+.colorAndGroupBy {
+  display: flex;
+  gap: 14px;
+}
+
+.TranscriptColorByViewOptions {
+  margin-bottom: 4px;
+  scroll-margin-bottom: 24px;
+
+  div[data-dimension-select] {
+    margin: 10px 0;
+  }
+}
+
+.TranscriptGroupByViewOptions {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 4px;
+  scroll-margin-bottom: 24px;
+  gap: 10px;
+
+  div[data-dimension-select] {
+    margin: 10px 0;
+  }
+}
+
+.colorByContext {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
+  &:not(:empty) {
+    margin-top: 10px;
+  }
+}
+
+.TableViewsContent {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+
+  button {
+    min-width: 300px;
+  }
+
+  :global .glyphicon {
+    float: right;
+  }
+}
+
+.modal {
+  :global .modal-lg.modal-dialog {
+    width: calc(100% - 150px);
+  }
+
+  :global .modal-body {
+    padding: 20px 20px;
+  }
+}
+
+.tableContainer {
+  height: calc(100vh - 218px);
+}
+
+.geneAnnotationNote {
+  display: flex;
+  flex-wrap: wrap;
+
+  div:nth-child(1) {
+    display: flex;
+    width: 58px;
+
+    b {
+      margin-left: 4px;
+    }
+  }
+
+  div:nth-child(2) {
+    width: 300px;
+  }
+}

--- a/frontend/packages/portal-frontend/webpack.common.js
+++ b/frontend/packages/portal-frontend/webpack.common.js
@@ -29,6 +29,7 @@ module.exports = {
     doseViabilityPrototype: "./src/apps/doseViabilityPrototype.tsx",
     geneTea: "./src/apps/geneTea.tsx",
     custom_analyses: "./src/apps/custom_analyses.tsx",
+    transcriptExplorer: "./src/apps/transcriptExplorer.tsx",
   },
 
   plugins: [

--- a/portal-backend/depmap/app.py
+++ b/portal-backend/depmap/app.py
@@ -33,6 +33,7 @@ from depmap.celligner.views import blueprint as celligner_blueprint
 from depmap.cli_commands.copy_breadbox_names import copy_breadbox_names_cmd
 from depmap.compound.views.index import blueprint as compound_blueprint
 from depmap.compute.views import blueprint as compute_blueprint
+from depmap.transcript_explorer.views import blueprint as transcript_explorer_blueprint
 from depmap.anchor_screen_dashboard.views import (
     blueprint as anchor_screen_dashboard_blueprint,
 )
@@ -347,6 +348,7 @@ def register_blueprints(app: Flask):
     app.register_blueprint(resistance_screen_dashboard_blueprint)
     app.register_blueprint(gene_tea_blueprint)
     app.register_blueprint(custom_analyses_blueprint)
+    app.register_blueprint(transcript_explorer_blueprint)
 
     saved_handlers = app.handle_exception, app.handle_user_exception
     app.register_blueprint(api_blueprint)

--- a/portal-backend/depmap/dev/views.py
+++ b/portal-backend/depmap/dev/views.py
@@ -138,6 +138,11 @@ def table_tester():
     return render_template("dev/table_tester.html")
 
 
+@blueprint.route("/transcript_viewer")
+def transcript_viewer():
+    return render_template("dev/transcript_viewer.html")
+
+
 @blueprint.route("/dose_viability_prototype")
 def dose_viability_prototype():
     return render_template("dev/dose_viability_prototype.html")

--- a/portal-backend/depmap/templates/transcript_explorer/index.html
+++ b/portal-backend/depmap/templates/transcript_explorer/index.html
@@ -1,0 +1,27 @@
+{% extends "full_page.html" %}
+
+{% block page_title %}
+    Transcript Explorer | DepMap Portal
+{% endblock %}
+
+{% block meta_description %}
+  Easily plot all transcripts for a given gene.
+{% endblock %}
+
+{% block content %}
+    <div class='full-screen-div'>
+        {% include "nav_footer/nav.html" %}
+        <div id="react-root"></div>
+    </div>
+{% endblock %}
+
+{% block js %}
+    <script id="transcript-explorer-data" type="application/json">
+      {
+        "feedbackUrl": "{{ config.FEEDBACK_FORM_URL | safe }}",
+        "contactEmail": "{{ config.CONTACT_EMAIL | safe }}",
+        "tutorialLink": "{{ tutorial_link | safe }}"
+      }
+    </script>
+    <script src="{{ webpack_url('transcriptExplorer.js') }}"></script>
+{% endblock %}

--- a/portal-backend/depmap/transcript_explorer/views.py
+++ b/portal-backend/depmap/transcript_explorer/views.py
@@ -1,0 +1,16 @@
+from flask import Blueprint, render_template
+
+blueprint = Blueprint(
+    "transcript_explorer",
+    __name__,
+    url_prefix="/transcript_explorer",
+    static_folder="../static",
+)
+
+
+@blueprint.route("/")
+def view_transcript_explorer():
+    """
+    Entry point
+    """
+    return render_template("transcript_explorer/index.html")


### PR DESCRIPTION
available at: https://cds.team/depmap/transcript_explorer/

Adds the Transcript Explorer, a prototype DE2 route for inspecting transcript-level expression: a gene's plot fans out into its individual transcripts, so a plot of N models becomes N x M (model, transcript) points. It originated from Hannah's transcript-level expression proposal, with CD44 as the driving case study.

Building the prototype required a new, general "expansion" mechanism in DE2 -- the Transcript Explorer is simply its first consumer. Expansion fans a single-axis N-point plot into N x M (entity, expansion-member) pairs. It is deliberately general (the same shape applies to dose curves, replicates, and other raw-vs-aggregate situations); transcripts are just the first instance, and the bulk of this commit is that shared mechanism rather than the prototype-specific UI.

This is a large squashed commit spanning two work sessions. Much of it is load-bearing infrastructure meant to last; a meaningful slice is an explicit interim bandaid around pagination that should be removed once values-informed member selection lands. Read the "TEMPORARY" and "DEFERRED" sections before building on any of it.

## CORE ARCHITECTURE (intended to last)

Expansion is a named, structural plot mode -- not a reinterpretation of existing fields:

* `expand_by` is a single plot-level slot (DataExplorerExpandBy[], length 0 or 1). Making it one slot makes "at most one expansion per plot" structurally true rather than runtime-validated. Shape: { slice_type, context, limit, offset? }. `context` is the RULE that resolves to the expansion members (gene -> its transcripts), evaluated against transcript_metadata, so it is dataset-independent.

* `aggregation: "expansion"` is the SOLE identity marker (the sentinel) for the reading dimension. It is guarded at exactly one dangerous site (the materializer / getMatrixDatasetData aggregate construction) via a narrow isExpansionDimension check, rather than distributing narrowing across ~100 consumer sites. An earlier attempt to model this with a discriminated union was rolled back: it pushed the type-error count from 14 to 72 for no real safety gain (the originating bug was one materializer site, not a systemic type problem). Lesson encoded here: a flat interface + one honest guard beat a "correct" type that taxes every consumer.

* Breadbox arbitrates STRUCTURE, not SEMANTICS. Mechanical validity lives in the data layer; semantic curation lives at the config layer. The standing anti-pattern we are explicitly NOT repeating is `correlation_heatmap`, which overloaded shared fields with bespoke meaning and became a long-term liability. Expansion is a structural mode precisely to avoid that.

* group_by and color_by are separate config fields and are decoupled in the expansion path (gated on expand_by). Renderers resolve grouping through findCategoricalSlice; `group_by ?? color_by` is used where a single grouping key is needed. This is what lets an expanded plot group by transcript while coloring by something else.

* State lives where measurement reality dictates. dataset_id is stored on the expansion DIMENSION (the select_expansion reducer relocates it there); expand_by carries only slice_type / context / limit / offset. (This split is a known footgun -- see GOTCHAS -- it caused a real bug where dataset_id was read off expand_by and came back null.)

* Pair-typed selection. Selecting points in an expanded plot selects (entity, member) PAIRS, modeled with an EntityRef discriminated union ("single" | "pair") and an immutable Map-backed EntityRefSet (with toJSON so JSON.stringify works). pairRef() / entityRefKey() are the constructors/keys.

* normalize() is coherence-aware: it drops `expand_by` whenever no dimension still carries the expansion sentinel, so overwriting the expanding axis with a plain dimension cleans up after itself with no caller-side bookkeeping.

Supporting pieces built on the above: a unified fetcher (fetchExpandedPlot) that materializes the N x M pairs; faceted + pooled linear regression for both the plot and the stats table; expansion-aware point search (de-duped by entity, selecting all of an entity's member points at once); and a grouped expanded-selections panel rendered as a flat fixed-size virtual list whose rows are header/member kinds distinguished only by indentation.

## TEMPORARY / BANDAID -- MUST BE UNDONE OR REPLACED

** Pagination (limit / offset / MAX_EXPANSION_MEMBERS) is a STOPGAP. ** The two-knob windowing model -- `limit` (page size), MAX_EXPANSION_MEMBERS (hard ceiling, currently 16), and `offset` (which window) -- exists only so an arbitrary first-N slice of a gene's transcripts is viewable today. It is NOT the intended long-term design. It should be torn out and replaced by the "best members" selection workstream (see DEFERRED): a values-informed ranking that picks the M most interesting transcripts instead of an arbitrary positional window. When that lands, limit/offset/MAX and the pagination UI (TranscriptPaginationSelect, TranscriptMaxToShowSelect, the offset windowing in the fetcher) come out. Treat all of it as scaffolding.

** "(no data)" placeholders are a BANDAID tied to the pagination stopgap. ** Because datasets are not "total" -- the short-read and long-read transcript datasets each measure different subsets of a gene's transcripts -- a paginated window can include transcripts the chosen dataset never measured. Rather than filter the window per-dataset (which would break the metadata-universe model and de-align the Data Explorer Links list across datasets), we keep the dataset-independent metadata universe and PRESENT the gaps:
  - density tracks and scatter facets for all-null transcripts are kept and labeled "(no data)" instead of being dropped (the page keeps its size);
  - the Data Explorer Links list greys missing transcripts as "(no data)" instead of linking to an empty plot. This is explicitly interim. The real solution is to surface data availability in the stats table so the user makes an informed choice; once that exists, the placeholder/greying machinery (placeholderEmptyTracks, placeholderEmptyFacets, the includeEmpty path in sortLegendKeys1D, the Links availability fetch) should be reconsidered/removed.

** selectedIdsLegacy shim ** -- temporary compatibility so the existing PlotSelections operations keep working until pair-aware operations exist. Remove when selection operations understand EntityRef/EntityRefSet natively.

** HACK markers in code ** -- legacy computations carried forward but quarantined with honest comments:
  - HACK (LEGACY-COMPUTATION): waterfall rank reprojection, linreg, correlation matrix. New expansion code does NOT inherit these workarounds.
  - HACK (DEFERRED-GROUP-BY-MODES): the transcript group-by selector was narrowed to a single option ("Transcript") and the property/custom branches that dispatched unmodeled actions were removed; the broader group-by modes are deferred, not deleted.

## DEFERRED (intentionally not done here)

1. BEST-MEMBERS SELECTION (the headline follow-up). Replace first-N/positional truncation with a values-informed ranking. Design already explored: use Breadbox's aggregation endpoint (POST /datasets/matrix/{dataset_id}, which reads only the M x context block from HDF5 and is NaN-aware, exposing mean|median|per25|per75|stddev) rather than sql/query (rejected: no variance primitive, silently drops context). Open calls deliberately left for the design discussion: context-matched vs. global-intrinsic ranking (lean: context-matched, per the relational-interestingness principle -- a transcript is "interesting" by variance across its siblings in the rendered context, not intrinsically); which stats to show and the default ranking key (lean: SD-desc, n-floor, mean tiebreak); pinned vs. live selection (reproducibility); single multi-stat call vs. several.

2. AVAILABILITY IN THE STATS TABLE -- the real fix for non-total datasets, which retires the "(no data)" bandaids above. The stats table already lists missing transcripts as 0-point rows, so the seam exists.

3. SENTINEL-ROUTING FETCHER MIGRATION. The fetcher still routes by axis_type/slice_type matching; it should route by the `aggregation: "expansion"` sentinel instead. Deferred to avoid churn.

4. BREADBOX TYPE-RELATIONSHIP GRAPH ENDPOINT. Stranded frontend graph-construction utilities should move into Breadbox. Not on the critical path, but identified as the right investment. Success criterion: the annotation picker is migrated onto it and the frontend graph utilities are deleted.

5. `focus` CONCEPT. A unifying primitive underlying high-cardinality color rollup, expansion materialization limits, and legend toggling. Sequenced as late-stage work.

6. PAIR-AWARE PlotSelections operations (removes the selectedIdsLegacy shim). Also: PairsVirtualList hyperlinking is deferred pending a decision on the primary link target; the ExpandedPlotSelections panel intentionally has no Visualize/Copy/Save-as-Context buttons (per product direction).

7. EXPANDED SCATTER sort_by. sort_by currently drives group order on density_1d (and waterfall) only. See GOTCHAS for the normalizer split that needs aligning before scatter facet sorting will persist.

## GOTCHAS / NOTES FOR FUTURE READERS

* The expansion `context` resolves against transcript_metadata = the dataset-INDEPENDENT universe of a gene's transcripts. Individual expression datasets are SUBSETS of that universe (non-total). Do not "fix" missing transcripts by filtering the universe per dataset: that de-aligns pagination windows and the Links list across datasets. The metadata universe is the intended source of truth; availability is presented, not filtered.

* dataset_id lives on the DIMENSION, slice_type on expand_by. The makeSetExpansionAction literal lists dataset_id inside expand_by, but the reducer relocates it to the dimension -- so reading expand_by[0].dataset_id returns null. When touching expansion state, confirm each field's true home rather than trusting the action literal.

* Two surfaces use DIFFERENT "missing" signals, on purpose: the plot keys off "no plottable points in this view" (an all-null track/facet, already computed, no extra fetch); the Links list keys off "not a feature of the dataset" (getDatasetFeatures). A transcript that is in the dataset but null for the current models still gets a live link (clicking opens a valid, if sparse, plot) -- that asymmetry is intended.

* sort_by + placeholders: sortLegendKeys drops all-null categories by design. The expanded group side re-includes them via an includeEmpty path that still RESPECTS sort_by -- alphabetical interleaves the empties; value-based sorts (mean/num_points/min/max) append them at the end, since an all-null group has no value to sort on. An earlier version forced window order and ignored sort_by; that was wrong and was reverted. If you want empties pinned to their window slot under value sorts instead of sinking to the bottom, that is a deliberate one-line change.

* Two normalizers, slightly divergent for scatter. normalizePlot (utils.ts) now preserves sort_by for ANY expanded plot. The reducer's normalize only keeps sort_by for density_1d/waterfall. They agree for density_1d (the shipped case) but diverge for scatter: an expanded scatter would lose sort_by on the next dimension-changing action. Align both (gate scatter on expand_by) before enabling scatter facet sorting.

* Density "(no data)" label is PREPENDED, not appended: the y-axis ticktext truncates names to ~25 chars and a transcript label alone exceeds that, so a trailing marker would be cut off.

* Autorange edge case (cosmetic): an all-null placeholder track/facet has no drawn geometry, so the axis autoranges over the populated tracks. A missing transcript at the very first/last window position can place its "(no data)" tick at the plot edge. Interior gaps render cleanly.

* useAvailableTranscriptIds fetches per hook instance; the underlying fetchDatasetIdentifiers call is cached, so two simultaneous consumers hit the cache rather than the network. Lift to a shared parent only if that ever matters.

* Why transcripts model the way they do: the protein FK is at GENE level, not transcript, because mass spectrometry cannot resolve isoform identity -- the schema reflects measurement reality. reindex_through resolves "downhill" (transcript-indexed -> gene-level) but not "uphill" (gene -> its individual transcripts); expansion is the uphill mechanism.

* Constants (current values): MAX_EXPANSION_MEMBERS = 16 (hard ceiling), DEFAULT_EXPANSION_LIMIT = 9 (platform default page size), DEFAULT_MAX_TRANSCRIPTS = 9 (TranscriptViewer). The 9 is a 3x3 grid default. All three are pagination-stopgap parameters (see TEMPORARY).