### PR TITLE
Add schema versioning to DataExplorerPlotConfig

### DIFF
--- a/frontend/packages/@depmap/data-explorer-2/docs/adr/0001-plot-config-schema-versioning.md
+++ b/frontend/packages/@depmap/data-explorer-2/docs/adr/0001-plot-config-schema-versioning.md
@@ -1,0 +1,204 @@
+# ADR 0001 — Schema versioning for `DataExplorerPlotConfig`
+
+- **Status:** Accepted
+- **Applies to:** `@depmap/data-explorer-2` — plot config (de)serialization
+- **Key symbols:** `CURRENT_PLOT_VERSION`, `readPlotFromQueryString`,
+  `plotToQueryString`, `normalizePlot`, `parseShorthandParams`,
+  `replaceLegacyPropertyNames`, `makePlotConfigBreadboxModeCompatible`
+
+---
+
+## Context
+
+A `DataExplorerPlotConfig` is a **wire format**, not just an in-memory object. Hyperlinks
+encode the entire config (compressed, base64'd, in the `p` query param), so every payload
+we have ever minted is still out there in bookmarks, Slack threads, and papers. We must
+be able to read a config written years ago.
+
+Data Explorer survived for years **without** any version field, by retroactively making
+old defaults make sense in an extended world. That strategy works — but **only while
+absence is stable**. A missing field has always meant one time-invariant thing, so a
+missing field could always be reconciled after the fact.
+
+The `color_by` default flip breaks that precondition. It gives `color_by` a `"group"`
+value that becomes the new default, meaning "color follows `group_by`", and removes the
+old "if no `group_by`, fall back to grouping by color" fallback. This is the **first
+change that makes absence ambiguous**: after the flip, an absent `color_by` must resolve
+to `"group"`, but every payload minted before it meant *uniform*. The two cannot be
+reconciled retroactively, because the change **inverts** the default rather than
+extending it.
+
+Timing is not cost-neutral. If the version field ships *after* the flip, we manufacture a
+third cohort — unversioned-but-new-regime — that is shape-indistinguishable from
+genuinely-old payloads and must migrate in the *opposite* direction. Stamp with or before
+the flip and every unversioned payload is uniformly legacy.
+
+## Decision
+
+Add an explicit `version` field to the serialized payload, and restructure the read path
+so migrations are keyed on that version rather than sniffed from payload shape.
+
+### 1. The four concerns in the read path are distinct, and separate by discriminator
+
+The read path used to interleave several migration axes in one flat sequence, which was
+the real source of confusion. They are not the same kind of thing:
+
+| Concern | Write twin? | Gated on version? |
+|---|---|---|
+| **Serialization machinery** (compress/decompress, context hash/unhash) | **Yes** — symmetric | Never. Permanent. |
+| **Plot-schema migration** | No | **Yes.** The only axis `version` gates. |
+| **Context vintage (V1→V2)** | No | Never. Independent axis (see §5). |
+| **Environment-adaptation** (dataset-ID translation, `"custom"` sentinel, `slice_id`→`SliceQuery`) | No | **Never.** Unconditional forever (see §4). |
+
+Read order: `decompress` → read `version` → **Phase A** → **Phase B** →
+`replaceHashesWithContexts` → `makePlotConfigBreadboxModeCompatible`.
+
+Version is read *before* context rehydration — it is a plot-level field available on the
+decompressed-but-still-hashed payload, and no migration needs expanded contexts.
+
+### 2. Two phases, one bright line
+
+The line is **"the schema the day versioning shipped."**
+
+- **Phase A — frozen, version-gated (`< 1`).** Pre-v1 structural repairs: the
+  array→object `dimensions` transform and `replaceLegacyPropertyNames`. These are
+  **shape-detected by necessity** — the payloads predate version numbers, so shape is the
+  only signal available. The clarifying property: this is a **closed set that only shrinks**
+  as old links rot. No future change ever adds a sniffer here.
+
+- **Phase B — version-keyed.** `v0 → v1 → …`, ordered. All future schema migrations live
+  here.
+
+This resolves the apparent paradox that *old* renames live in Phase A while *new* renames
+would live in Phase B: old renames **define what v0 is**; new renames **define a
+transition**. Same operation, opposite sides of the line.
+
+**Do not build a runner framework.** One transition is a single `if (payloadVersion < N)`
+branch. The ordered shape exists so the next step slots in, not to be infrastructure.
+
+### 3. `version` is a wire-format field, never an in-memory field
+
+In-memory plots are **always current-schema**. The reader strips `version` on the way in;
+`plotToQueryString` re-stamps `CURRENT_PLOT_VERSION` on the way out. Two touch points,
+no others.
+
+If any render or selection code ever branches on `version`, that is a bug: it means schema
+vintage leaked past the boundary. (Mechanically, leaving it in memory also makes
+`plotsAreEquivalentWhenSerialized` see spurious diffs between a loaded plot and an
+otherwise-identical in-memory one.)
+
+### 4. Every mint point stamps — so absent means pre-versioning
+
+**Invariant: every code path that mints a plot config stamps `CURRENT_PLOT_VERSION`.**
+Today that is `plotToQueryString` (the `p` param) and `parseShorthandParams` (the
+human-readable shorthand params). If a third mint point is ever added, it stamps too.
+
+This is what makes **absent version ⟹ pre-versioning legacy** a *true* statement, and
+therefore what makes the reader's `?? 0` coercion sound rather than a guess. The
+alternative — leaving some producers unstamped — would mean a link minted one second from
+now is indistinguishable from a years-old bookmark, and the first Phase B migration would
+silently reinterpret it under semantics it was never minted under. **Stamp at the mint
+point; never sniff payload shape at the reader.**
+
+Corollary: **`version` certifies SCHEMA vintage, never backend-nativity.** A payload can be
+honestly current-schema and still carry backend-legacy forms. `parseShorthandParams` is the
+proof — it matches legacy dataset IDs via `legacyPortalIdToBreadboxGivenId` but
+deliberately writes the **raw** id, deferring the rewrite downstream; it also emits
+`context_type` contexts, the `"custom"` `slice_type` sentinel, and `slice_id` metadata. A
+hand-written or LLM-generated URL can do the same.
+
+Therefore **environment-adaptation is unconditional, forever.** It is load-bearing for
+those inputs, not an idempotent no-op, and must never be gated on version. (It is
+*additionally* idempotent on already-native payloads, which is what makes "always run"
+cheap.) Note also that `makePlotConfigBreadboxModeCompatible` has a **second caller**,
+`StartScreenExample.tsx`, which passes a hardcoded plot that never went through
+hash-expansion and carries no version — gating there would dispatch a non-native plot.
+
+### 5. Context vintage is an independent axis
+
+Contexts are **independently persisted** and dereferenced at read time, carrying their
+**own** vintage. A current-schema plot can hold a hash resolving to a V1 context minted
+years earlier. You cannot stamp a dereferenced context with the plot's version.
+
+Conversion therefore stays at **point-of-dereference** (`isV2Context` /
+`convertContextV1toV2` inside the hash-expansion loop), keyed on the context's shape, not
+the plot's version.
+
+**Do not confuse this with `StoredContexts.version`.** That is a separate field on a
+separate type, and it uses the **opposite** absent-default (absent ⟹ `1`; the plot
+config's is absent ⟹ `0`). The two axes never gate each other.
+
+### 6. Phase B gates on the coerced local, never the raw field
+
+```ts
+const payloadVersion = plot?.version ?? 0;   // capture BEFORE the strip
+...
+if (payloadVersion < N) { /* migration */ }
+```
+
+Never `plot.version`. The pre-versioning cohort has **no** `version` field, and
+`undefined < N` evaluates to `false` — which would silently skip exactly the payloads a
+migration exists to upgrade, while appearing to work correctly on everything newer. The
+`?? 0` coercion is the only thing that makes `0 < N === true` for that cohort. This failure
+mode is independent of where the strip happens; do not "fix" it by moving the strip.
+
+### 7. A version bump moves as a unit
+
+Bumping `CURRENT_PLOT_VERSION` **simultaneously re-certifies every mint point** as
+conformant to the new schema — without touching a line of those producers. So a bump is
+never a one-line change. In the **same commit**:
+
+1. Bump the constant.
+2. Add the Phase B migration step for the new transition.
+3. **Audit every mint point** to confirm it actually emits the new schema.
+
+The number and the schema semantics must move together, or the reader will certify
+payloads it has not actually migrated.
+
+**Worked example — why step 3 is not a formality.** `parseShorthandParams` infers
+`color_by` and returns `null` (i.e. writes nothing) when there is nothing to color by:
+
+```ts
+const inferColorBy = (partialPlot) => {
+  if (partialPlot.filters?.color1 || partialPlot.filters?.color2) return "aggregated_slice";
+  if (partialPlot.metadata) return "property";
+  return null;   // <-- absent color_by
+};
+```
+
+Under v1 that absence means **uniform**. The moment `CURRENT_PLOT_VERSION` becomes `2`,
+that same untouched line is *declared* to mean **group** — a semantic change to a live
+producer, caused by editing a constant in a different file. Nothing breaks loudly. The
+audit is the only thing standing between a version bump and a mint point quietly emitting
+payloads whose meaning it never intended.
+
+### 8. Migrations write the old *effective* value; they never adopt the new default
+
+A migrated payload gets **its resolved past**, written explicitly. New plots get the new
+default from `DEFAULT_EMPTY_PLOT` / the creation path. A migration that "helpfully"
+upgrades an old plot into the new default silently changes what an existing link renders.
+
+## Consequences
+
+- Absent `version` is now a **meaningful, load-bearing signal**, and stays meaningful only
+  as long as §4 holds. A new unstamped mint point is a latent data-corruption bug, not an
+  oversight.
+- Phase A can only ever shrink. If someone proposes adding a shape sniffer to it, the
+  proposal is in the wrong phase.
+- We accept a permanently unconditional environment-adaptation pass — the version field
+  buys nothing there, by design.
+- Version **1** is the post-mechanism, **pre-flip** schema: absent `color_by` still means
+  uniform. The `color_by` default flip ships as version **2**, filling the Phase B slot
+  with its materialization migration.
+
+## Related
+
+- Commit introducing this: "Add schema versioning to DataExplorerPlotConfig (version 1)".
+- **ADR 0002 — `normalizePlot` is an allowlist normalizer.** The `sort_by` fix in this
+  commit is an instance of that hazard class, and the incoming `color_by: "group"` is a
+  latent one. Read 0002 before adding any field to `DataExplorerPlotConfig`.
+- The `color_by` default flip (version 2) is not yet decided and has no ADR. Its open
+  design inputs — the `ColorByValue` type split, the `group: null` degenerate, the
+  `findCategoricalSlice("expansion")` throw, the categorical 1D-fidelity branch, and the
+  `group_by: "expansion"` lifecycle — are tracked in the v2 gotchas handoff, not here. An
+  ADR records a decision that was *made*; those are inputs to one that has not been.

--- a/frontend/packages/@depmap/data-explorer-2/docs/adr/0002-normalizeplot-is-an-allowlist.md
+++ b/frontend/packages/@depmap/data-explorer-2/docs/adr/0002-normalizeplot-is-an-allowlist.md
@@ -1,0 +1,99 @@
+# ADR 0002 — `normalizePlot` is an allowlist normalizer
+
+- **Status:** Accepted (describes existing behavior; the safer alternative is deferred)
+- **Applies to:** `@depmap/data-explorer-2` — `normalizePlot` in `DataExplorerPage/utils.ts`
+- **Read this before:** adding any field to `DataExplorerPlotConfig`
+
+---
+
+## Context
+
+`normalizePlot` runs on the **write** path. Its job is to drop options that are set but
+meaningless — a `color_by` whose backing dimension was never completed, a `use_clustering`
+on a plot type that has no clustering — so we do not serialize junk into a URL that lives
+forever.
+
+It does this by **destructuring fields off the top** and re-adding them only in the
+branches where they are meaningful:
+
+```ts
+const {
+  color_by, sort_by, hide_points, use_clustering, show_regression_line, filters, metadata,
+  ...rest
+} = plot;
+const normalized: DataExplorerPlotConfig = rest;   // <-- everything destructured is now GONE
+// ...conditionally add some of them back
+```
+
+The consequence is easy to miss and has now bitten three times:
+
+> **A field that is destructured off the top and re-added only inside conditional branches
+> is a field that is *conditionally lost*.**
+
+This is an **allowlist**: the default is to drop, and survival must be earned in every arm.
+Nothing fails loudly when an arm forgets. The plot renders correctly in memory, serializes
+without the field, and the loss only surfaces when the user reloads the page — at which
+point the symptom (a setting that "doesn't stick") is several steps removed from the cause.
+
+### The three instances
+
+1. **`color_by: "expansion"`** — `color_by` was re-added only when a filter / metadata /
+   color-dimension backing was complete. `"expansion"` is backed by `expand_by`, not by any
+   of those, so expanded plots silently lost their coloring on write. Fixed with an explicit
+   arm.
+
+2. **`sort_by`** — re-added only *inside* the `color_by` arms, so it survived only when some
+   color backing happened to be complete. An uncolored plot silently lost its sort order.
+   This is why `sort_by: "alphabetical"` set via Transcript Explorer disappeared on refresh.
+   Fixed by hoisting the preserve out of the color arms entirely (ADR 0001's commit).
+
+3. **`color_by: "group"`** *(latent, arrives with the version-2 flip)* — `"group"` has **no
+   backing at all**, exactly like `"expansion"`. It will be stripped unless the flip either
+   adds an explicit arm or strips it *deliberately* for URL brevity. Note the trap: stripping
+   is actually **sound** post-v2, because absent `color_by` in a v2 payload reads back as
+   `"group"`. So the correct behavior and the bug look **identical in the diff**. It must be
+   a decision with a comment, not a coincidence.
+
+Instances 1 and 2 also show the failure is not merely "forgot an arm" — `sort_by` was
+re-added in *two* arms and still lost, because the arms it was in were the wrong ones. The
+hazard is **coupling a field's survival to an unrelated field's state.**
+
+## Decision
+
+1. **`normalizePlot` stays an allowlist for now.** Inverting it to a subtractive normalizer
+   (start from the full plot, `delete` what is meaningless) would be structurally safer —
+   new fields would survive by default — but it changes the drop semantics of every existing
+   field at once and is not worth coupling to any in-flight change. Deferred, not rejected.
+
+2. **Every field added to `DataExplorerPlotConfig` must be explicitly accounted for in
+   `normalizePlot`.** Either it is destructured and shepherded back in *every* arm where it
+   is meaningful, or it is deliberately left in `...rest` to ride through untouched. There is
+   no third option, and "I didn't touch `normalizePlot`" is not one of them — a new field
+   left out of the destructure rides through by default, which may or may not be what you
+   want.
+
+3. **A field's survival must not be coupled to an unrelated field's state.** If preservation
+   depends on some other field being complete, that dependency must be *semantic*, not
+   incidental. `sort_by` was preserved inside the `color_by` arms because of a historical
+   conflation, not because sort order depends on coloring — and that is exactly why it broke.
+
+4. **`version` is deliberately NOT destructured**, so it rides through in `...rest`. There is
+   a comment in the destructure saying so, and a test pinning it. Do not "tidy" it into the
+   destructure list.
+
+5. **New fields get a test that they survive a `normalizePlot` round-trip.** This is the only
+   mechanism that turns a silent, deferred, reload-time symptom into a loud, immediate one.
+
+## Consequences
+
+- Adding a field to `DataExplorerPlotConfig` is never a one-file change. The type, the
+  normalizer, and a round-trip test move together.
+- Reviewers should treat "new field on the plot config" as a prompt to open `normalizePlot`
+  and ask which arms it needs to survive.
+- The subtractive rewrite remains the real fix. If a fourth instance of this class appears,
+  that is the signal to stop patching arms and invert the normalizer.
+
+## Related
+
+- ADR 0001 — Schema versioning for `DataExplorerPlotConfig` (the `version` field is the
+  field referenced in decision 4; the `sort_by` fix shipped in its commit).

--- a/frontend/packages/@depmap/data-explorer-2/docs/adr/README.md
+++ b/frontend/packages/@depmap/data-explorer-2/docs/adr/README.md
@@ -1,0 +1,71 @@
+# Architecture Decision Records
+
+Durable answers to **"why is the system this way?"**
+
+## What goes here (and what doesn't)
+
+The line is the reader's question:
+
+| Question | Where it belongs |
+|---|---|
+| *Why is this diff the way it is?* | The commit message |
+| *Why is the system the way it is?* | An ADR here |
+
+A commit message is read by someone bisecting a regression. An ADR is read by someone about
+to change something and wondering what they'd be breaking. They are different people with
+different questions, and cramming both into a commit message means the second person never
+finds the answer — commit messages are effectively write-only after a few months.
+
+**Commit messages reference ADRs. ADRs do not duplicate commit messages.** If a fact will
+still be true after ten more commits, it belongs here and the commit should link to it.
+
+### Why this directory exists at all
+
+Data Explorer's plot config is a **wire format**. Hyperlinks encode the entire
+`DataExplorerPlotConfig` (compressed, in the `p` query param), so every payload we have ever
+minted is still live — in bookmarks, in Slack threads, in published papers. We cannot see
+those payloads, cannot migrate them in place, and cannot stop supporting them.
+
+That makes "why is the system this way?" unusually expensive to rediscover here, because
+half the constraints come from data nobody can look at. Several of our load-bearing rules
+are invisible in the code and were only recovered by tracing years of history. Writing them
+down once is much cheaper than deriving them again — and much safer than a future reader
+concluding a constraint is arbitrary and "cleaning it up."
+
+## The bar for writing one
+
+**An ADR records a decision that was made.** That is the whole filter, and it cuts both ways:
+
+- **Not a design doc.** If the decision is still open, it does not get an ADR. It lives in a
+  handoff doc or an issue until it lands. Writing up open questions as "Accepted" launders
+  speculation into settled architecture, which is worse than not writing it down at all.
+- **Not a changelog.** If it only explains one diff, it belongs in that diff's commit message.
+- **Not a style guide.** Conventions with no consequences don't need a record.
+
+Good triggers, from the ones we have:
+
+- A constraint that is **invisible in the code** and expensive to re-derive. (0001: absent
+  `version` means "pre-versioning" *only because* every mint point stamps. Nothing in the
+  code says that; delete the stamp and everything still compiles and passes.)
+- A hazard that has **bitten more than once**. (0002: the same normalizer bug, three times.)
+- A rule that a future reader would otherwise **"fix"**, because it looks wrong. (0001:
+  environment-adaptation runs unconditionally and looks like a redundant pass. It isn't.)
+
+If you're unsure, the question to ask is: *would someone touching this code six months from
+now do the wrong thing without it?* If no, skip it.
+
+## Conventions
+
+- **Filename:** `NNNN-kebab-case-title.md`, four digits, sequential. Numbers are never
+  reused, even if an ADR is superseded.
+- **Status:** `Accepted` | `Superseded by NNNN`. That's it so far — add more only when you
+  actually need them.
+- **Superseding:** write a **new** ADR, flip the old one's Status, and leave the old one in
+  place. Never edit an ADR's decision after the fact. The record of what we used to think, and
+  why we changed our minds, is most of the value — an ADR that is silently rewritten is just
+  documentation, and documentation is what we already had.
+- **Corrections** (typos, broken links, a clarifying sentence) are fine to edit in place. The
+  distinction is: correcting the record, versus changing the decision.
+
+Beyond that, don't over-formalize yet. There is no template, deliberately. Write the thing a
+confused reader needs; we'll notice what we reach for twice and codify *that*.

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/__tests__/query-string-parser.test.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/__tests__/query-string-parser.test.ts
@@ -1,6 +1,7 @@
 import qs from "qs";
 import { DataExplorerDatasetDescriptor } from "@depmap/types";
 import { parseShorthandParams } from "../query-string-parser";
+import { CURRENT_PLOT_VERSION } from "../plot-version";
 
 const MOCK_DATASETS_BY_INDEX_TYPE: Record<
   string,
@@ -131,6 +132,21 @@ describe("Data Explorer 2.0 query string parser", () => {
 
     expect(result2).toBeDefined();
     expect(result2?.plot_type).toEqual("scatter");
+  });
+
+  it("should stamp the current schema version", () => {
+    // Shorthand params are a mint point. An unstamped plot would coerce to
+    // version 0 at the reader and get migrated as though it were pre-versioning
+    // legacy, even though it was minted this second.
+    const result = parseShorthandParams(
+      {
+        xDataset: "Chronos_Combined",
+        xFeature: "SOX10",
+      },
+      MOCK_DATASETS_BY_INDEX_TYPE
+    );
+
+    expect(result?.version).toEqual(CURRENT_PLOT_VERSION);
   });
 
   it("should infer `index_type` from `dataset_id` and `slice_type`", () => {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/__tests__/utils.test.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/__tests__/utils.test.ts
@@ -1,5 +1,5 @@
 import { DataExplorerPlotConfig } from "@depmap/types";
-import { toRelatedPlot } from "../utils";
+import { CURRENT_PLOT_VERSION, normalizePlot, toRelatedPlot } from "../utils";
 
 // `toRelatedPlot` pins the selection-to-context translation: given a plot
 // the user is looking at and a set of selected IDs, return the plot that
@@ -180,6 +180,67 @@ describe("toRelatedPlot", () => {
       expect(next.dimensions.x?.slice_type).toBe("gene");
       // Pre-refactor: labelToIdMap["ENSG00000181449"] === undefined.
       expect(givenIdOf(next.dimensions.x?.context)).toBe("ENSG00000181449");
+    });
+  });
+});
+
+describe("normalizePlot", () => {
+  // Minimal valid plot used as the base fixture.
+  const basePlot: DataExplorerPlotConfig = ({
+    plot_type: "scatter",
+    index_type: "depmap_model",
+    dimensions: {
+      x: {
+        axis_type: "raw_slice",
+        aggregation: "first",
+        slice_type: "gene",
+        dataset_id: "Chronos_Combined",
+        context: {
+          name: "FABP5",
+          dimension_type: "gene",
+          expr: { "==": [{ var: "entity_label" }, "FABP5"] },
+          vars: {},
+        },
+      },
+    },
+  } as unknown) as DataExplorerPlotConfig;
+
+  test("version survives normalizePlot — stamped payloads must round-trip the field", () => {
+    // If version were pulled into the destructure, this would return undefined
+    // and the writer would serialize a version-less blob, defeating the versioning
+    // scheme. Fail loudly here rather than silently at the reader's gate.
+    const result = normalizePlot({ ...basePlot, version: CURRENT_PLOT_VERSION });
+    expect(result.version).toBe(CURRENT_PLOT_VERSION);
+  });
+
+  // `sort_by` used to be re-added only inside the `color_by` arms, so it survived
+  // normalization only when some color backing happened to be complete. These pin
+  // the fix: sort order is a property of the plot, not of its coloring.
+  describe("sort_by preservation", () => {
+    test("survives with no color_by and no group_by", () => {
+      // The Transcript Explorer regression: a plot with `sort_by: "alphabetical"`
+      // matched no color arm, so `plotToQueryString` serialized it without a
+      // `sort_by` and the setting vanished on refresh.
+      const result = normalizePlot(({
+        ...basePlot,
+        sort_by: "alphabetical",
+      } as unknown) as DataExplorerPlotConfig);
+
+      expect(result.sort_by).toBe("alphabetical");
+    });
+
+    test("survives when grouped but uncolored", () => {
+      const result = normalizePlot(({
+        ...basePlot,
+        group_by: "expansion",
+        sort_by: "alphabetical",
+      } as unknown) as DataExplorerPlotConfig);
+
+      expect(result.sort_by).toBe("alphabetical");
+    });
+
+    test("is absent when the plot never had one", () => {
+      expect(normalizePlot(basePlot).sort_by).toBeUndefined();
     });
   });
 });

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/plot-version.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/plot-version.ts
@@ -1,0 +1,27 @@
+// The schema version stamped on every serialized `DataExplorerPlotConfig`.
+//
+// Version history:
+//   1 — Property names are canonical and `dimensions` is an object. This is the
+//       post-mechanism, PRE-`color_by`-flip schema: an absent `color_by` still
+//       means "uniform", not "group". The flip ships as version 2. Do not attach
+//       new default semantics to version 1 after the fact.
+//
+// When a schema change ships, bump this constant AND add the corresponding
+// Phase B step in `readPlotFromQueryString` in the SAME commit. The number and
+// the schema semantics must move as a unit, or the reader will certify payloads
+// it hasn't actually migrated.
+//
+// INVARIANT — every mint point stamps this. Today that means:
+//   * `plotToQueryString`     (the compressed `p` param)
+//   * `parseShorthandParams`  (the human-readable shorthand params)
+// If you add a third way to mint a plot config, stamp it there too. The reader
+// coerces an absent version to 0 and runs pre-versioning migrations against it,
+// so an unstamped-but-modern payload is not merely untagged — it is actively
+// mistaken for a years-old one and migrated as such.
+//
+// This constant lives in its own module rather than in `utils.ts` because
+// `query-string-parser.ts` needs it and `utils.ts` already imports from
+// `query-string-parser.ts`. Defining it here keeps the import graph acyclic.
+// `utils.ts` re-exports it, so `import { CURRENT_PLOT_VERSION } from "../utils"`
+// keeps working for existing callers.
+export const CURRENT_PLOT_VERSION = 1;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/query-string-parser.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/query-string-parser.ts
@@ -8,6 +8,7 @@ import {
   PartialDataExplorerPlotConfig,
 } from "@depmap/types";
 import { isCompletePlot } from "./validation";
+import { CURRENT_PLOT_VERSION } from "./plot-version";
 
 type Datasets = Record<string, DataExplorerDatasetDescriptor[]>;
 
@@ -444,5 +445,24 @@ export function parseShorthandParams(params: qs.ParsedQs, datasets: Datasets) {
     throw new Error(message);
   }
 
-  return plot;
+  // Shorthand params are a MINT POINT, so stamp the schema version here.
+  //
+  // The plot built above is current-schema by construction: object `dimensions`,
+  // canonical property names, and only canonical `color_by` / `axis_type` values
+  // (never the legacy "entity" / "context" spellings, never `entity_type`). It is
+  // therefore honestly v1, not merely untagged.
+  //
+  // Stamping matters because the reader coerces an absent `version` to 0 and runs
+  // pre-versioning migrations against it. Leave shorthand unstamped and a link
+  // generated one second from now becomes indistinguishable from a years-old
+  // bookmark — the moment a Phase B migration exists, it would be applied to a
+  // payload that was never minted under the old regime.
+  //
+  // This says nothing about backend-nativity, and must not be read as such: the
+  // dimensions above still carry raw legacy dataset IDs (the rewrite is
+  // deliberately deferred), context_type contexts, the "custom" slice_type
+  // sentinel, and slice_id metadata. Those are repaired unconditionally
+  // downstream by makePlotConfigBreadboxModeCompatible, which does not — and must
+  // not — gate on version.
+  return { ...plot, version: CURRENT_PLOT_VERSION };
 }

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/utils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/utils.ts
@@ -39,6 +39,12 @@ import {
   omitShorthandParams,
   parseShorthandParams,
 } from "./query-string-parser";
+import { CURRENT_PLOT_VERSION } from "./plot-version";
+
+// Re-exported so existing callers (and tests) can keep importing this from
+// `./utils`. The definition lives in its own module to keep the import graph
+// acyclic — see the comment there.
+export { CURRENT_PLOT_VERSION };
 
 export const defaultContextName = (numLabels: number) => {
   return ["(", numLabels, " selected", ")"].join("");
@@ -291,7 +297,7 @@ function decompress(str: string): object {
   return JSON.parse(json);
 }
 
-function normalizePlot(plot: DataExplorerPlotConfig) {
+export function normalizePlot(plot: DataExplorerPlotConfig) {
   // Remove any incomplete options first.
   const {
     color_by,
@@ -301,6 +307,11 @@ function normalizePlot(plot: DataExplorerPlotConfig) {
     show_regression_line,
     filters,
     metadata,
+    // `version` is deliberately NOT listed here — it must survive into `rest`
+    // so the serialization in plotToQueryString round-trips it correctly. If you
+    // add it to this destructure for any reason, you must re-add it
+    // unconditionally in every branch below, or stamped payloads lose their
+    // version and the reader treats them as pre-versioning legacy.
     ...rest
   } = plot;
   const normalized: DataExplorerPlotConfig = rest;
@@ -322,6 +333,28 @@ function normalizePlot(plot: DataExplorerPlotConfig) {
       normalized.use_clustering = true;
     }
   } else {
+    // `sort_by` controls the ordering of groups. Every one of its values is a
+    // function of the data alone; none is semantically dependent on the color
+    // dimension. Its entanglement with `color_by` was historical: preservation
+    // used to happen only inside the color arms below, so `sort_by` survived
+    // normalization only when some color backing happened to be complete, and
+    // was silently dropped otherwise. That is why `sort_by: "alphabetical"` set
+    // by Transcript Explorer vanished on refresh — the plot round-tripped
+    // through `plotToQueryString` and matched no color arm.
+    //
+    // Preserve it unconditionally here and let the color arms below concern
+    // themselves only with color. This is the same allowlist hazard that bit
+    // `color_by: "expansion"`: anything destructured out at the top of this
+    // function must be deliberately shepherded back in, and a field re-added
+    // only inside conditional branches is a field that is conditionally lost.
+    //
+    // (Deliberately inside the non-heatmap arm: `correlation_heatmap` has no
+    // groups to order — it is ordered by `use_clustering` — so it has never
+    // carried a meaningful `sort_by`.)
+    if (sort_by) {
+      normalized.sort_by = sort_by;
+    }
+
     // `color_by: "expansion"` colors points by their expansion member and is
     // backed by `expand_by` (which rides through untouched in `rest`), not by a
     // color dimension/filter/metadata. The branches below only re-add `color_by`
@@ -355,19 +388,11 @@ function normalizePlot(plot: DataExplorerPlotConfig) {
     ) {
       normalized.color_by = color_by;
       normalized.metadata = metadata;
-
-      if (sort_by) {
-        normalized.sort_by = sort_by;
-      }
     }
 
     if (color_by && rest.dimensions?.color) {
       if (isCompleteDimension(rest.dimensions.color)) {
         normalized.color_by = color_by;
-
-        if (sort_by) {
-          normalized.sort_by = sort_by;
-        }
       } else {
         normalized.dimensions = omit(rest.dimensions, "color");
       }
@@ -537,7 +562,9 @@ export async function plotToQueryString(
     nextParams = omit(nextParams, paramsToDrop);
   }
 
-  const encodedPlot = await replaceContextsWithHashes(normalizePlot(plot));
+  const encodedPlot = await replaceContextsWithHashes(
+    normalizePlot({ ...plot, version: CURRENT_PLOT_VERSION })
+  );
   const serialized = compress(encodedPlot);
 
   return `?${qs.stringify({ ...nextParams, p: serialized })}`;
@@ -591,6 +618,11 @@ const replaceLegacyPropertyNames = (plot: DataExplorerPlotConfig | null) => {
   return plot;
 };
 
+// Called only from makePlotConfigBreadboxModeCompatible, which itself has a
+// second caller (StartScreenExample) besides readPlotFromQueryString. Do not
+// gate this on payload version: the side effect
+// (replaceLegacyContextIfExistsInLocalStorage) must fire for every caller, and
+// version describes only the `p`-param payload, not the StartScreen path.
 async function convertAllLegacyContexts(plot: DataExplorerPlotConfig | null) {
   if (!plot) {
     return null;
@@ -667,91 +699,101 @@ export async function makePlotConfigBreadboxModeCompatible(
   }
 
   // Convert any `metadata` values from slice IDs to SliceQuery objects.
+  // The two dataset fetches are gated on whether any value actually needs
+  // conversion — native (already-SliceQuery) payloads skip the round-trips.
   if (plot?.metadata) {
-    const datasets = await cached(breadboxAPI).getDatasets();
-    const dimTypes = await cached(breadboxAPI).getDimensionTypes();
+    const hasSliceIds = Object.keys(plot.metadata).some(
+      (key) => "slice_id" in plot.metadata[key]
+    );
 
-    // eslint-disable-next-line no-inner-declarations
-    function maybeFallbackToMetadataDatasetNonGivenId(dataset_id: string) {
-      const dimTypeName = dataset_id.replace(/_metadata$/, "");
-      const dimType = dimTypes.find((dt) => dt.name === dimTypeName);
+    if (hasSliceIds) {
+      const datasets = await cached(breadboxAPI).getDatasets();
+      const dimTypes = await cached(breadboxAPI).getDimensionTypes();
 
-      if (dimType?.metadata_dataset_id) {
-        const regularId = dimType.metadata_dataset_id;
-        const dataset = datasets.find((d) => d.id === regularId);
+      // eslint-disable-next-line no-inner-declarations
+      function maybeFallbackToMetadataDatasetNonGivenId(dataset_id: string) {
+        const dimTypeName = dataset_id.replace(/_metadata$/, "");
+        const dimType = dimTypes.find((dt) => dt.name === dimTypeName);
 
-        if (dataset && dataset.given_id !== dataset_id) {
-          return regularId;
+        if (dimType?.metadata_dataset_id) {
+          const regularId = dimType.metadata_dataset_id;
+          const dataset = datasets.find((d) => d.id === regularId);
+
+          if (dataset && dataset.given_id !== dataset_id) {
+            return regularId;
+          }
         }
+
+        return dataset_id;
       }
 
-      return dataset_id;
-    }
+      for (const key of Object.keys(plot.metadata)) {
+        const value = plot.metadata[key];
 
-    for (const key of Object.keys(plot.metadata)) {
-      const value = plot.metadata[key];
-
-      if ("slice_id" in value) {
-        const nextValue = sliceIdToSliceQuery(
-          value.slice_id,
-          "categorical",
-          plot.index_type
-        );
-
-        if (nextValue.dataset_id.endsWith("_metadata")) {
-          // This shouldn't bee necessary because we now auto-generate a
-          // given_id for every metadata dataset. However, at least at one
-          // point, there were some crufty dimension types that slipped through
-          // the cracks. This accounts for that.
-          nextValue.dataset_id = maybeFallbackToMetadataDatasetNonGivenId(
-            nextValue.dataset_id
+        if ("slice_id" in value) {
+          const nextValue = sliceIdToSliceQuery(
+            value.slice_id,
+            "categorical",
+            plot.index_type
           );
-        }
 
-        plot.metadata[key] = nextValue;
+          if (nextValue.dataset_id.endsWith("_metadata")) {
+            // This shouldn't bee necessary because we now auto-generate a
+            // given_id for every metadata dataset. However, at least at one
+            // point, there were some crufty dimension types that slipped through
+            // the cracks. This accounts for that.
+            nextValue.dataset_id = maybeFallbackToMetadataDatasetNonGivenId(
+              nextValue.dataset_id
+            );
+          }
 
-        if (key === "color_property" && nextValue) {
-          if (nextValue.identifier_type === "column") {
-            plot.color_by = nextValue.dataset_id.endsWith("_metadata")
-              ? "property"
-              : "custom";
-          } else if (
-            nextValue.dataset_id === wellKnownDatasets.subtype_matrix
-          ) {
-            plot.color_by = "property";
-          } else {
-            // In some rare cases, what used to be considered a color "property"
-            // (was keyed as model metadata) is now now stored in a matrix.
-            // Known cases:
-            // mutations_prioritized
-            // mutation_protein_change
-            const slice_type =
-              nextValue.dataset_id === wellKnownDatasets.mutations_prioritized
-                ? "gene"
-                : null;
+          plot.metadata[key] = nextValue;
 
-            plot.color_by = "custom";
-            plot.dimensions.color = ({
-              axis_type: "raw_slice",
-              slice_type,
-              aggregation: "first",
-              dataset_id: nextValue.dataset_id,
-              context: {
-                name: nextValue.identifier,
-                dimension_type: slice_type,
-                expr: { "==": [{ var: "entity_label" }, nextValue.identifier] },
-                vars: {
-                  entity_label: {
-                    dataset_id: maybeFallbackToMetadataDatasetNonGivenId(
-                      `${slice_type}_metadata`
-                    ),
-                    identifier_type: "column" as const,
-                    identifier: "label",
+          if (key === "color_property" && nextValue) {
+            if (nextValue.identifier_type === "column") {
+              plot.color_by = nextValue.dataset_id.endsWith("_metadata")
+                ? "property"
+                : "custom";
+            } else if (
+              nextValue.dataset_id === wellKnownDatasets.subtype_matrix
+            ) {
+              plot.color_by = "property";
+            } else {
+              // In some rare cases, what used to be considered a color "property"
+              // (was keyed as model metadata) is now now stored in a matrix.
+              // Known cases:
+              // mutations_prioritized
+              // mutation_protein_change
+              const slice_type =
+                nextValue.dataset_id === wellKnownDatasets.mutations_prioritized
+                  ? "gene"
+                  : null;
+
+              plot.color_by = "custom";
+              plot.dimensions.color = ({
+                axis_type: "raw_slice",
+                slice_type,
+                aggregation: "first",
+                dataset_id: nextValue.dataset_id,
+                context: {
+                  name: nextValue.identifier,
+                  dimension_type: slice_type,
+                  expr: {
+                    "==": [{ var: "entity_label" }, nextValue.identifier],
+                  },
+                  vars: {
+                    entity_label: {
+                      dataset_id: maybeFallbackToMetadataDatasetNonGivenId(
+                        `${slice_type}_metadata`
+                      ),
+                      identifier_type: "column" as const,
+                      identifier: "label",
+                    },
                   },
                 },
-              },
-            } as unknown) as DataExplorerPlotConfigDimension;
-            delete plot.metadata[key];
+              } as unknown) as DataExplorerPlotConfigDimension;
+              delete plot.metadata[key];
+            }
           }
         }
       }
@@ -786,20 +828,82 @@ export async function readPlotFromQueryString(): Promise<DataExplorerPlotConfig>
     plot = decompress(params.p as string) as DataExplorerPlotConfig;
   }
 
-  // `plot.dimensions` used to be an array but now it's an object.
-  // Just in case there are any old bookmarks hanging around,
-  // we'll parse the array and transform it into an object.
-  if (plot && Array.isArray(plot.dimensions)) {
-    const [x, y] = plot.dimensions;
+  // Both live mint points stamp `version`: `plotToQueryString` (the `p` param)
+  // and `parseShorthandParams` (the shorthand params). The only producers left
+  // unstamped are genuinely old — the base64 `plot` param, a format we no longer
+  // write, and `p` payloads minted before versioning shipped. So absent version
+  // ⟹ pre-versioning legacy, and coercing it to 0 is sound rather than a guess.
+  //
+  // Keeping that implication TRUE is the whole job of stamping at the mint point,
+  // and it is load-bearing for every future migration. A Phase B step gated on
+  // `payloadVersion < N` necessarily assumes an unstamped payload was minted
+  // under the old regime. Were shorthand links left unstamped, a link generated
+  // one second from now would coerce to 0 and be migrated as though it were years
+  // old — silently reinterpreted under semantics it was never minted under. Stamp
+  // at the mint point; never sniff payload shape at the reader.
+  const payloadVersion = plot?.version ?? 0;
 
-    plot.dimensions = {
-      ...(x && { x }),
-      ...(y && { y }),
-      // no `color` dimension because this format predates that
-    };
+  // Phase A: structural repairs — skipped for version >= 1, which certifies that
+  // `dimensions` is already an object and all property names are canonical (no
+  // legacy `entity`/`context` values for color_by/axis_type, no entity_type).
+  //
+  // Shorthand plots are certified by construction, not by assumption: the parser
+  // only ever writes `color_by` of "aggregated_slice" | "property", `axis_type` of
+  // "raw_slice" | "aggregated_slice", always `slice_type` (never `entity_type`),
+  // and always an object `dimensions`. Phase A was already a no-op on them before
+  // they carried a version; stamping simply lets us skip the no-op honestly.
+  if (payloadVersion < 1) {
+    // `plot.dimensions` used to be an array but now it's an object.
+    // Just in case there are any old bookmarks hanging around,
+    // we'll parse the array and transform it into an object.
+    if (plot && Array.isArray(plot.dimensions)) {
+      const [x, y] = plot.dimensions;
+
+      plot.dimensions = {
+        ...(x && { x }),
+        ...(y && { y }),
+        // no `color` dimension because this format predates that
+      };
+    }
+
+    plot = replaceLegacyPropertyNames(plot);
   }
 
-  plot = replaceLegacyPropertyNames(plot);
+  // Strip version before the plot enters memory. It's a wire-only field;
+  // leaving it in would cause plotsAreEquivalentWhenSerialized to see spurious
+  // diffs between a loaded plot and an otherwise-identical in-memory one.
+  if (plot) {
+    delete plot.version;
+  }
+
+  // Phase B migrations go here, gated on `payloadVersion` — the coerced local
+  // captured above, NOT `plot.version`. The reason isn't only that `plot.version`
+  // has been deleted; it's that `plot.version` is undefined for the ENTIRE
+  // pre-versioning cohort regardless of where the strip sits, and
+  // `undefined < 2` evaluates to false, which would silently skip the legacy
+  // payloads a migration exists to upgrade while appearing to work on v1+.
+  // The `?? 0` coercion is the only thing that makes `0 < 2 === true` for that
+  // cohort. Do not "fix" this by moving the strip — the silent-skip failure mode
+  // is independent of strip placement. Each migration should be its own named
+  // step, not folded into Phase A's block.
+  // Example slot: if (payloadVersion < 2) { /* color_by flip migration */ }
+  //
+  // replaceHashesWithContexts and makePlotConfigBreadboxModeCompatible are
+  // unconditional regardless of version, for two independent reasons:
+  //   1. `version` certifies SCHEMA vintage, never backend-nativity. A payload can
+  //      be honestly v1 and still carry backend-legacy forms. Shorthand is the
+  //      proof: parseShorthandParams matches legacy dataset IDs via
+  //      legacyPortalIdToBreadboxGivenId but writes the RAW id, deliberately
+  //      deferring the rewrite to here; it likewise emits context_type contexts,
+  //      the "custom" slice_type sentinel, and slice_id metadata. A hand-written
+  //      or LLM-generated v1 URL can do the same. For those inputs these passes
+  //      are LOAD-BEARING, not idempotent no-ops. Never gate them on version.
+  //   2. Context hashes resolve to contexts persisted by any client vintage, so
+  //      V1→V2 conversion happens at point-of-dereference inside
+  //      replaceHashesWithContexts, keyed on the context's shape, not the plot's
+  //      version.
+  // The function is additionally idempotent on already-native input, so running
+  // it unconditionally is cheap.
   plot = await replaceHashesWithContexts(plot);
 
   if (plot) {

--- a/frontend/packages/@depmap/types/src/data-explorer-2.ts
+++ b/frontend/packages/@depmap/types/src/data-explorer-2.ts
@@ -194,6 +194,7 @@ export interface DataExplorerExpandedPlotResponse
 // certain plot types (but encoding that in type system would be much more
 // trouble than it's worth).
 export interface DataExplorerPlotConfig {
+  version?: number;
   plot_type: DataExplorerPlotType;
   index_type: string;
   dimensions: Partial<Record<DimensionKey, DataExplorerPlotConfigDimension>>;


### PR DESCRIPTION
This add an explicit `version` on the serialized plot payload. Up until
now, all changes to the schema had been additive. I'm about to add
support for a `group_by` field which will alter the semantics of the
existing `color_by` field. That breaking change makes me uneasy and I
want to be able to document it for Delphi to understand and give it
insrtuctions to include the `version` so it can be migrated as needed.

Design rationale lives in the ADR added here — read it first if you are
changing the migration structure or bumping the version:

    docs/adr/0001-plot-config-schema-versioning.md   (versioning design)
    docs/adr/0002-normalizeplot-is-an-allowlist.md   (why sort_by broke)