### PR TITLE
feat(breadbox): report how much of a context each dataset covers

### DIFF
--- a/breadbox/breadbox/api/temp/context.py
+++ b/breadbox/breadbox/api/temp/context.py
@@ -7,8 +7,10 @@ from breadbox.api.dependencies import get_db_with_user
 from breadbox.config import Settings, get_settings
 from breadbox.schemas.custom_http_exception import UserError
 from breadbox.db.session import SessionWithUser
+from breadbox.crud import dataset as dataset_crud
 from breadbox.schemas.context import (
     Context,
+    ContextDatasetCoverageResponse,
     ContextMatchResponse,
 )
 from breadbox.service import slice as slice_service
@@ -18,6 +20,36 @@ from breadbox.depmap_compute_embed.context import ContextEvaluator
 from .router import router
 
 log = getLogger(__name__)
+
+
+def _evaluate(db: SessionWithUser, settings: Settings, context: Context):
+    """Resolve a context to its matching ids, with the loaders it needs.
+
+    Shared by the two endpoints below rather than duplicated: the loaders close
+    over the request's own db session and filestore, so they cannot be hoisted
+    to module scope, and having two copies invites them to drift.
+    """
+
+    def slice_loader(slice_query):
+        return slice_service.get_slice_data(
+            db, settings.filestore_location, slice_query
+        )
+
+    def label_loader(dimension_type):
+        return get_dimension_type_labels_by_id(db, dimension_type)
+
+    try:
+        evaluator = ContextEvaluator(context.dict(), slice_loader, label_loader)
+        return evaluator.evaluate()
+    except LookupError as e:
+        raise UserError(f"Encountered lookup error: {e}") from e
+    except (ValueError, TypeError) as e:
+        log.error(
+            "Context evaluation failed: %s\nContext: %s",
+            e,
+            context.model_dump_json(indent=2),
+        )
+        raise UserError(f"Context evaluation error: {e}") from e
 
 
 @router.post(
@@ -38,28 +70,45 @@ def evaluate_context(
     Also get the total number of "candidate" records (all records with labels belonging to the dimension type).
     Requests must be in the version 2 context format.
     """
-
-    def slice_loader(slice_query):
-        return slice_service.get_slice_data(
-            db, settings.filestore_location, slice_query
-        )
-
-    def label_loader(dimension_type):
-        return get_dimension_type_labels_by_id(db, dimension_type)
-
-    try:
-        evaluator = ContextEvaluator(context.dict(), slice_loader, label_loader)
-        result = evaluator.evaluate()
-    except LookupError as e:
-        raise UserError(f"Encountered lookup error: {e}") from e
-    except (ValueError, TypeError) as e:
-        log.error(
-            "Context evaluation failed: %s\nContext: %s",
-            e,
-            context.model_dump_json(indent=2),
-        )
-        raise UserError(f"Context evaluation error: {e}") from e
+    result = _evaluate(db, settings, context)
 
     return ContextMatchResponse(
         ids=result.ids, labels=result.labels, num_candidates=result.num_candidates,
     )
+
+
+@router.post(
+    "/context/dataset-coverage",
+    operation_id="get_context_dataset_coverage",
+    response_model=ContextDatasetCoverageResponse,
+    response_model_exclude_none=False,
+)
+def get_context_dataset_coverage(
+    db: Annotated[SessionWithUser, Depends(get_db_with_user)],
+    settings: Annotated[Settings, Depends(get_settings)],
+    context: Annotated[
+        Context, Body(description="A Data Explorer 2 context expression")
+    ],
+):
+    """
+    How many of a context's entities each visible dataset actually contains.
+
+    Exists so a caller choosing a dataset on the user's behalf can prefer one
+    that has the data. `GET /datasets/?feature_id=` answers this for a single
+    entity; a context routinely names thousands, and asking per entity is a
+    round trip each.
+
+    The context is evaluated here rather than by the caller because the ids are
+    only needed to be counted: returning them so they can be sent straight back
+    means a large payload in both directions, and a `WHERE ... IN` built from
+    whatever the client chose to send.
+
+    Datasets with no matching entity are omitted rather than reported as zero.
+    """
+    result = _evaluate(db, settings, context)
+
+    counts = dataset_crud.count_dataset_coverage(
+        db, db.user, context.dimension_type, result.ids
+    )
+
+    return ContextDatasetCoverageResponse(counts=counts, total=len(result.ids))

--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -170,6 +170,88 @@ def get_datasets(
     return datasets
 
 
+# SQLite caps how many bound parameters one statement may carry, and a context
+# routinely resolves to more ids than that -- every gene, every model. Chunked
+# well under the limit rather than at it, since the query carries a few
+# parameters of its own.
+_ID_CHUNK_SIZE = 900
+
+
+def count_dataset_coverage(
+    db: SessionWithUser, user: str, dimension_type_name: str, given_ids: List[str],
+) -> Dict[str, int]:
+    """How many of `given_ids` each visible matrix dataset actually contains.
+
+    Answers "which of these datasets has the data?" for a set of entities, which
+    is what picking a dataset on the user's behalf requires. Asking per id
+    instead -- the only thing get_datasets can do -- is one round trip per
+    entity, and a context can name thousands.
+
+    Datasets with no matching id are absent from the result rather than present
+    with a zero. Callers who need the zeroes have the dataset list already, and
+    the omission keeps the response proportional to what matched.
+    """
+    assert (
+        db.user == user
+    ), f"User parameter '{user}' must match the user set on the database session '{db.user}'"
+
+    dimension_type = (
+        db.query(DimensionType).filter_by(name=dimension_type_name).one_or_none()
+    )
+
+    if dimension_type is None:
+        raise ResourceNotFoundError(f"Unknown dimension type: '{dimension_type_name}'")
+
+    # Scoped to what this user may see, by asking the access-controlled query
+    # rather than counting over the dimension tables directly. Counting first
+    # and filtering afterwards would report the existence of private datasets
+    # to someone who cannot see them, which is precisely what the group checks
+    # in get_datasets exist to prevent.
+    axis_kwarg = (
+        {"feature_type": dimension_type_name}
+        if dimension_type.axis == "feature"
+        else {"sample_type": dimension_type_name}
+    )
+    visible_dataset_ids = {
+        dataset.id
+        for dataset in get_datasets(db, user, **axis_kwarg)  # pyright: ignore
+        if isinstance(dataset, MatrixDataset)
+    }
+
+    if not visible_dataset_ids or not given_ids:
+        return {}
+
+    dimension_model = (
+        DatasetFeature if dimension_type.axis == "feature" else DatasetSample
+    )
+
+    counts: Dict[str, int] = defaultdict(int)
+
+    for start in range(0, len(given_ids), _ID_CHUNK_SIZE):
+        chunk = given_ids[start : start + _ID_CHUNK_SIZE]
+
+        # `with_entities` rather than passing both columns to `query`:
+        # SessionWithUser.query takes a single entity, because it wraps every
+        # query with the caller's readable-group execution options. Narrowing
+        # afterwards keeps that wrapper rather than going around it.
+        rows = (
+            db.query(dimension_model)
+            .with_entities(
+                dimension_model.dataset_id,
+                func.count(distinct(dimension_model.given_id)),
+            )
+            .filter(dimension_model.given_id.in_(chunk))
+            .filter(dimension_model.dataset_id.in_(visible_dataset_ids))
+            .group_by(dimension_model.dataset_id)
+            .all()
+        )
+
+        for dataset_id, count in rows:
+            counts[dataset_id] += count
+
+    return dict(counts)
+
+
 def get_dataset(
     db: SessionWithUser, user: str, dataset_id: Union[str, UUID]
 ) -> Optional[Dataset]:
@@ -178,9 +260,11 @@ def get_dataset(
         db.user == user
     ), f"User parameter '{user}' must match the user set on the database session '{db.user}'"
 
-    dataset: Optional[Dataset] = db.query(Dataset).filter(
-        or_(Dataset.id == str(dataset_id), Dataset.given_id == str(dataset_id))
-    ).one_or_none()
+    dataset: Optional[Dataset] = (
+        db.query(Dataset)
+        .filter(or_(Dataset.id == str(dataset_id), Dataset.given_id == str(dataset_id)))
+        .one_or_none()
+    )
 
     if dataset is None:
         return None
@@ -550,10 +634,10 @@ def get_current_datetime():
 
 def find_expired_datasets(db: SessionWithUser, max_age: timedelta) -> List[Dataset]:
     """
-    Finds transient datasets which can be deleted (because they've "expired") 
-    Two ways a transient dataset can be expired: 
+    Finds transient datasets which can be deleted (because they've "expired")
+    Two ways a transient dataset can be expired:
     1. the `expiry` field can be explictly set, and that time is in the past
-    2. the upload_date is before now - `max_age`. 
+    2. the upload_date is before now - `max_age`.
     """
 
     now = get_current_datetime()

--- a/breadbox/breadbox/schemas/context.py
+++ b/breadbox/breadbox/schemas/context.py
@@ -3,6 +3,16 @@ from typing import Annotated, Any, Optional, Union
 from breadbox.schemas.dataset import SliceQueryIdentifierType
 
 
+class ContextDatasetCoverageResponse(BaseModel):
+    # Per-dataset count of how many of the context's entities that dataset
+    # contains, keyed by dataset id. Datasets matching nothing are absent
+    # rather than present with a zero.
+    counts: dict[str, int]
+    # How many entities the context resolved to, so a count reads as a share
+    # without the caller evaluating the context a second time to find out.
+    total: int
+
+
 class ContextMatchResponse(BaseModel):
     ids: list[str]
     labels: list[str]

--- a/breadbox/tests/api/test_temp.py
+++ b/breadbox/tests/api/test_temp.py
@@ -168,6 +168,220 @@ class TestPost:
         assert response_content["labels"] == ["featureLabel2"]
         assert response_content["num_candidates"] == 3
 
+    def test_context_dataset_coverage(
+        self, client: TestClient, minimal_db: SessionWithUser, public_group, settings,
+    ):
+        """
+        The endpoint that lets a caller pick a dataset that actually has the
+        data, rather than the highest-priority one that may have none of it.
+        """
+        factories.add_dimension_type(
+            minimal_db,
+            settings,
+            user=settings.admin_users[0],
+            name="some_feature_type",
+            display_name="Feature With Metadata",
+            id_column="ID",
+            annotation_type_mapping={
+                "ID": AnnotationType.text,
+                "label": AnnotationType.text,
+            },
+            axis="feature",
+            metadata_df=pd.DataFrame(
+                {
+                    "ID": ["featureID1", "featureID2", "featureID3"],
+                    "label": ["featureLabel1", "featureLabel2", "featureLabel3"],
+                }
+            ),
+        )
+        factories.add_dimension_type(
+            minimal_db,
+            settings,
+            user=settings.admin_users[0],
+            name="some_sample_type",
+            display_name="Sample",
+            id_column="ID",
+            annotation_type_mapping={
+                "ID": AnnotationType.text,
+                "label": AnnotationType.text,
+            },
+            axis="sample",
+            metadata_df=pd.DataFrame(
+                {
+                    "ID": ["sampleID1", "sampleID2"],
+                    "label": ["sampleLabel1", "sampleLabel2"],
+                }
+            ),
+        )
+
+        # Covers two of the three features.
+        partial = factories.matrix_dataset(
+            minimal_db,
+            settings,
+            feature_type="some_feature_type",
+            sample_type="some_sample_type",
+            data_file=factories.matrix_csv_data_file_with_values(
+                feature_ids=["featureID1", "featureID2"],
+                sample_ids=["sampleID1", "sampleID2"],
+                values=np.array([[1, 2], [3, 4]]),
+            ),
+        )
+
+        # Covers all three.
+        complete = factories.matrix_dataset(
+            minimal_db,
+            settings,
+            feature_type="some_feature_type",
+            sample_type="some_sample_type",
+            data_file=factories.matrix_csv_data_file_with_values(
+                feature_ids=["featureID1", "featureID2", "featureID3"],
+                sample_ids=["sampleID1", "sampleID2"],
+                values=np.array([[1, 2, 3], [4, 5, 6]]),
+            ),
+        )
+
+        everything = {
+            "dimension_type": "some_feature_type",
+            "name": "all features",
+            "expr": True,
+        }
+
+        response = client.post(
+            "/temp/context/dataset-coverage",
+            json=everything,
+            headers={"X-Forwarded-User": "some-public-user"},
+        )
+
+        assert_status_ok(response)
+        content = response.json()
+
+        assert content["total"] == 3
+        assert content["counts"][complete.id] == 3
+        # The point of the endpoint: this one is a worse match, and says so
+        # rather than being indistinguishable from the other.
+        assert content["counts"][partial.id] == 2
+
+        # A context matching nothing any dataset carries. Datasets are omitted
+        # rather than reported as zero, so the caller sees an empty map.
+        response = client.post(
+            "/temp/context/dataset-coverage",
+            json={
+                "dimension_type": "some_feature_type",
+                "name": "nothing",
+                "expr": {"==": [{"var": "given_id"}, "featureID-does-not-exist"]},
+            },
+            headers={"X-Forwarded-User": "some-public-user"},
+        )
+
+        assert_status_ok(response)
+        assert response.json() == {"counts": {}, "total": 0}
+
+        # Counts the sample axis when the dimension type lives there, rather
+        # than always reaching for features.
+        response = client.post(
+            "/temp/context/dataset-coverage",
+            json={
+                "dimension_type": "some_sample_type",
+                "name": "all samples",
+                "expr": True,
+            },
+            headers={"X-Forwarded-User": "some-public-user"},
+        )
+
+        assert_status_ok(response)
+        content = response.json()
+        assert content["total"] == 2
+        assert content["counts"][complete.id] == 2
+
+    def test_context_dataset_coverage_respects_access(
+        self,
+        client: TestClient,
+        minimal_db: SessionWithUser,
+        public_group,
+        private_group,
+        settings,
+    ):
+        """
+        Counting has to go through the access-controlled dataset query. Counting
+        over the dimension tables directly would be simpler and would report the
+        contents of datasets the caller cannot see -- which is the one mistake
+        this endpoint must not make, since it reports per-dataset numbers.
+        """
+        factories.add_dimension_type(
+            minimal_db,
+            settings,
+            user=settings.admin_users[0],
+            name="some_feature_type",
+            display_name="Feature With Metadata",
+            id_column="ID",
+            annotation_type_mapping={
+                "ID": AnnotationType.text,
+                "label": AnnotationType.text,
+            },
+            axis="feature",
+            metadata_df=pd.DataFrame(
+                {
+                    "ID": ["featureID1", "featureID2"],
+                    "label": ["featureLabel1", "featureLabel2"],
+                }
+            ),
+        )
+        factories.add_dimension_type(
+            minimal_db,
+            settings,
+            user=settings.admin_users[0],
+            name="some_sample_type",
+            display_name="Sample",
+            id_column="ID",
+            annotation_type_mapping={
+                "ID": AnnotationType.text,
+                "label": AnnotationType.text,
+            },
+            axis="sample",
+            metadata_df=pd.DataFrame({"ID": ["sampleID1"], "label": ["sampleLabel1"]}),
+        )
+
+        data_file = factories.matrix_csv_data_file_with_values(
+            feature_ids=["featureID1", "featureID2"],
+            sample_ids=["sampleID1"],
+            values=np.array([[1, 2]]),
+        )
+
+        secret = factories.matrix_dataset(
+            minimal_db,
+            settings,
+            feature_type="some_feature_type",
+            sample_type="some_sample_type",
+            data_file=data_file,
+            group=private_group["id"],
+        )
+
+        request = {
+            "dimension_type": "some_feature_type",
+            "name": "all features",
+            "expr": True,
+        }
+
+        response = client.post(
+            "/temp/context/dataset-coverage",
+            json=request,
+            headers={"X-Forwarded-User": "nobody@some-other-place.com"},
+        )
+
+        assert_status_ok(response)
+        assert secret.id not in response.json()["counts"]
+
+        # Visible to someone in the group, so the absence above is about access
+        # rather than the dataset simply having no matching features.
+        response = client.post(
+            "/temp/context/dataset-coverage",
+            json=request,
+            headers={"X-Forwarded-User": "someone@private-group.com"},
+        )
+
+        assert_status_ok(response)
+        assert response.json()["counts"][secret.id] == 2
+
     def test_evaluate_context_errors(
         self, client: TestClient, minimal_db: SessionWithUser, public_group, settings,
     ):
@@ -256,7 +470,7 @@ def test_cas_operations(client: TestClient, settings):
 
     # make sure storing and getting results in same value
     value = "payload"
-    response = client.post("/temp/cas", json={"value": value,})
+    response = client.post("/temp/cas", json={"value": value,},)
     assert response.status_code == 200
     key = response.json()["key"]
 
@@ -266,7 +480,7 @@ def test_cas_operations(client: TestClient, settings):
 
     # make sure storing a different value results in a different key
     value2 = "different"
-    response = client.post("/temp/cas", json={"value": value2,})
+    response = client.post("/temp/cas", json={"value": value2,},)
     assert response.status_code == 200
     key2 = response.json()["key"]
 


### PR DESCRIPTION
Picking a dataset on a user's behalf needs to know which datasets actually have the data. `GET /datasets/?feature_id=` answers that for one entity; a context routinely names thousands, and asking per entity is a round trip each.

New `POST /temp/context/dataset-coverage` takes a context and returns a per-dataset count of how many of its entities that dataset contains, alongside the context's own total so a count reads as a share. Evaluated server-side rather than taking an id list.