### PR TITLE
add "sum" as a supported aggregation

### DIFF
--- a/breadbox/breadbox/schemas/dataset.py
+++ b/breadbox/breadbox/schemas/dataset.py
@@ -48,6 +48,7 @@ class AggregationMethod(enum.Enum):
     per25 = "25%tile"
     per75 = "75%tile"
     stddev = "stddev"
+    sum = "sum"
 
 
 # NOTE: `param: Annotated[Optional[str], Field(None)]` gives pydantic error 'ValueError: `Field` default cannot be set in `Annotated` for 'param''.
@@ -485,7 +486,7 @@ class MatrixAggregation(BaseModel):
             AggregationMethod(v)
         except ValueError as err:
             raise UserError(
-                "Aggregations method must be one of ['mean', 'median', '25%tile', '75%tile']"
+                f"Aggregations method must be one of {[m.value for m in AggregationMethod]}"
             ) from err
 
         return v

--- a/breadbox/breadbox/service/dataset.py
+++ b/breadbox/breadbox/service/dataset.py
@@ -278,6 +278,7 @@ def _aggregate_matrix_df(
         AggregationMethod.per25: lambda x: np.nanpercentile(x, q=25),
         AggregationMethod.per75: lambda x: np.nanpercentile(x, q=75),
         AggregationMethod.stddev: lambda x: np.nanstd(x, ddof=1),
+        AggregationMethod.sum: "sum",
     }
 
     axis = 0 if aggregate_by == "samples" else 1

--- a/breadbox/tests/api/test_dataset_queries.py
+++ b/breadbox/tests/api/test_dataset_queries.py
@@ -433,6 +433,20 @@ def test_get_aggregated_matrix_dataset_data(
 
     response = client.post(
         f"/datasets/matrix/{matrix_dataset.json()['result']['datasetId']}",
+        json={"aggregate": {"aggregate_by": "samples", "aggregation": "sum"}},
+    )
+    """
+    Expected:
+        sum
+    -------------------
+    A     6
+    B     7
+    C     9
+    """
+    assert response.json() == {"sum": {"A": 6, "B": 7, "C": 9}}
+
+    response = client.post(
+        f"/datasets/matrix/{matrix_dataset.json()['result']['datasetId']}",
         json={
             "feature_identifier": "id",
             "features": ["A", "B"],

--- a/breadbox/tests/service/test_dataset.py
+++ b/breadbox/tests/service/test_dataset.py
@@ -46,6 +46,10 @@ def test_aggregate_stddev():
             AggregationMethod.median,
             pd.DataFrame({"median": [2, 6.50]}, index=["A", "B"]),  # pyright: ignore
         ),
+        (
+            AggregationMethod.sum,
+            pd.DataFrame({"sum": [32.0, 39.0]}, index=["A", "B"]),  # pyright: ignore
+        ),
     ],
 )
 def test_aggregate_matrix_methods(method, expected_df):

--- a/frontend/packages/@depmap/api/src/breadboxAPI/resources/datasets.ts
+++ b/frontend/packages/@depmap/api/src/breadboxAPI/resources/datasets.ts
@@ -56,7 +56,7 @@ export function getMatrixDatasetData(
     features?: string[] | null;
     aggregate?: {
       aggregate_by: "features" | "samples";
-      aggregation: "mean" | "median" | "25%tile" | "75%tile" | "stddev";
+      aggregation: "mean" | "median" | "25%tile" | "75%tile" | "stddev" | "sum";
     };
   }
 ) {
@@ -81,6 +81,7 @@ export function getMatrixDatasetData(
       "25%tile",
       "75%tile",
       "stddev",
+      "sum",
     ];
     const requested = args.aggregate.aggregation as string;
     if (!validAggregations.includes(requested)) {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/AggregationSelect.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/AggregationSelect.tsx
@@ -36,6 +36,7 @@ function AggregationSelect({
           "25%tile": "25%tile",
           "75%tile": "75%tile",
           stddev: "Standard deviation",
+          sum: "Sum",
         }}
         value={value}
         onChange={(nextValue) => onChange(nextValue as DataExplorerAggregation)}

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/__tests__/expandedPlot.test.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/__tests__/expandedPlot.test.ts
@@ -1,0 +1,252 @@
+import { breadboxAPI } from "@depmap/api";
+import { fetchExpandedPlot } from "../expandedPlot";
+
+// Scenario under test: a Transcript-Explorer-shaped plot. The x axis is the
+// expansion (transcripts of one gene, carrying the "expansion" sentinel), and
+// the y axis is an ordinary aggregated slice that happens to ALSO be
+// transcript-typed — e.g. "mean expression over transcripts of CD44" read from
+// a different transcript dataset. Changing y's `aggregation` must change the
+// values y contributes to the plot.
+
+const modelIdentifiers = [
+  { id: "ACH-000425", label: "NIHOVCAR3" },
+  { id: "ACH-000552", label: "HT29" },
+];
+
+const transcriptIdentifiers = [
+  { id: "ENST0001", label: "CD44-201" },
+  { id: "ENST0002", label: "CD44-202" },
+];
+
+const dimensionTypes = [
+  {
+    name: "depmap_model",
+    display_name: "Cell Line",
+    id_column: "depmap_id",
+    axis: "sample" as const,
+    metadata_dataset_id: "depmap_model_metadata",
+  },
+  {
+    name: "transcript",
+    display_name: "Transcript",
+    id_column: "transcript_id",
+    axis: "feature" as const,
+    metadata_dataset_id: "transcript_metadata",
+  },
+];
+
+const shortReadDataset = {
+  id: "short_read",
+  given_id: "short_read",
+  name: "Expression (short read)",
+  format: "matrix_dataset" as const,
+  feature_type_name: "transcript",
+  sample_type_name: "depmap_model",
+  units: "log2(TPM+1)",
+  value_type: "continuous" as const,
+  data_type: "Expression",
+  priority: 1,
+};
+
+const longReadDataset = {
+  ...shortReadDataset,
+  id: "long_read",
+  given_id: "long_read",
+  name: "Expression (long read)",
+};
+
+const transcriptContext = {
+  name: "CD44",
+  dimension_type: "transcript",
+  expr: { "==": [{ var: "gene" }, "CD44"] },
+  vars: {
+    gene: {
+      dataset_id: "transcript_metadata",
+      identifier: "Gene",
+      identifier_type: "column" as const,
+      source: "property" as const,
+    },
+  },
+};
+
+function makeConfig(aggregation: string) {
+  return {
+    index_type: "depmap_model",
+    plot_type: "scatter",
+    dimensions: {
+      // The expansion axis: carries the "expansion" sentinel.
+      x: {
+        axis_type: "aggregated_slice",
+        slice_type: "transcript",
+        dataset_id: "short_read",
+        context: transcriptContext,
+        aggregation: "expansion",
+      },
+      // A plain aggregated slice that is also transcript-typed.
+      y: {
+        axis_type: "aggregated_slice",
+        slice_type: "transcript",
+        dataset_id: "long_read",
+        context: transcriptContext,
+        aggregation,
+      },
+    },
+    expand_by: [
+      {
+        slice_type: "transcript",
+        context: transcriptContext,
+        limit: 9,
+        offset: 0,
+      },
+    ],
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+// Every getMatrixDatasetData call, so we can inspect how y was fetched.
+let matrixCalls: { datasetId: string; args: Record<string, unknown> }[] = [];
+
+beforeEach(() => {
+  matrixCalls = [];
+
+  breadboxAPI.getDimensionTypes = jest
+    .fn<ReturnType<typeof breadboxAPI.getDimensionTypes>, []>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockResolvedValue(dimensionTypes as any);
+
+  breadboxAPI.getDatasets = jest
+    .fn<ReturnType<typeof breadboxAPI.getDatasets>, []>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockResolvedValue([shortReadDataset, longReadDataset] as any);
+
+  breadboxAPI.getDataset = jest
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .fn<any, [string]>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockImplementation(
+      (datasetId: string) =>
+        Promise.resolve(
+          datasetId === "long_read" ? longReadDataset : shortReadDataset
+        )
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ) as any;
+
+  breadboxAPI.getDatasetSamples = jest
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .fn<any, [string]>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockResolvedValue(modelIdentifiers as any);
+
+  breadboxAPI.getDatasetFeatures = jest
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .fn<any, [string]>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockResolvedValue(transcriptIdentifiers as any);
+
+  breadboxAPI.evaluateContext = jest
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .fn<any, [any]>()
+    .mockResolvedValue({
+      ids: transcriptIdentifiers.map((t) => t.id),
+      labels: transcriptIdentifiers.map((t) => t.label),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+  breadboxAPI.getDimensionTypeIdentifiers = jest
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .fn<any, [string]>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockResolvedValue(transcriptIdentifiers as any);
+
+  breadboxAPI.getTabularDatasetData = jest
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .fn<any, [string, any]>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockImplementation((_datasetId: string, args: any) => {
+      const column = args?.identifier ?? args?.columns?.[0] ?? "label";
+
+      return Promise.resolve({
+        [column]: {
+          "ACH-000425": "Ovary/Fallopian Tube",
+          "ACH-000552": "Bowel",
+        },
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+
+  breadboxAPI.getMatrixDatasetData = jest
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .fn<any, [string, any]>()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .mockImplementation((datasetId: string, args: any) => {
+      matrixCalls.push({ datasetId, args });
+
+      // Aggregated request: response is keyed by the aggregation name. The
+      // values differ per aggregation (mean of 10,30 vs sum of 10,30) so a
+      // test can tell whether the requested aggregation reached the response.
+      if (args.aggregate) {
+        const isSum = args.aggregate.aggregation === "sum";
+
+        return Promise.resolve({
+          [args.aggregate.aggregation]: {
+            "ACH-000425": isSum ? 40 : 20,
+            "ACH-000552": isSum ? 60 : 30,
+          },
+        });
+      }
+
+      // Un-aggregated matrix: Record<feature_id, Record<sample_id, value>>.
+      return Promise.resolve({
+        ENST0001: { "ACH-000425": 10, "ACH-000552": 20 },
+        ENST0002: { "ACH-000425": 30, "ACH-000552": 40 },
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any;
+});
+
+test("a non-expansion aggregated slice sharing the expansion's slice_type is aggregated", async () => {
+  await fetchExpandedPlot(makeConfig("mean"));
+
+  const yCall = matrixCalls.find((c) => c.datasetId === "long_read");
+
+  expect(yCall).toBeDefined();
+  expect(yCall!.args.aggregate).toEqual({
+    aggregate_by: "features",
+    aggregation: "mean",
+  });
+});
+
+test("the sentinel-bearing axis is still materialized per-pair, not aggregated", async () => {
+  const response = await fetchExpandedPlot(makeConfig("mean"));
+
+  const xCall = matrixCalls.find((c) => c.datasetId === "short_read");
+
+  expect(xCall).toBeDefined();
+  expect(xCall!.args.aggregate).toBeUndefined();
+  // Two models × two transcripts, index-major.
+  expect(response.dimensions.x!.values).toEqual([10, 30, 20, 40]);
+});
+
+test("an `expand_by` with no sentinel-bearing axis is rejected", async () => {
+  const config = makeConfig("mean");
+  config.dimensions.x.aggregation = "mean";
+
+  await expect(fetchExpandedPlot(config)).rejects.toThrow(
+    /no dimension carries the "expansion" sentinel/
+  );
+});
+
+test("changing that slice's aggregation changes the values it contributes", async () => {
+  const withMean = await fetchExpandedPlot(makeConfig("mean"));
+  const withSum = await fetchExpandedPlot(makeConfig("sum"));
+
+  const requested = matrixCalls
+    .filter((c) => c.datasetId === "long_read")
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    .map((c) => (c.args.aggregate as any)?.aggregation);
+
+  expect(requested).toEqual(["mean", "sum"]);
+  expect(withSum.dimensions.y!.values).not.toEqual(
+    withMean.dimensions.y!.values
+  );
+});

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/expandedPlot.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/expandedPlot.ts
@@ -16,7 +16,11 @@ import {
   buildTablesByDim,
   resolveDisplayLabel,
 } from "@depmap/selects";
-import { isCompleteDimension, isSampleType } from "../../utils/misc";
+import {
+  isCompleteDimension,
+  isExpansionDimension,
+  isSampleType,
+} from "../../utils/misc";
 import { MAX_PLOTTABLE_CATEGORIES } from "../../constants/plotConstants";
 import { fetchDatasetIdentifiers } from "./identifiers";
 import { getDimensionDataWithoutLabels } from "./helpers";
@@ -168,16 +172,41 @@ export async function fetchExpandedPlot(
   const filterKeys = Object.keys(filters || {}) as FilterKey[];
   const metadataKeys = Object.keys(extendedMetadata);
 
-  // A dimension expands when its slice_type matches the expansion's, AND
-  // it's an aggregated_slice (i.e. its context resolves to many ids that
-  // we'd normally aggregate). A raw_slice transcript dimension picks one
-  // specific transcript and is broadcast like any other singleton value.
-  const isExpanding = (k: string) =>
-    dimensions[k].axis_type === "aggregated_slice" &&
-    dimensions[k].slice_type === exp.slice_type;
+  // A dimension expands when it carries the "expansion" sentinel on
+  // `aggregation` — the single documented identity for an expansion axis (see
+  // isExpansionDimension, and the DataExplorerAggregation comments in
+  // @depmap/types). `select_expansion` stamps it on exactly the axis being
+  // expanded, and it survives URL round-tripping, so it is authoritative no
+  // matter where a config came from.
+  //
+  // This deliberately does NOT match on `(axis_type, slice_type)` shape.
+  // Doing so also captured any OTHER aggregated dimension that happened to
+  // share the expansion's slice_type — in Transcript Explorer, an aggregated
+  // transcript slice on the opposite axis, which is an entirely ordinary
+  // thing to configure. Such a dimension was routed here, materialized
+  // per-pair, and its `aggregation` silently discarded, so that axis's
+  // aggregation dropdown had no effect on the plot. The shape check also
+  // disagreed with normalize() in plotConfigReducer, which has always used
+  // the sentinel to decide whether `expand_by` is still live.
+  const isExpanding = (k: string) => isExpansionDimension(dimensions[k]);
 
   const expandedKeys = dimensionKeys.filter(isExpanding);
   const broadcastKeys = dimensionKeys.filter((k) => !isExpanding(k));
+
+  // An `expand_by` with no sentinel-bearing axis has nothing to read the
+  // expansion from: every dimension would be broadcast and each index
+  // entity's single value replicated M times, producing an N×M plot of
+  // duplicated points that looks plausible and is wrong. normalize() strips
+  // `expand_by` in exactly this case, so reaching here means the config
+  // bypassed the reducer (a hand-authored link, or a caller assembling a
+  // config directly). Fail loudly instead.
+  if (expandedKeys.length === 0) {
+    throw new Error(
+      `fetchExpandedPlot got an \`expand_by\` for "${exp.slice_type}" but no ` +
+        `dimension carries the "expansion" sentinel on \`aggregation\`, so ` +
+        `there is no axis to materialize the expansion from.`
+    );
+  }
 
   // Shared state. Same pattern as fetchPlotDimensions: every fetcher
   // populates these; the canonical index is derived from them at the end.

--- a/frontend/packages/@depmap/types/src/data-explorer-2.ts
+++ b/frontend/packages/@depmap/types/src/data-explorer-2.ts
@@ -81,6 +81,7 @@ export type DataExplorerAggregation =
   | "25%tile"
   | "75%tile"
   | "stddev"
+  | "sum"
   // Sentinel — NOT a real aggregation; if anything, the opposite. It marks an
   // axis whose per-pair values come from an expansion (fetchExpandedPlot), not
   // from aggregating a slice. It rides on the required `aggregation` field to

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/DataExplorerLinks/toUnexpandedPlotLink.ts
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/DataExplorerLinks/toUnexpandedPlotLink.ts
@@ -14,6 +14,10 @@ function toUnexpandedPlotLink(
     nextPlot = omit(nextPlot, "color_by");
   }
 
+  if (nextPlot.facet_by === "expansion") {
+    nextPlot = omit(nextPlot, "facet_by");
+  }
+
   nextPlot.dimensions = (() => {
     const out: DataExplorerPlotConfig["dimensions"] = {};
 


### PR DESCRIPTION
This updates Breadbox with a new "sum" aggregation and adds it to the list options in Data Explorer.