### PR TITLE
fix(breadbox): prevent Redis pub/sub connection corruption on SQL tas…

### DIFF
--- a/breadbox/breadbox/api/temp/sql.py
+++ b/breadbox/breadbox/api/temp/sql.py
@@ -168,7 +168,9 @@ async def query_sql(
                 },
             )
         except UserError as e:
-            return JSONResponse(status_code=e.status_code, content={"detail": e.detail})
+            raise
+        except Exception as e:
+            raise Exception(f"Exception executing sql query {query.sql}") from e
 
         assert isinstance(output_file, str)
         return CSVFileResponse(output_file)

--- a/breadbox/breadbox/api/temp/sql.py
+++ b/breadbox/breadbox/api/temp/sql.py
@@ -101,12 +101,22 @@ async def _run_time_bounded_celery_task(
     """
     task = task_fn.apply_async(args=args, time_limit=time_limit)
 
-    # run the get() in an executor so that this coroutine can yield to any other requests
-    result = await anyio.to_thread.run_sync(
-        lambda: task.get(timeout=time_limit + time_limit_padding)
+    # Use propagate=False so task.get() returns normally instead of raising the task's
+    # exception. When propagate=True (the default), a task failure causes the exception
+    # to propagate through Celery's generator-based drain_events_until/_wait_for_pending
+    # chain. Python doesn't close generators when an exception escapes a for-loop, so
+    # their finally blocks (including the Redis pub/sub unsubscribe) never run. The shared
+    # _pubsub connection (a @cached_property on the backend) is then left subscribed to
+    # the stale channel, and subsequent calls read leftover bytes (b'1') as a Redis
+    # protocol response, causing InvalidResponse errors for all queries until restart.
+    await anyio.to_thread.run_sync(
+        lambda: task.get(timeout=time_limit + time_limit_padding, propagate=False)
     )
 
-    return result
+    if task.state == "FAILURE":
+        raise task.result
+
+    return task.result
 
 
 @router.post("/sql/query", operation_id="query_sql", response_class=CSVFileResponse)
@@ -158,10 +168,7 @@ async def query_sql(
                 },
             )
         except UserError as e:
-            raise
-        except Exception as e:
-            breakpoint()
-            raise Exception(f"Exception executing sql query {query.sql}") from e
+            return JSONResponse(status_code=e.status_code, content={"detail": e.detail})
 
         assert isinstance(output_file, str)
         return CSVFileResponse(output_file)


### PR DESCRIPTION
# Fix: Prevent Redis pub/sub connection corruption on SQL task failure

## Problem

The `/temp/sql/query` endpoint uses a Celery worker (backed by Redis) to execute SQL queries. Twice in production, the service entered a broken state where all SQL queries returned 500 errors until the service was restarted. The symptom was:

```
redis.exceptions.InvalidResponse: Protocol Error: b'1'
```

## Root cause

The bug is triggered by submitting a SQL query with invalid syntax. The Celery task raises a `UserError`, which `task.get()` re-raises on the API side using the default `propagate=True`. This causes the exception to propagate through Celery's generator-based polling chain (`wait_for_pending` → `_wait_for_pending` → `drain_events_until`).

Python does not automatically call `.close()` on a generator when an exception escapes a `for _ in generator:` loop — the generators are abandoned mid-execution. Any cleanup in their `finally` blocks, including the Redis pub/sub **unsubscribe**, never runs. The `_pubsub` connection is a `@cached_property` shared across all calls on the same backend instance, so it's now permanently stuck in a subscribed state with stale channel data in its read buffer.

Every subsequent call to `task.get()` reuses this corrupted connection and immediately fails when `get_message()` reads the leftover bytes (`b'1'` — a subscription acknowledgment integer) as a Redis protocol response. This is a known issue: [celery/celery#6335](https://github.com/celery/celery/issues/6335), [celery/celery#4670](https://github.com/celery/celery/issues/4670).

## Fix

Two changes to `breadbox/api/temp/sql.py`:

1. **`_run_time_bounded_celery_task`**: Pass `propagate=False` to `task.get()`. This makes the call return normally regardless of whether the task succeeded or failed, allowing Celery's internal cleanup (the pub/sub unsubscribe) to complete. The task exception is then re-raised manually after cleanup, outside of Celery's generator chain.

2. **`query_sql`**: Add an explicit `except UserError` handler so invalid SQL returns a proper `400` response rather than propagating as an unhandled exception.
