### PR TITLE
Fix clustering bug on correlation heatmap

### DIFF
--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/__tests__/breadboxMethods.test.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/__tests__/breadboxMethods.test.ts
@@ -514,4 +514,110 @@ describe("fetchCorrelation", () => {
 
     expect(response.index_id_column).toBe("entrez_id");
   });
+
+  // Regression: with both distinguish1 and distinguish2, each correlateDimension
+  // call runs an independent clustering pass. The two passes can produce different
+  // column orders. Without realignment, x2.values[i][j] describes a different gene
+  // pair than x.values[i][j] (and index_ids[i/j]), so a selected heatmap cell shows
+  // the wrong correlation value from the second heatmap.
+  test("x2 matrix is aligned with index_ids when clustering and distinguish2 are both active", async () => {
+    mockDimensionTypes();
+    mockDatasets();
+    mockDatasetIdentifiers();
+    mockDimensionTypeIdentifiers();
+
+    // distinguish1 data: GENE_A and GENE_B perfectly correlated, GENE_C anti-correlated.
+    // Clustering will place A and B adjacent.
+    const distinguish1MatrixResponse = {
+      GENE_A: { S1: 1.0, S2: 2.0, S3: 3.0, S4: 4.0 },
+      GENE_B: { S1: 1.0, S2: 2.0, S3: 3.0, S4: 4.0 },
+      GENE_C: { S1: 4.0, S2: 3.0, S3: 2.0, S4: 1.0 },
+    };
+
+    // distinguish2 data: GENE_A and GENE_C perfectly correlated, GENE_B anti-correlated.
+    // Independent clustering would place A and C adjacent — a different order than x.
+    const distinguish2MatrixResponse = {
+      GENE_A: { T1: 1.0, T2: 2.0, T3: 3.0, T4: 4.0 },
+      GENE_B: { T1: 4.0, T2: 3.0, T3: 2.0, T4: 1.0 },
+      GENE_C: { T1: 1.0, T2: 2.0, T3: 3.0, T4: 4.0 },
+    };
+
+    const distinguish1Context = {
+      name: "filter1",
+      context_type: "depmap_model",
+      expr: { in: [{ var: "given_id" }, ["S1", "S2", "S3", "S4"]] },
+    };
+    const distinguish2Context = {
+      name: "filter2",
+      context_type: "depmap_model",
+      expr: { in: [{ var: "given_id" }, ["T1", "T2", "T3", "T4"]] },
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    breadboxAPI.evaluateContext = jest.fn<any, [any]>().mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (ctx: any) => {
+        if (ctx === distinguish1Context) {
+          return Promise.resolve({ ids: ["S1", "S2", "S3", "S4"], labels: ["S1", "S2", "S3", "S4"] });
+        }
+        if (ctx === distinguish2Context) {
+          return Promise.resolve({ ids: ["T1", "T2", "T3", "T4"], labels: ["T1", "T2", "T3", "T4"] });
+        }
+        // Gene context
+        return Promise.resolve({
+          ids: correlationGeneIdentifiers.map((g) => g.id),
+          labels: correlationGeneIdentifiers.map((g) => g.label),
+        });
+      }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) as any;
+
+    breadboxAPI.getMatrixDatasetData = jest
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .fn<ReturnType<typeof breadboxAPI.getMatrixDatasetData>, [string, any]>()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation((_datasetId: string, params: any) => {
+        const samples: string[] = params.samples || [];
+        if (samples.includes("S1")) {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          return Promise.resolve(distinguish1MatrixResponse as any);
+        }
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return Promise.resolve(distinguish2MatrixResponse as any);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any;
+
+    const response = await fetchCorrelation(
+      "gene",
+      { x: xDimension },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { distinguish1: distinguish1Context as any, distinguish2: distinguish2Context as any },
+      true
+    );
+
+    const x1Matrix = response.dimensions.x.values as unknown as number[][];
+    const x2Matrix = (response.dimensions as any).x2?.values as unknown as number[][];
+
+    expect(x2Matrix).toBeDefined();
+
+    // Build a lookup by id so assertions are independent of clustering order.
+    const idToPos: Record<string, number> = {};
+    response.index_ids.forEach((id, i) => { idToPos[id] = i; });
+
+    const a = idToPos["11111"]; // GENE_A
+    const b = idToPos["22222"]; // GENE_B
+    const c = idToPos["33333"]; // GENE_C
+
+    // x (distinguish1): A↔B = 1, A↔C = B↔C = -1
+    expect(x1Matrix[a][b]).toBeCloseTo(1, 5);
+    expect(x1Matrix[a][c]).toBeCloseTo(-1, 5);
+    expect(x1Matrix[b][c]).toBeCloseTo(-1, 5);
+
+    // x2 (distinguish2): A↔C = 1, A↔B = B↔C = -1.
+    // Before the fix, x2's matrix was in a different clustering order than index_ids,
+    // so these look-ups by index_ids position would return wrong values.
+    expect(x2Matrix[a][c]).toBeCloseTo(1, 5);
+    expect(x2Matrix[a][b]).toBeCloseTo(-1, 5);
+    expect(x2Matrix[b][c]).toBeCloseTo(-1, 5);
+  });
 });

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/breadboxMethods.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/breadboxMethods.ts
@@ -1153,14 +1153,33 @@ export async function fetchCorrelation(
     use_clustering
   );
 
-  const [x2] = filters?.distinguish2
+  const [x2Raw, x2Ids] = filters?.distinguish2
     ? await correlateDimension(
         dimensions.x,
         index_type,
         filters?.distinguish2 as DataExplorerContextV2,
         use_clustering
       )
-    : [null];
+    : [null, null];
+
+  // When clustering is enabled, correlateDimension runs a separate clustering
+  // pass for x2 that may produce a different column order than x. Without
+  // realignment, x2.values[i][j] describes a different gene pair than
+  // x.values[i][j] (and index_ids[i/j]), so a selected cell shows the wrong
+  // value from one of the two heatmaps. Reorder x2's matrix to follow x's
+  // clustering order.
+  let x2 = x2Raw;
+  if (x2Raw && x2Ids && use_clustering) {
+    const x2Matrix = x2Raw.values as unknown as number[][];
+    const x2IdToIndex: Record<string, number> = {};
+    x2Ids.forEach((id: string, i: number) => {
+      x2IdToIndex[id] = i;
+    });
+    const reorderedMatrix = ids.map((rowId: string) =>
+      ids.map((colId: string) => x2Matrix[x2IdToIndex[rowId]][x2IdToIndex[colId]])
+    );
+    x2 = { ...x2Raw, values: reorderedMatrix as unknown as number[] };
+  }
 
   const dimTypes = await cached(breadboxAPI).getDimensionTypes();
   const indexDimType = dimTypes.find((t) => t.name === index_type);

--- a/frontend/packages/@depmap/statistics/package.json
+++ b/frontend/packages/@depmap/statistics/package.json
@@ -5,7 +5,23 @@
   "types": "index.d.ts",
   "license": "MIT",
   "scripts": {
-    "test": "echo 'no tests to run'"
+    "test": "jest"
+  },
+  "jest": {
+    "moduleFileExtensions": ["js", "ts"],
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "diagnostics": false,
+          "tsconfig": {
+            "module": "commonjs"
+          }
+        }
+      ]
+    },
+    "testRegex": ".*/__tests__/.*\\.test\\.(ts|js)$",
+    "testEnvironment": "node"
   },
   "dependencies": {
     "jstat": "^1.9.6",

--- a/frontend/packages/@depmap/statistics/src/__tests__/correlationMatrix.test.ts
+++ b/frontend/packages/@depmap/statistics/src/__tests__/correlationMatrix.test.ts
@@ -1,0 +1,149 @@
+import {
+  clusterCorrelationMatrix,
+  correlationMatrix,
+} from "../correlationMatrix";
+
+// Build a lookup table: col1 → col2 → correlation value.
+// This lets tests find the correlation between two named columns without
+// caring about their position in the (potentially reordered) result.
+function buildLookup(result: {
+  columns: string[];
+  matrix: number[][];
+}): Record<string, Record<string, number>> {
+  const lookup: Record<string, Record<string, number>> = {};
+  result.columns.forEach((col1, i) => {
+    lookup[col1] = {};
+    result.columns.forEach((col2, j) => {
+      lookup[col1][col2] = result.matrix[i][j];
+    });
+  });
+  return lookup;
+}
+
+// Fixture: A and B are perfectly correlated; C is perfectly anti-correlated
+// with both. Distance matrix: d(A,B)=0, d(A,C)=d(B,C)=2, d(A,A)=0 etc.
+// Clustering should always place A and B adjacent.
+const perfectTriple = {
+  columns: ["A", "B", "C"],
+  matrix: [
+    [1, 1, -1],
+    [1, 1, -1],
+    [-1, -1, 1],
+  ],
+};
+
+describe("clusterCorrelationMatrix", () => {
+  test("result has the same number of columns and rows as the input", () => {
+    const result = clusterCorrelationMatrix(perfectTriple);
+    expect(result.columns.length).toBe(3);
+    expect(result.matrix.length).toBe(3);
+    result.matrix.forEach((row) => expect(row.length).toBe(3));
+  });
+
+  test("result contains exactly the same column names as the input", () => {
+    const result = clusterCorrelationMatrix(perfectTriple);
+    expect(result.columns.slice().sort()).toEqual(
+      perfectTriple.columns.slice().sort()
+    );
+  });
+
+  test("diagonal is 1 for every column after clustering", () => {
+    const result = clusterCorrelationMatrix(perfectTriple);
+    result.columns.forEach((_, i) => {
+      expect(result.matrix[i][i]).toBeCloseTo(1, 10);
+    });
+  });
+
+  test("matrix is symmetric after clustering", () => {
+    const result = clusterCorrelationMatrix(perfectTriple);
+    const n = result.matrix.length;
+    for (let i = 0; i < n; i += 1) {
+      for (let j = 0; j < n; j += 1) {
+        expect(result.matrix[i][j]).toBeCloseTo(result.matrix[j][i], 10);
+      }
+    }
+  });
+
+  // This is the core regression: the correlation value between any pair of
+  // named columns must be the same before and after clustering — it should
+  // just appear at a different (i, j) position in the reordered matrix.
+  // A heatmap selection stores column *names* (IDs); when clustering changes
+  // their visual positions the displayed value must not change.
+  test("pairwise correlation values are preserved after reordering", () => {
+    const before = buildLookup(perfectTriple);
+    const after = buildLookup(clusterCorrelationMatrix(perfectTriple));
+
+    perfectTriple.columns.forEach((col1) => {
+      perfectTriple.columns.forEach((col2) => {
+        expect(after[col1][col2]).toBeCloseTo(before[col1][col2], 10);
+      });
+    });
+  });
+
+  // Similar items should end up adjacent. With ρ(A,B)=1 and ρ(A,C)=ρ(B,C)=-1,
+  // A and B are the closest pair and must be neighbors in the clustered output.
+  test("groups the most-similar pair adjacent", () => {
+    const result = clusterCorrelationMatrix(perfectTriple);
+    const posA = result.columns.indexOf("A");
+    const posB = result.columns.indexOf("B");
+    expect(Math.abs(posA - posB)).toBe(1);
+  });
+
+  // Verify the alignment contract directly: matrix[i][j] == correlation
+  // between columns[i] and columns[j], not between whatever was at position
+  // (i, j) before clustering.
+  test("matrix[i][j] equals the correlation between columns[i] and columns[j]", () => {
+    const expected: Record<string, Record<string, number>> = {
+      A: { A: 1, B: 1, C: -1 },
+      B: { A: 1, B: 1, C: -1 },
+      C: { A: -1, B: -1, C: 1 },
+    };
+
+    const result = clusterCorrelationMatrix(perfectTriple);
+    result.columns.forEach((col1, i) => {
+      result.columns.forEach((col2, j) => {
+        expect(result.matrix[i][j]).toBeCloseTo(expected[col1][col2], 10);
+      });
+    });
+  });
+});
+
+describe("correlationMatrix", () => {
+  // Raw data matching the perfectTriple fixture above.
+  const data = {
+    A: [1, 2, 3, 4],
+    B: [1, 2, 3, 4], // identical to A → ρ = 1
+    C: [4, 3, 2, 1], // reversed → ρ = -1 vs A and B
+  };
+
+  test("without clustering: diagonal is 1 and off-diagonal is ±1", () => {
+    const result = correlationMatrix(data, false);
+    result.columns.forEach((_, i) => {
+      expect(result.matrix[i][i]).toBeCloseTo(1, 5);
+    });
+    const lookup = buildLookup(result);
+    expect(lookup.A.B).toBeCloseTo(1, 5);
+    expect(lookup.A.C).toBeCloseTo(-1, 5);
+    expect(lookup.B.C).toBeCloseTo(-1, 5);
+  });
+
+  // Toggling clustering must not change the correlation value between any
+  // named pair of columns — only their positions in the matrix should differ.
+  test("with clustering: pairwise values match the unclustered result", () => {
+    const unclustered = buildLookup(correlationMatrix(data, false));
+    const clustered = buildLookup(correlationMatrix(data, true));
+
+    Object.keys(data).forEach((col1) => {
+      Object.keys(data).forEach((col2) => {
+        expect(clustered[col1][col2]).toBeCloseTo(unclustered[col1][col2], 5);
+      });
+    });
+  });
+
+  test("with clustering: A and B are placed adjacent", () => {
+    const result = correlationMatrix(data, true);
+    const posA = result.columns.indexOf("A");
+    const posB = result.columns.indexOf("B");
+    expect(Math.abs(posA - posB)).toBe(1);
+  });
+});


### PR DESCRIPTION
fix(data-explorer-2): realign x2 correlation matrix to x's clustering order

When both distinguish1 and distinguish2 filters are active on a correlation heatmap with clustering enabled, fetchCorrelation called correlateDimension independently for x and x2. Each call ran its own hierarchical clustering pass on different sample data, producing different column orderings. Because index_ids was set from x's clustering order only, x2.values[i][j] described a different gene pair than x.values[i][j], so a selected heatmap cell showed the correct correlation from one half-matrix and a wrong value from the other.

Fix: after computing x2, if use_clustering is true, reorder x2's matrix rows and columns to match the column order established by x's clustering pass. x2Ids (previously discarded) is now retained from the correlateDimension return value to drive the remapping.

Add tests to @depmap/statistics (correlationMatrix.test.ts):
- clusterCorrelationMatrix preserves all pairwise correlation values
- diagonal remains 1 and matrix remains symmetric after reordering
- columns and matrix stay aligned (matrix[i][j] is the correlation between columns[i] and columns[j], not whatever was at position (i,j) before)
- most-similar pair ends up adjacent in the clustered output
- correlationMatrix with/without clustering produces the same named values

Add regression test to @depmap/data-explorer-2 (breadboxMethods.test.ts):
- fetchCorrelation with distinguish1, distinguish2, and clustering active produces an x2 matrix whose values at index_ids positions are the correct distinguish2 correlations, not the values from x2's own clustering order