### PR TITLE
Add cloudflare turnstile support to verify user is not a bot

### DIFF
--- a/config/public/settings.py
+++ b/config/public/settings.py
@@ -52,6 +52,8 @@ class ExternalConfig(RemoteConfig):
     FORUM_RESOURCES_CATEGORY = "resources"
     FORUM_RESOURCES_DEFAULT_TOPIC_ID = 3396
     BREADBOX_PROXY_DEFAULT_USER = "anonymous"
+    TURNSTILE_SITE_KEY = "0x4AAAAAADUm6LZT0GHl88BI"
+    TURNSTILE_SECRET_KEY = os.getenv("TURNSTILE_SECRET_KEY")
 
 
 class ExternalQAConfig(ExternalConfig):

--- a/portal-backend/depmap/app.py
+++ b/portal-backend/depmap/app.py
@@ -61,6 +61,7 @@ from depmap.extensions import (
     markdown,
     methylation_db,
     breadbox,
+    turnstile,
 )
 from depmap.gene.views.index import blueprint as gene_blueprint
 from depmap.global_search.views import blueprint as global_search_blueprint
@@ -243,7 +244,12 @@ def register_extensions(app: Flask):
     cansar.init_app(app)
     breadbox.init_app(app)
 
+    # if we don't have a site key, don't add turnstile
+    if app.config.get("TURNSTILE_SITE_KEY") is not None:
+        turnstile.init_app(app)
+
     exception_reporter.init_app(app, service_name="depmap-" + app.config["ENV"])
+
     markdown(app)
     humanize(app)
 

--- a/portal-backend/depmap/extensions.py
+++ b/portal-backend/depmap/extensions.py
@@ -16,6 +16,7 @@ from .methylation.extension import MethylationDbExtension
 from depmap.cansar.extension import CansarExtension
 from depmap.breadbox_shim.extension import BreadboxClientExtension
 from functools import wraps
+from depmap.flask_turnstile import Turnstile
 
 bcrypt = Bcrypt()
 csrf_protect = CSRFProtect()
@@ -26,6 +27,7 @@ in_memory_cache = Cache()
 debug_toolbar = DebugToolbarExtension()
 exception_reporter = ExceptionReporter()
 markdown = Markdown
+turnstile = Turnstile()
 humanize = Humanize
 methylation_db = MethylationDbExtension()
 cansar = CansarExtension()

--- a/portal-backend/depmap/flask_turnstile/__init__.py
+++ b/portal-backend/depmap/flask_turnstile/__init__.py
@@ -1,0 +1,1 @@
+from .extension import Turnstile

--- a/portal-backend/depmap/flask_turnstile/extension.py
+++ b/portal-backend/depmap/flask_turnstile/extension.py
@@ -1,0 +1,113 @@
+import re
+import urllib.parse
+
+import requests
+from flask import Blueprint, redirect, render_template, request
+from itsdangerous import BadSignature, SignatureExpired, TimestampSigner
+
+
+class Turnstile:
+    def __init__(self, app=None):
+        if app is not None:
+            self.init_app(app)
+
+    def init_app(self, app):
+        for key in ("TURNSTILE_SITE_KEY", "TURNSTILE_SECRET_KEY", "SECRET_KEY"):
+            if not app.config.get(key):
+                raise RuntimeError(f"Flask-Turnstile requires {key} in app.config")
+
+        blueprint = Blueprint(
+            "verify_turnstile", __name__, template_folder="templates",
+        )
+
+        def verify():
+            token = request.form.get("cf-turnstile-response", "")
+            next_url = request.form.get("next_url", "/")
+
+            parsed = urllib.parse.urlparse(next_url)
+            if parsed.scheme or parsed.netloc:
+                req_parsed = urllib.parse.urlparse(request.url)
+                if (
+                    parsed.scheme != req_parsed.scheme
+                    or parsed.netloc != req_parsed.netloc
+                ):
+                    return "Invalid next_url", 400
+
+            secret_key = app.config["TURNSTILE_SECRET_KEY"]
+            site_key = app.config["TURNSTILE_SITE_KEY"]
+
+            try:
+                resp = requests.post(
+                    "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+                    json={"secret": secret_key, "response": token},
+                    timeout=10,
+                )
+                data = resp.json()
+            except Exception as exc:
+                app.logger.error("Turnstile verification request failed: %s", exc)
+                response = redirect(next_url)
+                _set_cookie(app, response)
+                return response
+
+            if not data.get("success"):
+                return render_template(
+                    "turnstile_challenge.html",
+                    site_key=site_key,
+                    next_url=next_url,
+                    error=True,
+                )
+
+            response = redirect(next_url)
+            _set_cookie(app, response)
+            return response
+
+        blueprint.add_url_rule(
+            "/verify-turnstile-token",
+            endpoint="verify",
+            view_func=verify,
+            methods=["POST"],
+        )
+        app.register_blueprint(blueprint)
+
+        @app.before_request
+        def _gate():
+            if request.endpoint == "verify_turnstile.verify":
+                return None
+
+            bypass_patterns = app.config.get("TURNSTILE_BYPASS", [])
+            print("request.path", request.path)
+            for pattern in bypass_patterns:
+                if re.match(pattern, request.path):
+                    print("Bypassing due to", pattern)
+                    return None
+
+            cookie_value = request.cookies.get("PROBABLY_HUMAN")
+            if cookie_value:
+                signer = TimestampSigner(app.config["SECRET_KEY"])
+                max_age = app.config.get("TURNSTILE_COOKIE_EXPIRY", 604800)
+                try:
+                    signer.unsign(cookie_value, max_age=max_age)
+                    return None
+                except (SignatureExpired, BadSignature):
+                    pass
+
+            return render_template(
+                "turnstile_challenge.html",
+                site_key=app.config["TURNSTILE_SITE_KEY"],
+                next_url=request.url,
+                error=False,
+            )
+
+
+def _set_cookie(app, response):
+    signer = TimestampSigner(app.config["SECRET_KEY"])
+    signed = signer.sign("1").decode()
+    max_age = app.config.get("TURNSTILE_COOKIE_EXPIRY", 604800)
+    response.set_cookie(
+        "PROBABLY_HUMAN",
+        signed,
+        max_age=max_age,
+        httponly=True,
+        secure=True,
+        samesite="Strict",
+    )

--- a/portal-backend/depmap/flask_turnstile/extension.py
+++ b/portal-backend/depmap/flask_turnstile/extension.py
@@ -4,6 +4,7 @@ import urllib.parse
 import requests
 from flask import Blueprint, redirect, render_template, request
 from itsdangerous import BadSignature, SignatureExpired, TimestampSigner
+from typing import cast, Optional
 
 
 class Turnstile:
@@ -21,12 +22,19 @@ class Turnstile:
         )
 
         def verify():
-            token = request.form.get("cf-turnstile-response", "")
-            next_url = request.form.get("next_url", "/")
+            parameters: dict[str, Optional[str]] = cast(
+                dict[str, Optional[str]], request.form
+            )
+            token = parameters.get("cf-turnstile-response", "")
+            next_url = parameters.get("next_url", "/")
+            assert isinstance(next_url, str)
+
+            request_url: str = cast(str, request.url)
+            assert isinstance(request_url, str)
 
             parsed = urllib.parse.urlparse(next_url)
             if parsed.scheme or parsed.netloc:
-                req_parsed = urllib.parse.urlparse(request.url)
+                req_parsed = urllib.parse.urlparse(request_url)
                 if (
                     parsed.scheme != req_parsed.scheme
                     or parsed.netloc != req_parsed.netloc
@@ -74,14 +82,15 @@ class Turnstile:
             if request.endpoint == "verify_turnstile.verify":
                 return None
 
-            bypass_patterns = app.config.get("TURNSTILE_BYPASS", [])
-            print("request.path", request.path)
+            bypass_patterns: list[str] = app.config.get("TURNSTILE_BYPASS", [])
+            request_path: str = cast(str, request.path)
+            assert isinstance(request_path, str)
             for pattern in bypass_patterns:
-                if re.match(pattern, request.path):
+                if re.match(pattern, request_path):
                     print("Bypassing due to", pattern)
                     return None
 
-            cookie_value = request.cookies.get("PROBABLY_HUMAN")
+            cookie_value = request.cookies.get("PROBABLY_HUMAN")  # pyright: ignore
             if cookie_value:
                 signer = TimestampSigner(app.config["SECRET_KEY"])
                 max_age = app.config.get("TURNSTILE_COOKIE_EXPIRY", 604800)

--- a/portal-backend/depmap/settings/settings.py
+++ b/portal-backend/depmap/settings/settings.py
@@ -354,6 +354,16 @@ class Config(object):
     # How long to wait for breadbox before reporting a timeout (in proxy)
     BREADBOX_PROXY_TIMEOUT = 60
 
+    # setting site key to None disables Turnstile check
+    TURNSTILE_SITE_KEY = None
+    TURNSTILE_SECRET_KEY = None
+    # alternatively, if you want to test turnstile, you can use Cloudflare's always-pass test keys:
+    # https://developers.cloudflare.com/turnstile/troubleshooting/testing/
+    # just uncomment the below
+    # TURNSTILE_SITE_KEY = "1x00000000000000000000AA"
+    # TURNSTILE_SECRET_KEY = "1x0000000000000000000000000000000AA"
+    TURNSTILE_BYPASS = [".*/static/.*", "^/$", "^/terms_text$"]
+
 
 class RemoteConfig(Config):
     CACHE_TYPE = "redis"

--- a/portal-backend/install_prereqs.sh
+++ b/portal-backend/install_prereqs.sh
@@ -25,13 +25,13 @@ done
 source setup_env.sh
 
 # install python requirements
-pyenv install "$(cat .python-version)"
+pyenv install -s "$(cat .python-version)"
 poetry env use "$(pyenv which python)"
 poetry install
 
 # generate python version of shared constants between frontend and backend
-python ../depmap-shared/generate-py ../depmap-shared/color_palette.json depmap/utilities/_color_palette.py
-python ../depmap-shared/generate-ts-from-schema.py ../pipeline/scripts/format_models.py schema ModelAnnotation ../frontend/packages/portal-frontend/src/cellLine/models/ModelAnnotation.ts
+poetry run python ../depmap-shared/generate-py ../depmap-shared/color_palette.json depmap/utilities/_color_palette.py
+poetry run python ../depmap-shared/generate-ts-from-schema.py ../pipeline/preprocessing-pipeline/scripts/format_models.py schema ModelAnnotation ../frontend/packages/portal-frontend/src/cellLine/models/ModelAnnotation.ts
 
 # install static assets used by depmap
 yarn --cwd depmap install --modules-folder static/libs
@@ -40,7 +40,7 @@ yarn --cwd depmap install --modules-folder static/libs
 yarn --cwd ../frontend install
 
 # Bundle and minify static css assets (like global.css)
-./flask assets build
+poetry run ./flask assets build
 
 # delete any old hooks because we want all hooks managed by pre-commit
 rm -rf .git/hooks

--- a/portal-backend/pyright-ratchet-errors.txt
+++ b/portal-backend/pyright-ratchet-errors.txt
@@ -22,11 +22,6 @@ app.py: error: Cannot access member "version" for type "list[str]"
 app.py: error: Cannot assign member "json_encoder" for type "Flask"
 app.py: error: No overloads for "__getitem__" match the provided arguments (reportCallIssue)
 app.py: error: No overloads for "join" match the provided arguments (reportCallIssue)
-association_loader.py: error: "dataset_id" is not a known member of "None" (reportOptionalMemberAccess)
-association_loader.py: error: "name" is not a known member of "None" (reportOptionalMemberAccess)
-association_loader.py: error: Argument of type "Literal['WEBAPP_DATA_DIR']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
-association_loader.py: error: Argument of type "str" cannot be assigned to parameter "__key" of type "LiteralString" in function "__getitem__"
-association_loader.py: error: No overloads for "__getitem__" match the provided arguments (reportCallIssue)
 autoapp.py: error: "DispatcherMiddleware" is unknown import symbol (reportAttributeAccessIssue)
 biomarker_loader.py: error: "dataset_versions" is not defined (reportUndefinedVariable)
 biomarker_loader.py: error: "record" is possibly unbound (reportPossiblyUnboundVariable)
@@ -75,9 +70,6 @@ conftest.py: error: Argument of type "dict[str, Any]" cannot be assigned to para
 conftest.py: error: Expression of type "None" cannot be assigned to parameter of type "str"
 conftest.py: error: No overloads for "__getitem__" match the provided arguments (reportCallIssue)
 conftest.py: error: No overloads for "update" match the provided arguments (reportCallIssue)
-constellation_loader.py: error: Argument of type "Literal['ENV']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
-constellation_loader.py: error: Argument of type "Literal['WEBAPP_DATA_DIR']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
-constellation_loader.py: error: No overloads for "__getitem__" match the provided arguments (reportCallIssue)
 context_explorer_loader.py: error: Argument of type "Literal['WEBAPP_DATA_DIR']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 context_explorer_loader.py: error: No overloads for "__getitem__" match the provided arguments (reportCallIssue)
 database.py: error: Cannot access member "Boolean" for type "SQLAlchemy"
@@ -118,10 +110,6 @@ download_settings.py: error: Argument of type "Literal['ENV']" cannot be assigne
 download_settings.py: error: Argument of type "Literal['SHOW_TAIGA_IN_DOWNLOADS']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 download_settings.py: error: Cannot access member "get" for type "list[str]"
 download_settings.py: error: No overloads for "__getitem__" match the provided arguments (reportCallIssue)
-enrichment.py: error: Argument of type "Geneset" cannot be assigned to parameter "__value" of type "set[Unknown]" in function "__setitem__"
-enrichment.py: error: Cannot access member "genes" for type "set[Unknown]"
-enrichment.py: error: Expression of type "list[None]" cannot be assigned to declared type "List[List[str]]"
-enrichment.py: error: Expression of type "list[None]" cannot be assigned to declared type "List[str]"
 executive.py: error: "_has_statsmodels" is not a known member of module "seaborn.distributions" (reportAttributeAccessIssue)
 executive.py: error: "ax" is possibly unbound (reportPossiblyUnboundVariable)
 executive.py: error: "groups" is not a known member of "None" (reportOptionalMemberAccess)
@@ -137,7 +125,6 @@ executive.py: error: Cannot access member "spines" for type "ndarray[Any, dtype[
 executive.py: error: Cannot access member "tick_params" for type "ndarray[Any, dtype[Any]]"
 executive.py: error: Expected type expression but received "(typename: str, fields: dict[str, type[Any]], total: bool = ...) -> type[dict[str, Any]]" (reportGeneralTypeIssues)
 executive.py: error: Expression of type "None" cannot be assigned to parameter of type "DependencyDataset"
-executive.py: error: Expression of type "None" cannot be assigned to parameter of type "List[int]"
 executive.py: error: Expression of type "dict[Any, Any]" cannot be assigned to declared type "CrisprDepDistInfo" (reportAssignmentType)
 executive.py: error: Expression of type "dict[Any, Any]" cannot be assigned to declared type "GeneExecutiveInfoDict" (reportAssignmentType)
 executive.py: error: Expression of type "tuple[CompoundExperiment | None, Unknown | None]" cannot be assigned to return type "Tuple[CompoundExperiment, DependencyDataset]"
@@ -187,38 +174,13 @@ hdf5_utils.py: error: Cannot access member "shape" for type "Datatype"
 hdf5_utils.py: error: Cannot access member "shape" for type "Group"
 hdf5_utils.py: error: No overloads for "__call__" match the provided arguments (reportCallIssue)
 hdf5_utils.py: error: No overloads for "apply_along_axis" match the provided arguments (reportCallIssue)
-index.py: error: "about" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "celfie" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "characterizations" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "correlations" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "depmap_id" is not a known member of "None" (reportOptionalMemberAccess)
-index.py: error: "display_name" is not a known member of "None" (reportOptionalMemberAccess)
-index.py: error: "entity_id" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "gene_name" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "has_celfie" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "has_confidence" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "has_datasets" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "has_predictability" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "matrix" is not a known member of "None" (reportOptionalMemberAccess)
-index.py: error: "name" is not a known member of "None" (reportOptionalMemberAccess)
-index.py: error: "order" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "predictability_custom_downloads_link" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "predictability_methodology_link" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "pubmed_search_terms" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "show_mutations_tile" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "show_omics_expression_tile" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "show_targeting_compounds_tile" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "summary" is possibly unbound (reportPossiblyUnboundVariable)
-index.py: error: "title" is possibly unbound (reportPossiblyUnboundVariable)
 index.py: error: Argument of type "(model: PredictiveModel) -> (int | None)" cannot be assigned to parameter "key" of type "(PredictiveModel) -> SupportsRichComparison" in function "sort"
-index.py: error: Argument of type "Index | Any | Unknown" cannot be assigned to parameter "model_ids" of type "Sequence[str]" in function "get_cell_line_display_names"
 index.py: error: Argument of type "Literal['ENABLED_FEATURES']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 index.py: error: Argument of type "Literal['WEBAPP_DATA_DIR']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 index.py: error: Cannot access member "any" for type "List[Gene]"
 index.py: error: Cannot access member "get" for type "list[str]"
 index.py: error: No overloads for "__getitem__" match the provided arguments (reportCallIssue)
 index.py: error: No overloads for "sort" match the provided arguments (reportCallIssue)
-index.py: error: Object of type "None" is not subscriptable (reportOptionalSubscript)
 initialize_auth_config.py: error: Argument of type "type[GroupAuthConfig]" cannot be assigned to parameter "groups" of type "List[GroupAuthConfig]" in function "_create_authorization_config"
 initialize_current_auth.py: error: Argument of type "str | None" cannot be assigned to parameter "user_id_override" of type "str" in function "_setup_current_authorizations"
 initialize_current_auth.py: error: Cannot access member "groups" for type "list[str]"
@@ -267,7 +229,6 @@ models.py: error: Cannot access member "download_file" for type "_File*"
 models.py: error: Cannot access member "gene" for type "_Gene*"
 models.py: error: Cannot access member "nominal_range" for type "TabularDatasetMeta"
 models.py: error: Cannot access member "relationship" for type "SQLAlchemy"
-models.py: error: Cannot access member "unquote" for type "type[Serializer]"
 models.py: error: Cannot assign member "funding" for type "DownloadRelease*"
 models.py: error: Expression of type "None" cannot be assigned to parameter of type "Dict[int, GroupAuthConfig]"
 models.py: error: Expression of type "None" cannot be assigned to parameter of type "str"
@@ -383,10 +344,7 @@ test_global_search_loader.py: error: "__load_context_search_index" is not a know
 test_global_search_loader.py: error: "__load_gene_search_index" is not a known member of module "loader.global_search_loader" (reportAttributeAccessIssue)
 test_global_search_loader.py: error: Cannot access member "entity_id" for type "CompoundFactory"
 test_hdf5_utils.py: error: Cannot access member "tolist" for type "float"
-test_index.py: error: Cannot access member "entity_id" for type "CompoundExperimentFactory"
-test_index.py: error: Cannot access member "entity_id" for type "CompoundFactory"
 test_index.py: error: Cannot access member "entity_id" for type "GeneFactory"
-test_index.py: error: Cannot access member "xref_full" for type "CompoundExperimentFactory"
 test_index.py: error: Object of type "None" is not subscriptable (reportOptionalSubscript)
 test_match_related_loader.py: error: "entity_id" is not a known member of "None" (reportOptionalMemberAccess)
 test_models.py: error: "__getitem__" method not defined on type "LazyAttribute" (reportIndexIssue)
@@ -429,13 +387,8 @@ test_predictability_loader.py: error: "entity_id" is not a known member of "None
 test_predictability_loader.py: error: "name" is not a known member of "None" (reportOptionalMemberAccess)
 test_predictability_loader.py: error: Argument of type "Literal[DependencyEnum.Chronos_Combined]" cannot be assigned to parameter "dependency_dataset_name" of type "str" in function "get_dataset_by_name"
 test_tasks.py: error: Cannot access member "entity_id" for type "GeneFactory"
-test_trees.py: error: Cannot access member "entity_id" for type "GeneFactory"
 test_utils.py: error: "__get_taiga_id_to_download_url" is unknown import symbol (reportAttributeAccessIssue)
-test_utils.py: error: Cannot access member "dataset_id" for type "DependencyDatasetFactory"
-test_utils.py: error: Cannot access member "entity_id" for type "GeneFactory"
-test_utils.py: error: Cannot access member "matrix_id" for type "LazyAttribute"
 test_views.py: error: Cannot access member "entity_id" for type "SubFactory"
-test_views.py: error: Object of type "None" is not subscriptable (reportOptionalSubscript)
 util.py: error: Argument of type "Literal['CAS_BUCKET']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 util.py: error: Argument of type "Literal['DOWNLOADS_KEY']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 util.py: error: Expression of type "None" cannot be assigned to parameter of type "Client"
@@ -443,21 +396,15 @@ util.py: error: Expression of type "None" cannot be assigned to return type "str
 util.py: error: No overloads for "__getitem__" match the provided arguments (reportCallIssue)
 utils.py: error: "abs_dest_path" is possibly unbound (reportPossiblyUnboundVariable)
 utils.py: error: "base_name" is possibly unbound (reportPossiblyUnboundVariable)
-utils.py: error: "display_name" is not a known member of "None" (reportOptionalMemberAccess)
-utils.py: error: "name" is not a known member of "None" (reportOptionalMemberAccess)
-utils.py: error: "reset_index" is not a known member of "None" (reportOptionalMemberAccess)
 utils.py: error: Argument of type "Literal['ANNOUNCEMENTS_FILE_PATH']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 utils.py: error: Argument of type "Literal['OAUTH_SIGNATURE_KEY']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 utils.py: error: Argument of type "Literal['TAIGA_CACHE_DIR']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
-utils.py: error: Argument of type "Literal['WEBAPP_DATA_DIR']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 utils.py: error: Argument of type "Unknown | None" cannot be assigned to parameter "string" of type "bytes | bytearray" in function "quote" (reportArgumentType)
 utils.py: error: Cannot access member "get" for type "list[str]"
-utils.py: error: Expression of type "None" cannot be assigned to return type "DataFrame"
 utils.py: error: No overloads for "__getitem__" match the provided arguments (reportCallIssue)
 utils.py: error: No overloads for "quote" match the provided arguments (reportCallIssue)
 views.py: error: "__getitem__" method not defined on type "Datatype" (reportIndexIssue)
 views.py: error: "csv_path" is possibly unbound (reportPossiblyUnboundVariable)
-views.py: error: "dataset_id" is not a known member of "None" (reportOptionalMemberAccess)
 views.py: error: "dataset_name" is possibly unbound (reportPossiblyUnboundVariable)
 views.py: error: "get" is not a known member of "None" (reportOptionalMemberAccess)
 views.py: error: "index" is not a known member of "None" (reportOptionalMemberAccess)
@@ -467,7 +414,6 @@ views.py: error: "name" is not a known member of "None" (reportOptionalMemberAcc
 views.py: error: "source_dir" is possibly unbound (reportPossiblyUnboundVariable)
 views.py: error: Argument expression after ** must be a mapping with a "str" key type (reportCallIssue)
 views.py: error: Argument of type "Literal['COMPUTE_RESULTS_ROOT']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
-views.py: error: Argument of type "Literal['CONTACT_EMAIL']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 views.py: error: Argument of type "Literal['DMC_SYMPOSIA_PATH']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 views.py: error: Argument of type "Literal['DOCUMENTATION_PATH']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 views.py: error: Argument of type "Literal['DOWNLOADS_KEY']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
@@ -490,21 +436,16 @@ views.py: error: Argument of type "Literal['url']" cannot be assigned to paramet
 views.py: error: Argument of type "Literal['user_id']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 views.py: error: Argument of type "Literal['value']" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
 views.py: error: Argument of type "Literal[DependencyEnum.Avana]" cannot be assigned to parameter "dependency_dataset_name" of type "str" in function "get_dataset_by_name"
-views.py: error: Argument of type "Unknown | FileStorage" cannot be assigned to parameter "filepath_or_buffer" of type "FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str]" in function "read_csv" (reportArgumentType)
 views.py: error: Argument of type "str | Any" cannot be assigned to parameter "__s" of type "slice" in function "__getitem__"
-views.py: error: Argument of type "str | None" cannot be assigned to parameter "s" of type "str | bytes | bytearray" in function "loads" (reportArgumentType)
 views.py: error: Argument of type "str" cannot be assigned to parameter "__value" of type "_VT@dict" in function "__setitem__"
 views.py: error: Cannot access member "any" for type "List[Gene]"
 views.py: error: Cannot access member "apply" for type "function"
-views.py: error: Cannot access member "genes" for type "set[Unknown]"
 views.py: error: Cannot access member "get" for type "list[str]"
 views.py: error: Cannot access member "getlist" for type "list[str]"
 views.py: error: Cannot access member "rename" for type "float"
-views.py: error: Cannot access member "term" for type "set[Unknown]"
 views.py: error: Cannot access member "to_dict" for type "list[str]"
 views.py: error: Expected type expression but received "(typename: str, fields: dict[str, type[Any]], total: bool = ...) -> type[dict[str, Any]]" (reportGeneralTypeIssues)
 views.py: error: Expression of type "None" cannot be assigned to parameter of type "List[Tuple[CompoundExperiment, DependencyDataset]]"
 views.py: error: No overloads for "__getitem__" match the provided arguments (reportCallIssue)
-views.py: error: No overloads for "read_csv" match the provided arguments (reportCallIssue)
 views.py: error: Object of type "None" is not subscriptable (reportOptionalSubscript)
 views.py: error: Variable not allowed in type expression (reportInvalidTypeForm)


### PR DESCRIPTION
The public portal has been occasionally been overwhelmed lately. This will add a verification to confirm cloudflare thinks this user is human before letting them proceed to the majority of the site.