### PR TITLE
paired screen follow-ups

### DIFF
--- a/frontend/packages/portal-frontend/src/cellLine/__tests__/ResistanceOrigin.test.tsx
+++ b/frontend/packages/portal-frontend/src/cellLine/__tests__/ResistanceOrigin.test.tsx
@@ -1,0 +1,109 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import * as React from "react";
+import ModelTab from "src/cellLine/components/ModelTab";
+import PairedScreensTile, {
+  ResistanceInfo,
+} from "src/cellLine/components/PairedScreensTile";
+import { derivePairedScreensData } from "src/cellLine/hooks/usePairedScreensData";
+import { ResistanceRow } from "src/cellLine/utilities/getResistanceScreenTable";
+import { ModelInfo } from "src/cellLine/models/types";
+
+jest.mock("@depmap/globals", () => ({
+  toPortalLink: (relativeUrl: string) => relativeUrl,
+}));
+
+const modelInfo = ({
+  lineage_tree: [],
+  molecular_subtype_tree: [],
+  aliases: [],
+  related_models: [],
+  metadata: {},
+} as unknown) as ModelInfo;
+
+describe("ModelTab resistance origin", () => {
+  it("renders a cultured resistance origin", () => {
+    render(
+      <ModelTab
+        modelInfo={modelInfo}
+        resistanceOrigin={{
+          type: "cultured",
+          description: "Selected in 1 µM afatinib",
+        }}
+      />
+    );
+
+    expect(screen.getByText("Resistance")).toBeInTheDocument();
+    expect(screen.getByText("Cultured Resistance")).toBeInTheDocument();
+    expect(screen.getByText("Selected in 1 µM afatinib")).toBeInTheDocument();
+  });
+
+  it("renders an engineered resistance origin", () => {
+    render(
+      <ModelTab
+        modelInfo={modelInfo}
+        resistanceOrigin={{
+          type: "engineered",
+          description: "EGFR T790M knock-in",
+        }}
+      />
+    );
+
+    expect(screen.getByText("Engineered Resistance")).toBeInTheDocument();
+    expect(screen.getByText("EGFR T790M knock-in")).toBeInTheDocument();
+  });
+
+  it("renders no resistance group without an origin", () => {
+    render(<ModelTab modelInfo={modelInfo} />);
+
+    expect(screen.queryByText("Resistance")).not.toBeInTheDocument();
+  });
+});
+
+describe("derivePairedScreensData origin inference", () => {
+  const baseRow = {
+    PairID: "PAIR095",
+    CtrlArmModelID: "ACH-002475",
+    CtrlArmStrippedCellLineName: "HEC59",
+    TestArmModelID: "ACH-002476",
+    TestArmStrippedCellLineName: "HEC59MLH1",
+    CulturedDrugResistance: null,
+    EngineeredModelDetails: "MLH1 13bp deletion",
+  };
+
+  it.each(["genetic knock-in", "genetic knock out"])(
+    "maps a %s row to an engineered origin",
+    (comparisonType) => {
+      const row: ResistanceRow = { ...baseRow, ComparisonType: comparisonType };
+      const { resistance } = derivePairedScreensData("ACH-002476", [], [row]);
+
+      expect(resistance).toEqual({
+        role: "derivative",
+        origin: { type: "engineered", description: "MLH1 13bp deletion" },
+        parentalLine: { id: "ACH-002475", name: "HEC59" },
+      });
+    }
+  );
+});
+
+describe("PairedScreensTile resistance metadata", () => {
+  it("shows the parental model link but not the origin", () => {
+    const resistance: ResistanceInfo = {
+      role: "derivative",
+      origin: {
+        type: "cultured",
+        description: "Selected in 1 µM afatinib",
+      },
+      parentalLine: { id: "ACH-000219", name: "PC14" },
+    };
+
+    render(<PairedScreensTile resistance={resistance} />);
+
+    expect(screen.getByText("Parental Model")).toBeInTheDocument();
+    expect(screen.getByText("PC14")).toBeInTheDocument();
+    expect(screen.queryByText("Cultured Resistance")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Selected in 1 µM afatinib")
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/packages/portal-frontend/src/cellLine/components/CellLineOverview.tsx
+++ b/frontend/packages/portal-frontend/src/cellLine/components/CellLineOverview.tsx
@@ -123,7 +123,14 @@ const CellLineOverview = ({ modelId, hasMetMapData }: Props) => {
           <React.Suspense
             fallback={<div className={styles.LoadingTile}>Loading...</div>}
           >
-            <DescriptionTile data={descriptionTileData} />
+            <DescriptionTile
+              data={descriptionTileData}
+              resistanceOrigin={
+                pairedScreens?.resistance?.role === "derivative"
+                  ? pairedScreens.resistance.origin
+                  : undefined
+              }
+            />
           </React.Suspense>
         )}
 

--- a/frontend/packages/portal-frontend/src/cellLine/components/DescriptionTile.tsx
+++ b/frontend/packages/portal-frontend/src/cellLine/components/DescriptionTile.tsx
@@ -4,13 +4,18 @@ import { ModelInfo } from "../models/types";
 import IdTab from "./IdTab";
 import ModelTab from "./ModelTab";
 import PatientTab from "./PatientTab";
+import type { ResistanceOrigin } from "./PairedScreensTile";
 import styles from "../styles/CellLinePage.scss";
 
 export interface DescriptionTileProps {
   data: ModelInfo;
+  resistanceOrigin?: ResistanceOrigin;
 }
 
-const DescriptionTile = ({ data }: DescriptionTileProps) => {
+const DescriptionTile = ({
+  data,
+  resistanceOrigin = undefined,
+}: DescriptionTileProps) => {
   if (data) {
     return (
       <article className="card_wrapper">
@@ -22,7 +27,7 @@ const DescriptionTile = ({ data }: DescriptionTileProps) => {
             id="cell_line_description_tile_tabs"
           >
             <Tab eventKey={1} title="Model">
-              <ModelTab modelInfo={data} />
+              <ModelTab modelInfo={data} resistanceOrigin={resistanceOrigin} />
             </Tab>
             <Tab eventKey={2} title="Patient">
               <PatientTab

--- a/frontend/packages/portal-frontend/src/cellLine/components/ModelTab.tsx
+++ b/frontend/packages/portal-frontend/src/cellLine/components/ModelTab.tsx
@@ -1,12 +1,17 @@
 import React from "react";
 import { ModelInfo, SubtypeTreeInfo } from "../models/types";
+import type { ResistanceOrigin } from "./PairedScreensTile";
 import styles from "../styles/CellLinePage.scss";
 
 export interface ModelTabProps {
   modelInfo: ModelInfo;
+  resistanceOrigin?: ResistanceOrigin;
 }
 
-const ModelTab = ({ modelInfo }: ModelTabProps) => {
+const ModelTab = ({
+  modelInfo,
+  resistanceOrigin = undefined,
+}: ModelTabProps) => {
   const showAnnotations =
     modelInfo.oncotree_lineage ||
     modelInfo.oncotree_primary_disease ||
@@ -71,6 +76,17 @@ const ModelTab = ({ modelInfo }: ModelTabProps) => {
                     </a>
                   </React.Fragment>
                 ))}
+            </>
+          )}
+          {resistanceOrigin && (
+            <>
+              <h4 className={styles.propertyGroupHeader}>Resistance</h4>
+              <h6 className={styles.propertyHeader}>
+                {resistanceOrigin.type === "cultured"
+                  ? "Cultured Resistance"
+                  : "Engineered Resistance"}
+              </h6>
+              <p>{resistanceOrigin.description}</p>
             </>
           )}
         </div>

--- a/frontend/packages/portal-frontend/src/cellLine/components/OncogenicAlterationsTile.tsx
+++ b/frontend/packages/portal-frontend/src/cellLine/components/OncogenicAlterationsTile.tsx
@@ -78,8 +78,8 @@ const OncogenicAlterationsTile = ({
                         title="Acquired alterations"
                         content={
                           <div>
-                            Alterations present in this resistant derivative but
-                            not in its parental model.
+                            Alterations observed in this resistant derivative
+                            but not in its parental model.
                           </div>
                         }
                       />

--- a/frontend/packages/portal-frontend/src/cellLine/components/PairedScreensTile.tsx
+++ b/frontend/packages/portal-frontend/src/cellLine/components/PairedScreensTile.tsx
@@ -159,16 +159,6 @@ function ResistanceMetadataSection({ data }: { data: ResistanceInfo }) {
         Resistance
       </h4>
 
-      {data.origin && (
-        <>
-          <h6 className={styles.propertyHeader}>
-            {data.origin.type === "cultured"
-              ? "Cultured Resistance"
-              : "Engineered Resistance"}
-          </h6>
-          <p>{data.origin.description}</p>
-        </>
-      )}
       <h6 className={styles.propertyHeader}>Parental Model</h6>
       <a
         className={styles.descriptionLinks}

--- a/frontend/packages/portal-frontend/src/cellLine/hooks/usePairedScreensData.ts
+++ b/frontend/packages/portal-frontend/src/cellLine/hooks/usePairedScreensData.ts
@@ -177,7 +177,13 @@ function deriveOrigin(row: ResistanceRow): ResistanceOrigin | undefined {
     return { type: "cultured", description: row.CulturedDrugResistance };
   }
 
-  if (row.ComparisonType === "genetic knock-in" && row.EngineeredModelDetails) {
+  // Note: the source data really does mix hyphenation ("knock-in" vs
+  // "knock out"). Both are genetically engineered models.
+  if (
+    (row.ComparisonType === "genetic knock-in" ||
+      row.ComparisonType === "genetic knock out") &&
+    row.EngineeredModelDetails
+  ) {
     return { type: "engineered", description: row.EngineeredModelDetails };
   }
 

--- a/frontend/packages/portal-frontend/src/cellLine/utilities/getResistanceScreenTable.ts
+++ b/frontend/packages/portal-frontend/src/cellLine/utilities/getResistanceScreenTable.ts
@@ -8,7 +8,11 @@ export interface ResistanceRow {
   TestArmStrippedCellLineName: string;
   CulturedDrugResistance: string | null;
   EngineeredModelDetails: string | null;
-  ComparisonType: "drug adapted" | "genetic knock-in" | string;
+  ComparisonType:
+    | "drug adapted"
+    | "genetic knock-in"
+    | "genetic knock out"
+    | string;
 }
 
 const getResistanceScreenTable = async () => {


### PR DESCRIPTION
- Move "Cultured/Engineered Resistance" indicator out of tile
  - Asana: https://app.asana.com/1/9513920295503/project/1155483306334244/task/1216955102108186?focus=true

- Change wording of alterations tooltip
  - "Alterations [present → observed] in this resistant derivative but not in its parental model."
  - Asana: https://app.asana.com/1/9513920295503/project/1155483306334244/task/1216955399730155?focus=true