### PR TITLE
Address comments on new Paired Screens tile

### DIFF
--- a/frontend/packages/portal-frontend/src/cellLine/components/CellLineOverview.tsx
+++ b/frontend/packages/portal-frontend/src/cellLine/components/CellLineOverview.tsx
@@ -6,6 +6,7 @@ import { CardContainer, CardColumn } from "src/common/components/Card";
 import { DatasetDataTypes, ModelInfo } from "src/cellLine/models/types";
 import styles from "src/common/styles/async_tile.module.scss";
 import { usePairedScreensData } from "src/cellLine/hooks/usePairedScreensData";
+import { useAcquiredAlterations } from "src/cellLine/hooks/useAcquiredAlterations";
 
 const DatasetsTile = React.lazy(
   () => import("src/cellLine/components/DatasetsTile")
@@ -67,6 +68,7 @@ const CellLineOverview = ({ modelId, hasMetMapData }: Props) => {
   const [oncokbDatasetVersion, setOncokbDatasetVersion] = useState<string>("");
 
   const { data: pairedScreens } = usePairedScreensData(modelId);
+  const { acquiredAlterations } = useAcquiredAlterations(modelId);
 
   useEffect(() => {
     legacyPortalAPI.getCellLineDescriptionTileData(modelId).then((data) => {
@@ -131,6 +133,7 @@ const CellLineOverview = ({ modelId, hasMetMapData }: Props) => {
           >
             <OncogenicAlterationsTile
               oncogenicAlterations={oncoAlterations}
+              acquiredAlterations={acquiredAlterations ?? undefined}
               oncokbDatasetVersion={oncokbDatasetVersion}
             />
           </React.Suspense>

--- a/frontend/packages/portal-frontend/src/cellLine/components/OncogenicAlterationsTile.tsx
+++ b/frontend/packages/portal-frontend/src/cellLine/components/OncogenicAlterationsTile.tsx
@@ -1,34 +1,60 @@
 import React from "react";
+import { InfoTip } from "@depmap/common-components";
 import { toStaticUrl } from "@depmap/globals";
 import { OncogenicAlteration } from "@depmap/types";
+import { altKey } from "../hooks/useAcquiredAlterations";
+import styles from "../styles/CellLinePage.scss";
 
 interface OncogenicAlterationsTileProps {
   oncogenicAlterations: Array<OncogenicAlteration>;
+  // Keys (gene name + alteration) of alterations acquired during derivation
+  // of the current model. Empty or omitted for non-derivative models.
+  acquiredAlterations?: Set<string>;
   oncokbDatasetVersion: string;
 }
 
 const OncogenicAlterationsTile = ({
   oncogenicAlterations,
+  acquiredAlterations = undefined,
   oncokbDatasetVersion,
 }: OncogenicAlterationsTileProps) => {
-  const tableRows = oncogenicAlterations.map((alteration, i) => (
-    <tr key={i}>
-      <td>
-        <a href={`https://www.oncokb.org/gene/${alteration.gene.name}`}>
-          {alteration.gene.name}
-        </a>
-      </td>
-      <td>
-        <a
-          href={`https://www.oncokb.org/gene/${alteration.gene.name}/${alteration.alteration}`}
-        >
-          {alteration.alteration}
-        </a>
-      </td>
-      <td className="center">{alteration.oncogenic}</td>
-      <td className="center">{alteration.function_change}</td>
-    </tr>
-  ));
+  const hasSomeAcquiredAlterations =
+    acquiredAlterations && acquiredAlterations.size > 0;
+
+  const tableRows = oncogenicAlterations.map((alteration) => {
+    const key = altKey(alteration);
+    const isAcquired = acquiredAlterations?.has(key) ?? false;
+
+    return (
+      <tr key={key}>
+        <td>
+          <a
+            href={`https://www.oncokb.org/gene/${alteration.gene.name}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {alteration.gene.name}
+          </a>
+        </td>
+        <td>
+          <a
+            href={`https://www.oncokb.org/gene/${alteration.gene.name}/${alteration.alteration}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {alteration.alteration}
+          </a>
+        </td>
+        <td className="center">{alteration.oncogenic}</td>
+        <td className="center">{alteration.function_change}</td>
+        {isAcquired && (
+          <td className={styles.acquiredAlterationCheckmark}>
+            <span className="glyphicon glyphicon-ok" />
+          </td>
+        )}
+      </tr>
+    );
+  });
 
   return (
     <article className="card_wrapper oncogenic_alterations_tile">
@@ -42,6 +68,24 @@ const OncogenicAlterationsTile = ({
                 <th>Alteration</th>
                 <th className="center">Oncogenic</th>
                 <th className="center">Function</th>
+                {hasSomeAcquiredAlterations && (
+                  <th className="center">
+                    <div style={{ display: "flex" }}>
+                      Acquired?
+                      <InfoTip
+                        placement="top"
+                        id="acquired-alterations"
+                        title="Acquired alterations"
+                        content={
+                          <div>
+                            Alterations present in this resistant derivative but
+                            not in its parental model.
+                          </div>
+                        }
+                      />
+                    </div>
+                  </th>
+                )}
               </tr>
             </thead>
             <tbody>{tableRows}</tbody>

--- a/frontend/packages/portal-frontend/src/cellLine/components/PairedScreensTile.tsx
+++ b/frontend/packages/portal-frontend/src/cellLine/components/PairedScreensTile.tsx
@@ -18,10 +18,27 @@ export interface ParentalLine {
   name?: string;
 }
 
-export interface ResistanceInfo {
-  origin?: ResistanceOrigin;
-  parentalLine?: ParentalLine;
+export interface DerivativeLine {
+  id: string;
+  name?: string;
 }
+
+// A model can be on one side of a paired-screen relationship or the other,
+// but not both. `role` discriminates the two cases:
+//   - "derivative": this model is a resistant derivative; carries its origin
+//     and a link to the parental line it was derived from.
+//   - "parental":   this model is itself a parental line; carries links to
+//     the derivatives that were created from it.
+export type ResistanceInfo =
+  | {
+      role: "derivative";
+      origin?: ResistanceOrigin;
+      parentalLine: ParentalLine;
+    }
+  | {
+      role: "parental";
+      derivatives: DerivativeLine[];
+    };
 
 export interface ResistanceScreenRows {
   // A single model can appear as a Test row, a Ctrl row, or both.
@@ -110,6 +127,30 @@ function ResistanceScreenLink({ rows }: { rows: ResistanceScreenRows }) {
 }
 
 function ResistanceMetadataSection({ data }: { data: ResistanceInfo }) {
+  if (data.role === "parental") {
+    return (
+      <>
+        <h4 className={styles.propertyGroupHeader} style={{ marginTop: 20 }}>
+          Derived Resistance Models
+        </h4>
+        {data.derivatives.map((d) => (
+          <div key={d.id}>
+            <a
+              className={styles.descriptionLinks}
+              href={toPortalLink(`/cell_line/${d.id}`)}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              {d.name ?? d.id}
+            </a>
+          </div>
+        ))}
+      </>
+    );
+  }
+
+  // role === "derivative"
+
   // Mirrors the property-group / property-header pattern used in the
   // Description tile so the visual rhythm matches what's already on the page.
   return (
@@ -128,20 +169,15 @@ function ResistanceMetadataSection({ data }: { data: ResistanceInfo }) {
           <p>{data.origin.description}</p>
         </>
       )}
-
-      {data.parentalLine && (
-        <>
-          <h6 className={styles.propertyHeader}>Parental Line</h6>
-          <a
-            href={toPortalLink(`/cell_line/${data.parentalLine.id}`)}
-            className={styles.descriptionLinks}
-            rel="noopener noreferrer"
-            target="_blank"
-          >
-            {data.parentalLine.name ?? data.parentalLine.id}
-          </a>
-        </>
-      )}
+      <h6 className={styles.propertyHeader}>Parental Model</h6>
+      <a
+        className={styles.descriptionLinks}
+        href={toPortalLink(`/cell_line/${data.parentalLine.id}`)}
+        target="_blank"
+        rel="noreferrer noopener"
+      >
+        {data.parentalLine.name ?? data.parentalLine.id}
+      </a>
     </>
   );
 }

--- a/frontend/packages/portal-frontend/src/cellLine/hooks/useAcquiredAlterations.ts
+++ b/frontend/packages/portal-frontend/src/cellLine/hooks/useAcquiredAlterations.ts
@@ -1,0 +1,82 @@
+import { useEffect, useState } from "react";
+import { cached, legacyPortalAPI } from "@depmap/api";
+import getResistanceScreenTable from "../utilities/getResistanceScreenTable";
+
+export async function getParentalModelId(
+  modelId: string
+): Promise<string | null> {
+  const rows = await getResistanceScreenTable();
+  const match = rows.find((r) => r.TestArmModelID === modelId);
+  return match ? match.CtrlArmModelID : null;
+}
+
+export function altKey(a: {
+  gene: { name: string };
+  alteration: string;
+}): string {
+  return `${a.gene.name}\t${a.alteration}`;
+}
+
+export interface UseAcquiredAlterationsState {
+  // Keys of alterations on this model that don't appear in the parent's list.
+  // null while loading, or when the model has no parental line (i.e. is not
+  // a resistant derivative).
+  acquiredAlterations: Set<string> | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useAcquiredAlterations(
+  modelId: string
+): UseAcquiredAlterationsState {
+  const [acquiredAlterations, setAcquired] = useState<Set<string> | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    setError(null);
+    setAcquired(null);
+
+    (async () => {
+      try {
+        const parentId = await getParentalModelId(modelId);
+        if (!mounted) return;
+
+        if (parentId === null) {
+          // Not a derivative — no parent to compare against.
+          setAcquired(null);
+          setLoading(false);
+          return;
+        }
+
+        const [own, parent] = await Promise.all([
+          cached(legacyPortalAPI).getOncogenicAlterations(modelId),
+          cached(legacyPortalAPI).getOncogenicAlterations(parentId),
+        ]);
+        if (!mounted) return;
+
+        const parentKeys = new Set(parent.onco_alterations.map(altKey));
+        setAcquired(
+          new Set(
+            own.onco_alterations
+              .map(altKey)
+              .filter((key) => !parentKeys.has(key))
+          )
+        );
+        setLoading(false);
+      } catch (err) {
+        if (!mounted) return;
+        setError(err as Error);
+        setLoading(false);
+      }
+    })();
+
+    return () => {
+      mounted = false;
+    };
+  }, [modelId]);
+
+  return { acquiredAlterations, loading, error };
+}

--- a/frontend/packages/portal-frontend/src/cellLine/hooks/usePairedScreensData.ts
+++ b/frontend/packages/portal-frontend/src/cellLine/hooks/usePairedScreensData.ts
@@ -1,6 +1,9 @@
 import { useEffect, useState } from "react";
 import { breadboxAPI, cached } from "@depmap/api";
 import { enabledFeatures } from "@depmap/globals";
+import getResistanceScreenTable, {
+  ResistanceRow,
+} from "../utilities/getResistanceScreenTable";
 
 import {
   ResistanceInfo,
@@ -20,17 +23,6 @@ import {
 interface AnchorRow {
   PairID: string;
   ModelID: string;
-}
-
-interface ResistanceRow {
-  PairID: string;
-  CtrlArmModelID: string;
-  CtrlArmStrippedCellLineName: string;
-  TestArmModelID: string;
-  TestArmStrippedCellLineName: string;
-  CulturedDrugResistance: string | null;
-  EngineeredModelDetails: string | null;
-  ComparisonType: "drug adapted" | "genetic knock-in" | string;
 }
 
 // ---------------------------------------------------------------------------
@@ -63,31 +55,6 @@ const getAnchorScreenTable = async () => {
     PairID,
     ModelID,
   })) as AnchorRow[];
-};
-
-const getResistanceScreenTable = async () => {
-  const data = await bb.getTabularDatasetData("PairedResScreenTable", {
-    columns: [
-      "CtrlArmModelID",
-      "CtrlArmStrippedCellLineName",
-      "TestArmModelID",
-      "TestArmStrippedCellLineName",
-      "CulturedDrugResistance",
-      "EngineeredModelDetails",
-      "ComparisonType",
-    ],
-  });
-
-  return Object.keys(data.ComparisonType).map((PairID) => ({
-    PairID,
-    CtrlArmModelID: data.CtrlArmModelID[PairID],
-    CtrlArmStrippedCellLineName: data.CtrlArmStrippedCellLineName[PairID],
-    TestArmModelID: data.TestArmModelID[PairID],
-    TestArmStrippedCellLineName: data.TestArmStrippedCellLineName[PairID],
-    CulturedDrugResistance: data.CulturedDrugResistance[PairID],
-    EngineeredModelDetails: data.EngineeredModelDetails[PairID],
-    ComparisonType: data.ComparisonType[PairID],
-  })) as ResistanceRow[];
 };
 
 export function usePairedScreensData(modelId: string): PairedScreensState {
@@ -174,11 +141,24 @@ export function derivePairedScreensData(
     // wants it presented.
     const row = testRows[0];
     resistance = {
+      role: "derivative",
       origin: deriveOrigin(row),
       parentalLine: {
         id: row.CtrlArmModelID,
         name: row.CtrlArmStrippedCellLineName,
       },
+    };
+  } else if (ctrlRows.length > 0) {
+    // The model is itself a parental line; surface its derivatives so users
+    // can navigate to each. A derivative may appear once per resistance
+    // experiment, so de-duplication isn't done here — the dashboard rows
+    // themselves are the source of truth.
+    resistance = {
+      role: "parental",
+      derivatives: ctrlRows.map((r) => ({
+        id: r.TestArmModelID,
+        name: r.TestArmStrippedCellLineName,
+      })),
     };
   }
 

--- a/frontend/packages/portal-frontend/src/cellLine/styles/CellLinePage.scss
+++ b/frontend/packages/portal-frontend/src/cellLine/styles/CellLinePage.scss
@@ -83,3 +83,13 @@
   color: #777;
   font-size: 0.9em;
 }
+
+.acquiredAlterationCheckmark {
+  font-size: 18px;
+  text-align: center;
+
+  :global .glyphicon {
+    margin-left: -10px;
+    margin-top: 8px;
+  }
+}

--- a/frontend/packages/portal-frontend/src/cellLine/utilities/getResistanceScreenTable.ts
+++ b/frontend/packages/portal-frontend/src/cellLine/utilities/getResistanceScreenTable.ts
@@ -1,0 +1,42 @@
+import { breadboxAPI, cached } from "@depmap/api";
+
+export interface ResistanceRow {
+  PairID: string;
+  CtrlArmModelID: string;
+  CtrlArmStrippedCellLineName: string;
+  TestArmModelID: string;
+  TestArmStrippedCellLineName: string;
+  CulturedDrugResistance: string | null;
+  EngineeredModelDetails: string | null;
+  ComparisonType: "drug adapted" | "genetic knock-in" | string;
+}
+
+const getResistanceScreenTable = async () => {
+  const data = await cached(breadboxAPI).getTabularDatasetData(
+    "PairedResScreenTable",
+    {
+      columns: [
+        "CtrlArmModelID",
+        "CtrlArmStrippedCellLineName",
+        "TestArmModelID",
+        "TestArmStrippedCellLineName",
+        "CulturedDrugResistance",
+        "EngineeredModelDetails",
+        "ComparisonType",
+      ],
+    }
+  );
+
+  return Object.keys(data.ComparisonType).map((PairID) => ({
+    PairID,
+    CtrlArmModelID: data.CtrlArmModelID[PairID],
+    CtrlArmStrippedCellLineName: data.CtrlArmStrippedCellLineName[PairID],
+    TestArmModelID: data.TestArmModelID[PairID],
+    TestArmStrippedCellLineName: data.TestArmStrippedCellLineName[PairID],
+    CulturedDrugResistance: data.CulturedDrugResistance[PairID],
+    EngineeredModelDetails: data.EngineeredModelDetails[PairID],
+    ComparisonType: data.ComparisonType[PairID],
+  })) as ResistanceRow[];
+};
+
+export default getResistanceScreenTable;

--- a/frontend/packages/portal-frontend/src/resistanceScreenDashboard/components/getCustomColumns.tsx
+++ b/frontend/packages/portal-frontend/src/resistanceScreenDashboard/components/getCustomColumns.tsx
@@ -51,9 +51,20 @@ function getCustomColumns(
     {
       width: 115,
       header: () => (
-        <span style={{ fontWeight: "normal" }}>
-          <b>Expression</b> in parental vs. resistant
-        </span>
+        <DependencyLinksHeader
+          heading={
+            <>
+              <b>Expression</b> in parental vs. resistant
+            </>
+          }
+          tooltipTitle="Comparing parental to resistant model"
+          tooltipContent={
+            <ul>
+              The “scatter” links will show a scatter plot of the parental vs
+              the resistance model gene expression.
+            </ul>
+          }
+        />
       ),
       cell: (_, getValue) => {
         return <ModelScatterLink dataset_id="expression" getValue={getValue} />;
@@ -64,9 +75,20 @@ function getCustomColumns(
     {
       width: 115,
       header: () => (
-        <span style={{ fontWeight: "normal" }}>
-          <b>Copy Number</b> in parental vs. resistant
-        </span>
+        <DependencyLinksHeader
+          heading={
+            <>
+              <b>Copy Number</b> in parental vs. resistant
+            </>
+          }
+          tooltipTitle="Comparing parental to resistant model"
+          tooltipContent={
+            <ul>
+              The “scatter” links will show a scatter plot of the parental vs
+              the resistance model copy number.
+            </ul>
+          }
+        />
       ),
       cell: (_, getValue) => {
         return (

--- a/portal-backend/depmap/cell_line/views.py
+++ b/portal-backend/depmap/cell_line/views.py
@@ -521,7 +521,7 @@ def get_cell_line_oncogenic_alterations(model_id: str):
                     "alteration": alteration,
                     "oncogenic": oncogenic_label,
                     "function_change": mutation.get("Mutation Effect"),
-                    "dataste": None,
+                    "dataset": None,
                 }
             )
 


### PR DESCRIPTION
- renamed "Parental Line" header -> "Parental Model"

- Updated the cell line page so that a Parental model now has links to all its derived  models

- Added tooltips to the new columns in the Resistance Screen Dashboard explaining what kind of plots they link to

- The Oncogenic Alterations tile gains an "Acquired?" column on cell line pages for resistant derivative models. A checkmark renders for any alteration present in the derivative but not in its parental line, with an InfoTip in the column header explaining the meaning.