### PR TITLE
feat(breadbox): add variance and count aggregations, and allow several per request

### DIFF
--- a/breadbox/breadbox/schemas/dataset.py
+++ b/breadbox/breadbox/schemas/dataset.py
@@ -48,6 +48,11 @@ class AggregationMethod(enum.Enum):
     per25 = "25%tile"
     per75 = "75%tile"
     stddev = "stddev"
+    variance = "variance"
+    # Number of non-null values that went into the other aggregations. Lets a
+    # caller tell a spread computed over three observations from one computed
+    # over three hundred.
+    count = "count"
     sum = "sum"
 
 
@@ -470,7 +475,12 @@ class MatrixAggregation(BaseModel):
     aggregate_by: Literal[
         "features", "samples"
     ]  # collapse features or samples into a single series
-    aggregation: AggregationMethod
+    # Either one method or several. Several are worth asking for together when
+    # they describe the same collapse -- e.g. a spread alongside the `count` it
+    # was computed over -- since the expensive part is reading the block out of
+    # HDF5, not the arithmetic. The response is keyed by method name either way,
+    # so a single method reads back exactly as it always has.
+    aggregation: Union[AggregationMethod, List[AggregationMethod]]
 
     @model_validator(mode="before")
     def check_valid_fields(self):
@@ -482,14 +492,27 @@ class MatrixAggregation(BaseModel):
 
     @field_validator("aggregation", mode="before")
     def valid_aggregation_methods(cls, v):
-        try:
-            AggregationMethod(v)
-        except ValueError as err:
-            raise UserError(
-                f"Aggregations method must be one of {[m.value for m in AggregationMethod]}"
-            ) from err
+        values = v if isinstance(v, list) else [v]
 
-        return v
+        if len(values) == 0:
+            raise UserError("'aggregation' must name at least one method!")
+
+        for value in values:
+            try:
+                AggregationMethod(value)
+            except ValueError as err:
+                raise UserError(
+                    f"Aggregations method must be one of {[m.value for m in AggregationMethod]}"
+                ) from err
+
+        if not isinstance(v, list):
+            return v
+
+        # The response is one column per method, named for the method, so a
+        # repeated method would ask for a duplicate column -- which is not
+        # serializable. Asking for the same thing twice has one obvious answer,
+        # so collapse it rather than complain.
+        return list(dict.fromkeys(AggregationMethod(value) for value in values))
 
 
 class FeatureResponse(BaseModel):

--- a/breadbox/breadbox/service/dataset.py
+++ b/breadbox/breadbox/service/dataset.py
@@ -248,8 +248,35 @@ def _chunked_aggregate_matrix_df(
     df: pd.DataFrame, axis: int, agg_method, chunk_size_in_mb=10
 ):
     aggregated = []
-    chunk_size = chunk_size_in_mb * 1024 ** 2 // (df.shape[axis] * 8)
+    aggregated_axis_length = df.shape[axis]
     chunked_axis_length = df.shape[axis ^ 1]
+
+    # Chunking only exists to bound peak memory, so anything it cannot express
+    # falls back to aggregating in one go -- which pandas handles correctly in
+    # every one of these cases, and which costs nothing when there is no memory
+    # to save. Three ways to get here:
+    #
+    #   - An empty aggregated axis: the requested ids matched nothing in this
+    #     dataset. Divides by zero below. Routinely reachable, not exotic --
+    #     datasets are often sparse and a context is typically chosen before the
+    #     dataset it will be applied to, with nothing forcing the two to
+    #     intersect. The right answer is NaN per surviving label (and a count of
+    #     0), which .agg already returns, and which is consistent with how
+    #     non-strict requests already treat partially missing ids: warn and
+    #     carry on. Callers wanting this to be an error pass strict=True.
+    #   - An empty chunked axis. The loop wouldn't run at all and pd.concat
+    #     would then raise on an empty list.
+    #   - A single row/column larger than the chunk budget, which floors
+    #     chunk_size to 0 and makes range() raise. Chunking cannot help here:
+    #     one slice is already over budget.
+    if aggregated_axis_length == 0 or chunked_axis_length == 0:
+        return df.replace({pd.NA: np.nan}).agg(agg_method, axis=axis)
+
+    chunk_size = chunk_size_in_mb * 1024 ** 2 // (aggregated_axis_length * 8)
+
+    if chunk_size == 0:
+        return df.replace({pd.NA: np.nan}).agg(agg_method, axis=axis)
+
     for chunk_start in range(0, chunked_axis_length, chunk_size):
         chunk_end = min(chunk_start + chunk_size, chunked_axis_length)
         if axis == 0:
@@ -267,6 +294,30 @@ def _chunked_aggregate_matrix_df(
 def _aggregate_matrix_df(
     df_: pd.DataFrame,
     aggregate_by: Literal["features", "samples"],
+    aggregation: Union[AggregationMethod, List[AggregationMethod]],
+    use_chunking=True,
+):
+    # Each method is computed independently and the one-column results are
+    # stitched together, rather than handing pandas a list of methods. `.agg`
+    # with a list names its output columns after the callables it was given
+    # (so every lambda here would come back as "<lambda>"), and it transposes
+    # its result for axis=0 but not axis=1. Doing them one at a time keeps the
+    # column names authoritative and means a single method produces exactly the
+    # frame it always did.
+    aggregations = aggregation if isinstance(aggregation, list) else [aggregation]
+
+    return pd.concat(
+        [
+            _aggregate_matrix_df_once(df_, aggregate_by, method, use_chunking)
+            for method in aggregations
+        ],
+        axis=1,
+    )
+
+
+def _aggregate_matrix_df_once(
+    df_: pd.DataFrame,
+    aggregate_by: Literal["features", "samples"],
     aggregation: AggregationMethod,
     use_chunking=True,
 ):
@@ -278,6 +329,11 @@ def _aggregate_matrix_df(
         AggregationMethod.per25: lambda x: np.nanpercentile(x, q=25),
         AggregationMethod.per75: lambda x: np.nanpercentile(x, q=75),
         AggregationMethod.stddev: lambda x: np.nanstd(x, ddof=1),
+        AggregationMethod.variance: lambda x: np.nanvar(x, ddof=1),
+        # Non-null count. Unlike the others this is a property of coverage
+        # rather than of the values, so it is the one aggregation that stays
+        # meaningful when everything else comes back NaN.
+        AggregationMethod.count: "count",
         AggregationMethod.sum: "sum",
     }
 

--- a/breadbox/tests/api/test_dataset_queries.py
+++ b/breadbox/tests/api/test_dataset_queries.py
@@ -464,6 +464,42 @@ def test_get_aggregated_matrix_dataset_data(
     """
     assert response.json() == {"mean": {"Id1": 2, "Id3": 3}}
 
+    # Several methods in one request. The response keys off the method name
+    # exactly as it does for one, so asking for two costs a caller nothing
+    # beyond a second key -- notably it reads the block out of HDF5 once.
+    response = client.post(
+        f"/datasets/matrix/{matrix_dataset.json()['result']['datasetId']}",
+        json={
+            "aggregate": {
+                "aggregate_by": "samples",
+                "aggregation": ["variance", "count"],
+            }
+        },
+    )
+    """
+    Expected:
+        variance  count
+    -------------------
+    A     1.0       3
+    B     0.5       2
+    C     1.0       3
+    """
+    assert response.json() == {
+        "variance": {"A": 1.0, "B": 0.5, "C": 1.0},
+        # B's NA does not count.
+        "count": {"A": 3, "B": 2, "C": 3},
+    }
+
+    # A repeated method collapses instead of asking for a duplicate column,
+    # which would not be serializable.
+    response = client.post(
+        f"/datasets/matrix/{matrix_dataset.json()['result']['datasetId']}",
+        json={
+            "aggregate": {"aggregate_by": "samples", "aggregation": ["mean", "mean"]}
+        },
+    )
+    assert response.json() == {"mean": {"A": 2, "B": 3.5, "C": 3}}
+
 
 def test_bad_matrix_dataset_categorical_aggregation(
     client: TestClient,

--- a/breadbox/tests/service/test_dataset.py
+++ b/breadbox/tests/service/test_dataset.py
@@ -1,5 +1,8 @@
 from breadbox.schemas.dataset import AggregationMethod
-from breadbox.service.dataset import _aggregate_matrix_df
+from breadbox.service.dataset import (
+    _aggregate_matrix_df,
+    _chunked_aggregate_matrix_df,
+)
 import pandas as pd
 import numpy as np
 from pandas.testing import assert_frame_equal
@@ -50,6 +53,17 @@ def test_aggregate_stddev():
             AggregationMethod.sum,
             pd.DataFrame({"sum": [32.0, 39.0]}, index=["A", "B"]),  # pyright: ignore
         ),
+        (
+            AggregationMethod.variance,
+            pd.DataFrame(
+                {"variance": [70.3, 3.5]}, index=["A", "B"]  # pyright: ignore
+            ),
+        ),
+        (
+            AggregationMethod.count,
+            # A has a NaN, so it counts one fewer than B.
+            pd.DataFrame({"count": [5, 6]}, index=["A", "B"]),  # pyright: ignore
+        ),
     ],
 )
 def test_aggregate_matrix_methods(method, expected_df):
@@ -61,6 +75,107 @@ def test_aggregate_matrix_methods(method, expected_df):
     agg_df = _aggregate_matrix_df(df, "samples", method)
 
     assert_frame_equal(agg_df, expected_df)
+
+
+def test_aggregate_matrix_several_methods():
+    df = pd.DataFrame(
+        {"A": [1, 2, 0, np.nan, 9, 20], "B": [4, 5, 6, 7, 9, 8]},
+        index=["a", "b", "c", "d", "e", "f"],  # pyright: ignore
+    )
+
+    for use_chunking in [True, False]:
+        agg_df = _aggregate_matrix_df(
+            df,
+            "samples",
+            [AggregationMethod.variance, AggregationMethod.count],
+            use_chunking=use_chunking,
+        )
+
+        # One column per method, named for its wire value and in the order
+        # asked for. Each column is identical to what the method produces on
+        # its own.
+        expected_df = pd.DataFrame(
+            {"variance": [70.3, 3.5], "count": [5, 6]},
+            index=["A", "B"],  # pyright: ignore
+        )
+        assert_frame_equal(agg_df, expected_df)
+
+
+def test_aggregate_matrix_count_survives_an_empty_column():
+    # The case the count exists for: a member with too few observations to say
+    # anything about. Its spread is undefined, but its count still reads 0/1 --
+    # which is how a caller tells "no signal" from "not measured".
+    df = pd.DataFrame(
+        {"empty": [np.nan, np.nan, np.nan], "single": [np.nan, 5.0, np.nan]},
+        index=["a", "b", "c"],  # pyright: ignore
+    )
+
+    agg_df = _aggregate_matrix_df(
+        df, "samples", [AggregationMethod.variance, AggregationMethod.count]
+    )
+
+    expected_df = pd.DataFrame(
+        {"variance": [np.nan, np.nan], "count": [0, 1]},
+        index=["empty", "single"],  # pyright: ignore
+    )
+    assert_frame_equal(agg_df, expected_df)
+
+
+def test_aggregate_matrix_empty_aggregated_axis():
+    # A subset that matched nothing on the axis being collapsed -- which is what
+    # a caller gets by asking for ids that aren't in this dataset. The chunking
+    # arithmetic used to size a chunk by dividing by that axis's length, so this
+    # raised ZeroDivisionError and surfaced as a 500 rather than as "nothing was
+    # measured".
+    no_samples = pd.DataFrame(
+        {"A": pd.Series(dtype=float), "B": pd.Series(dtype=float)}
+    )
+
+    for use_chunking in [True, False]:
+        agg_df = _aggregate_matrix_df(
+            no_samples,
+            "samples",
+            [AggregationMethod.mean, AggregationMethod.count],
+            use_chunking=use_chunking,
+        )
+
+        # Every feature survives, with no observations behind it. `count` of 0
+        # is the honest answer and is exactly how a caller distinguishes this
+        # from a feature that was measured and happened to be flat.
+        expected_df = pd.DataFrame(
+            {"mean": [np.nan, np.nan], "count": [0, 0]},
+            index=["A", "B"],  # pyright: ignore
+        )
+        assert_frame_equal(agg_df, expected_df)
+
+
+def test_aggregate_matrix_empty_chunked_axis():
+    # The mirror image: nothing left on the axis being iterated over. The loop
+    # never ran, so pd.concat got an empty list and raised "No objects to
+    # concatenate".
+    no_samples = pd.DataFrame(
+        {"A": pd.Series(dtype=float), "B": pd.Series(dtype=float)}
+    )
+
+    for use_chunking in [True, False]:
+        agg_df = _aggregate_matrix_df(
+            no_samples, "features", AggregationMethod.mean, use_chunking=use_chunking
+        )
+
+        assert len(agg_df) == 0
+
+
+def test_aggregate_matrix_slice_larger_than_chunk_budget():
+    # Chunking cannot help when a single slice already exceeds the budget: the
+    # floor division yields 0 and range() rejects a zero step. Aggregating in
+    # one go is the only option left, and it must still be correct.
+    df = pd.DataFrame(
+        {"A": [1.0, 2.0], "B": [3.0, 4.0]}, index=["a", "b"]  # pyright: ignore
+    )
+
+    aggregated = _chunked_aggregate_matrix_df(df, 0, "mean", chunk_size_in_mb=0)
+
+    assert aggregated.to_dict() == {"A": 1.5, "B": 3.5}
 
 
 def test_aggregate_matrix_chunking_df():


### PR DESCRIPTION
- `AggregationMethod` gains `variance` and `count`. `count` is the number of non-null values behind the other aggregations — it's what lets a caller tell a spread computed over three observations from one computed over three hundred.

- `aggregate.aggregation` now accepts a list as well as a single method. The response is keyed by method name either way, so **existing single-method callers are unaffected**. Asking for several together matters because the expensive part is reading the block out of HDF5, not the arithmetic: the stats table wants variance, stddev, mean and count over the same collapse, and now pays for one read instead of four.

- A repeated method (`["mean", "mean"]`) collapses to one rather than asking for a duplicate column, which isn't serializable.

Each method is computed separately and the one-column results concatenated, rather than handing pandas a list of them. `.agg` with a list names its output columns after the callables it was given (so every lambda here comes back as `<lambda>`) and transposes its result for `axis=0` but not `axis=1`. One at a time keeps the column names authoritative and means a single method produces exactly the frame it always did.

`_chunked_aggregate_matrix_df` sized a chunk by dividing by the length of the axis it was collapsing, so a request whose ids matched nothing in the dataset raised `ZeroDivisionError` and surfaced as a 500. Two siblings in the same three lines: an empty *chunked* axis left `pd.concat` with an empty list, and a single row or column larger than the chunk budget floored the step to 0, which `range()` rejects.

All three now aggregate in one go. Chunking exists only to bound peak memory and there is none to save in any of these cases; pandas handles them correctly, returning NaN per surviving label with a count of 0 — consistent with how non-strict requests already treat partially missing ids.

This predates the work above and is reachable from ordinary aggregation: datasets are sparse, and a context is typically chosen before the dataset it gets applied to, with nothing forcing the two to intersect.

- `tests/service/test_dataset.py` — variance and count as methods; several methods matching what each produces alone; count surviving an all-null column; the three chunking edge cases.
- `tests/api/test_dataset_queries.py` — a multi-method request end to end, and the duplicate-method collapse.