### PR TITLE
Fix problem where SQL queries completely break under load.

### DIFF
--- a/breadbox/breadbox/api/temp/sql.py
+++ b/breadbox/breadbox/api/temp/sql.py
@@ -101,22 +101,23 @@ async def _run_time_bounded_celery_task(
     """
     task = task_fn.apply_async(args=args, time_limit=time_limit)
 
-    # Use propagate=False so task.get() returns normally instead of raising the task's
-    # exception. When propagate=True (the default), a task failure causes the exception
-    # to propagate through Celery's generator-based drain_events_until/_wait_for_pending
-    # chain. Python doesn't close generators when an exception escapes a for-loop, so
-    # their finally blocks (including the Redis pub/sub unsubscribe) never run. The shared
-    # _pubsub connection (a @cached_property on the backend) is then left subscribed to
-    # the stale channel, and subsequent calls read leftover bytes (b'1') as a Redis
-    # protocol response, causing InvalidResponse errors for all queries until restart.
-    await anyio.to_thread.run_sync(
-        lambda: task.get(timeout=time_limit + time_limit_padding, propagate=False)
-    )
+    # we previously had the following here to do a blocking wait for the task
+    #
+    # await anyio.to_thread.run_sync(
+    #   lambda: task.get(timeout=time_limit + time_limit_padding, propagate=False)
+    # )
+    #
+    # However, it appears this results in some non-threadsafe use of a redis connection
+    # which can result in all future queries failing with an InvalidResponse exception,
+    #
+    # To avoid that, we're going to use a dumb polling strategy instead
 
-    if task.state == "FAILURE":
-        raise task.result
-
-    return task.result
+    deadline = asyncio.get_event_loop().time() + time_limit + time_limit_padding
+    while asyncio.get_event_loop().time() < deadline:
+        if task.ready():
+            return task.result
+        await asyncio.sleep(0.5)
+    raise TimeoutError(f"Task {task.id} did not complete in time")
 
 
 @router.post("/sql/query", operation_id="query_sql", response_class=CSVFileResponse)

--- a/breadbox/breadbox/service/sql/query.py
+++ b/breadbox/breadbox/service/sql/query.py
@@ -162,7 +162,6 @@ class Cursor:
         self.iterating: Union[Iterator[SQLiteValue], None] = None
         self.current_row: Any = None
         self.callable = callable
-        print(f"Cursor.__init__: {(self.param_values)}")
 
     def Filter(self, idx_num: int, idx_str: str, args: tuple[SQLiteValue]) -> None:
         params: dict[str, SQLiteValue] = self.param_values.copy()
@@ -237,7 +236,6 @@ def make_virtual_module(
 
 def add_matrix_dataset(connection, dataset: MatrixDataset, schema: SchemaNames):
     table_name = schema.get_dataset_table_name(dataset.id)
-    print("Creating ", table_name)
     connection.execute(
         f"CREATE VIRTUAL TABLE \"{table_name}\" using query_matrix_dataset('{dataset.id}')"
     )
@@ -353,7 +351,7 @@ def sorted_list_contains(haystack, needle):
 def _query_matrix_dataset_samples(
     db, index_cache, dataset_id, dim_id_type, **constraints
 ):
-    print(f"Querying {dim_id_type} dimensions with constraints ({constraints})")
+    log.info(f"Querying {dim_id_type} dimensions with constraints ({constraints})")
     dataset_key = f"dataset:{dataset_id}"
     if dataset_key not in index_cache:
         matrix_dataset = crud_dataset.get_dataset(db, db.user, dataset_id)
@@ -377,7 +375,7 @@ def _query_matrix_dataset_samples(
     if len(constraints) > 0:
         # if there's any constraint, we can assume it's on dim_id_type
         dim_id = constraints[dim_id_type]
-        print(f"Searching for {dim_id} among {dim_ids}")
+        log.info(f"Searching for {dim_id} among {dim_ids}")
         if sorted_list_contains(dim_ids, dim_id):
             yield (dim_id,)
         else:


### PR DESCRIPTION
This is a successor to https://github.com/broadinstitute/depmap-portal/pull/709 because the problem continued after that PR. 

Based on the linked github issues people seemed to be reporting a set of issues that were stemming from multiple threads reading from the same redis connection. Now there's a connection pool that is supposed to give one connection to each thread so that situation is impossible.

However, from the analysis that claude did (described on that PR) it sounds like there might be an issue with doing a blocking wait on a task (which uses pubsub in redis, which the claude's comment suggest might be using a cached connection. If that's really true, then it's logical that would leads the connection to be used across threads which would result in the error we're seeing.

To avoid this, switched from a blocking `task.get()` to polling `task.ready()`

I was able to reproduce the issue with this bash script:

```
jitter() { sleep $(awk 'BEGIN{srand(); print rand()}'); }
for i in {1..100}; do
  echo "$i"
  sh sample-sql-query-3.sh &
  jitter
done
```

where `sample-sql-query-3.sh` is
```
curl -X 'POST' \
  'http://localhost:8018/depmap-istaging/breadbox/temp/sql/query' \
  -H "X-Forwarded-Email: noone" \
  -H 'accept: text/csv' \
  -H 'Content-Type: application/json' \
  -d '{
  "sql": "SELECT sample_id, value\nFROM hotspot_mutations_internal_26q\nWHERE feature_id = '\''596'\'' AND sample_id in ( '\''ACH-000697'\'','\''ACH-000157'\'')"
}
```

After making the change, the queries appear to work as expected.