### PR TITLE
Persist immutable API responses across page loads

### DIFF
--- a/frontend/packages/@depmap/api/index.ts
+++ b/frontend/packages/@depmap/api/index.ts
@@ -5,10 +5,25 @@ export type { BreadboxApiResponse } from "./src/breadboxAPI";
 export { cached } from "./src/apiCacheDecorator";
 
 export {
-  enablePersistentApiCache,
+  initDatasetRegistry,
   clearPersistentApiCache,
   isPersistentApiCacheEnabled,
+  getPersistentApiCacheInfo,
+  persistentCacheStats,
+  PUBLIC_GROUP_ID,
 } from "./src/persistentApiCache";
+
+export type {
+  PersistOption,
+  DatasetRegistryEntry,
+} from "./src/persistentApiCache";
+
+export type { CachedOptions } from "./src/apiCacheDecorator";
+
+export {
+  evaluateContextPersisted,
+  getDimensionTypeIdentifiersPersisted,
+} from "./src/persistedFetches";
 
 // ❌ Don't use! This is only defined to support Elara's TypesPage.tsx
 export { deprecatedBreadboxAPI } from "./src/deprecatedBreadboxAPI";

--- a/frontend/packages/@depmap/api/jest-setup.js
+++ b/frontend/packages/@depmap/api/jest-setup.js
@@ -1,0 +1,9 @@
+// fake-indexeddb requires structuredClone, which jest-environment-jsdom does
+// not provide. Node's v8 serializer implements the same structured clone
+// algorithm, so it's a faithful stand-in.
+/* eslint-disable @typescript-eslint/no-var-requires */
+const v8 = require("v8");
+
+if (typeof globalThis.structuredClone === "undefined") {
+  globalThis.structuredClone = (value) => v8.deserialize(v8.serialize(value));
+}

--- a/frontend/packages/@depmap/api/package.json
+++ b/frontend/packages/@depmap/api/package.json
@@ -4,7 +4,7 @@
   "main": "index.ts",
   "license": "MIT",
   "scripts": {
-    "test": "echo 'no tests to run'"
+    "test": "jest"
   },
   "dependencies": {
     "@depmap/data-slicer": "1.0.0",
@@ -16,9 +16,34 @@
     "spark-md5": "^3.0.2"
   },
   "devDependencies": {
-    "@types/papaparse": "^4.5.2"
+    "@types/papaparse": "^4.5.2",
+    "fake-indexeddb": "^6.0.0"
   },
   "peerDependencies": {
     "react": "^16.9.35"
+  },
+  "jest": {
+    "moduleFileExtensions": [
+      "js",
+      "ts",
+      "tsx"
+    ],
+    "transform": {
+      "^.+\\.tsx?$": [
+        "ts-jest",
+        {
+          "diagnostics": false
+        }
+      ]
+    },
+    "testRegex": ".*/__tests__/.*test.*\\.(ts|tsx|js)$",
+    "testEnvironment": "jsdom",
+    "setupFiles": [
+      "<rootDir>/jest-setup.js"
+    ],
+    "moduleNameMapper": {
+      "@depmap/(.*)/src/(.*)": "<rootDir>/../$1/src/$2",
+      "@depmap/(.*)": "<rootDir>/../$1"
+    }
   }
 }

--- a/frontend/packages/@depmap/api/src/__tests__/apiCacheDecorator.test.ts
+++ b/frontend/packages/@depmap/api/src/__tests__/apiCacheDecorator.test.ts
@@ -1,0 +1,46 @@
+import { breadboxAPI } from "../breadboxAPI";
+import { cached } from "../apiCacheDecorator";
+
+// Minimal stand-ins for the fetch machinery request() uses; jsdom provides
+// neither fetch nor Headers.
+class FakeHeaders {
+  private map = new Map<string, string>();
+
+  constructor(init?: Record<string, string>) {
+    Object.entries(init || {}).forEach(([k, v]) => this.set(k, v));
+  }
+
+  has(name: string) {
+    return this.map.has(name.toLowerCase());
+  }
+
+  set(name: string, value: string) {
+    this.map.set(name.toLowerCase(), value);
+  }
+
+  get(name: string) {
+    return this.map.get(name.toLowerCase()) ?? null;
+  }
+}
+
+beforeEach(() => {
+  (globalThis as { Headers: unknown }).Headers = FakeHeaders;
+
+  (globalThis as { fetch: unknown }).fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    headers: new FakeHeaders({ "content-type": "application/json" }),
+    json: async () => [],
+  });
+});
+
+it("plain cached() serves repeated identical GETs from memory", async () => {
+  // REGRESSION: the decorator once mapped plain cached(api) to a null ambient
+  // context, which createJsonClient reads as "not inside cached() at all" —
+  // silently disabling the in-memory cache for every non-persisted call and
+  // re-fetching getDatasets/getDimensionTypes on every use.
+  await cached(breadboxAPI).getDimensionTypes();
+  await cached(breadboxAPI).getDimensionTypes();
+  await cached(breadboxAPI).getDimensionTypes();
+
+  expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+});

--- a/frontend/packages/@depmap/api/src/__tests__/persistedFetches.test.ts
+++ b/frontend/packages/@depmap/api/src/__tests__/persistedFetches.test.ts
@@ -1,0 +1,169 @@
+jest.mock("../apiCacheDecorator", () => ({
+  cached: jest.fn((api: unknown) => api),
+}));
+
+import { cached } from "../apiCacheDecorator";
+import { breadboxAPI } from "../breadboxAPI";
+import {
+  evaluateContextPersisted,
+  getDimensionTypeIdentifiersPersisted,
+} from "../persistedFetches";
+
+const cachedMock = (cached as unknown) as jest.Mock;
+
+const GENE_METADATA_UUID = "aaaaaaaa-0000-0000-0000-000000000001";
+const MODEL_METADATA_UUID = "bbbbbbbb-0000-0000-0000-000000000002";
+
+const geneSlice = {
+  dataset_id: "some_dataset",
+  identifier: "some_column",
+  identifier_type: "column" as const,
+};
+
+beforeEach(() => {
+  cachedMock.mockClear();
+
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  (breadboxAPI as any).getDimensionTypes = jest.fn().mockResolvedValue([
+    { name: "gene", metadata_dataset_id: GENE_METADATA_UUID },
+    { name: "depmap_model", metadata_dataset_id: MODEL_METADATA_UUID },
+    { name: "no_metadata_type", metadata_dataset_id: null },
+  ]);
+
+  (breadboxAPI as any).getDimensionTypeIdentifiers = jest
+    .fn()
+    .mockResolvedValue([]);
+
+  (breadboxAPI as any).evaluateContext = jest
+    .fn()
+    .mockResolvedValue({ ids: [], labels: [], num_candidates: 0 });
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+});
+
+describe("getDimensionTypeIdentifiersPersisted", () => {
+  it("declares the dimension type's metadata dataset as a dep", async () => {
+    await getDimensionTypeIdentifiersPersisted("gene");
+
+    expect(cachedMock).toHaveBeenCalledWith(breadboxAPI, {
+      persist: { deps: [GENE_METADATA_UUID] },
+    });
+    expect(breadboxAPI.getDimensionTypeIdentifiers).toHaveBeenCalledWith(
+      "gene"
+    );
+  });
+
+  it("falls back to in-memory caching without a metadata dataset", async () => {
+    await getDimensionTypeIdentifiersPersisted("no_metadata_type");
+
+    expect(cachedMock).toHaveBeenLastCalledWith(breadboxAPI);
+  });
+
+  it("falls back for an unknown dimension type", async () => {
+    await getDimensionTypeIdentifiersPersisted("never_heard_of_it");
+
+    expect(cachedMock).toHaveBeenLastCalledWith(breadboxAPI);
+  });
+});
+
+describe("evaluateContextPersisted", () => {
+  it("declares the context's dimension type metadata dataset as a dep", async () => {
+    const context = {
+      dimension_type: "gene",
+      expr: { in: [{ var: "v" }, ["a", "b"]] },
+      vars: { v: geneSlice },
+    };
+
+    await evaluateContextPersisted(context);
+
+    expect(cachedMock).toHaveBeenCalledWith(breadboxAPI, {
+      persist: { deps: [GENE_METADATA_UUID] },
+    });
+    expect(breadboxAPI.evaluateContext).toHaveBeenCalledWith(context);
+  });
+
+  it("includes nested contexts' metadata datasets", async () => {
+    const context = {
+      dimension_type: "gene",
+      expr: true,
+      vars: {},
+      contexts: {
+        c1: {
+          name: "nested",
+          dimension_type: "depmap_model",
+          expr: true,
+          vars: {},
+        },
+      },
+    };
+
+    await evaluateContextPersisted(context);
+
+    expect(cachedMock).toHaveBeenCalledWith(breadboxAPI, {
+      persist: { deps: [GENE_METADATA_UUID, MODEL_METADATA_UUID] },
+    });
+  });
+
+  it("falls back when any var uses reindex_through", async () => {
+    const context = {
+      dimension_type: "gene",
+      expr: { in: [{ var: "v" }, ["a"]] },
+      vars: {
+        v: {
+          ...geneSlice,
+          reindex_through: geneSlice,
+        },
+      },
+    };
+
+    await evaluateContextPersisted(context);
+
+    expect(cachedMock).toHaveBeenLastCalledWith(breadboxAPI);
+  });
+
+  it("falls back without throwing on a partial tree with undefined nodes", async () => {
+    // REGRESSION: interactive editors (Context Builder) evaluate
+    // partially-built contexts. The dep walk crashed on an undefined nested
+    // entry instead of downgrading to plain in-memory caching.
+    const context = {
+      dimension_type: "gene",
+      expr: true,
+      vars: { v: undefined },
+      contexts: { c1: undefined },
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    await evaluateContextPersisted(context);
+
+    expect(cachedMock).toHaveBeenLastCalledWith(breadboxAPI);
+    expect(breadboxAPI.evaluateContext).toHaveBeenCalledWith(context);
+  });
+
+  it("falls back without throwing when the context itself is undefined", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await evaluateContextPersisted(undefined as any);
+
+    // Downgrades to the plain call, which behaves exactly as it did before
+    // persistence existed (including however it chooses to fail).
+    expect(cachedMock).toHaveBeenLastCalledWith(breadboxAPI);
+  });
+
+  it("falls back when a nested dimension type has no metadata dataset", async () => {
+    const context = {
+      dimension_type: "gene",
+      expr: true,
+      vars: {},
+      contexts: {
+        c1: {
+          name: "nested",
+          dimension_type: "no_metadata_type",
+          expr: true,
+          vars: {},
+        },
+      },
+    };
+
+    await evaluateContextPersisted(context);
+
+    expect(cachedMock).toHaveBeenLastCalledWith(breadboxAPI);
+  });
+});

--- a/frontend/packages/@depmap/api/src/__tests__/persistentApiCache.test.ts
+++ b/frontend/packages/@depmap/api/src/__tests__/persistentApiCache.test.ts
@@ -1,0 +1,306 @@
+import { IDBFactory } from "fake-indexeddb";
+import {
+  __resetForTests,
+  buildPersistentKey,
+  getPersistentApiCacheInfo,
+  initDatasetRegistry,
+  isPersistentApiCacheEnabled,
+  persistentCacheGet,
+  persistentCacheSet,
+  persistentCacheStats,
+  PUBLIC_GROUP_ID,
+} from "../persistentApiCache";
+
+const PRIVATE_GROUP_ID = "99999999-9999-9999-9999-999999999999";
+
+const PUBLIC_UUID = "aaaaaaaa-0000-0000-0000-000000000001";
+const PRIVATE_UUID = "bbbbbbbb-0000-0000-0000-000000000002";
+const PUBLIC_DEP_UUID_1 = "cccccccc-0000-0000-0000-000000000003";
+const PUBLIC_DEP_UUID_2 = "dddddddd-0000-0000-0000-000000000004";
+const RESOLVED_UUID_V1 = "eeeeeeee-0000-0000-0000-000000000005";
+const RESOLVED_UUID_V2 = "ffffffff-0000-0000-0000-000000000006";
+
+const defaultDatasets = [
+  { id: PUBLIC_UUID, given_id: null, group_id: PUBLIC_GROUP_ID },
+  { id: PRIVATE_UUID, given_id: null, group_id: PRIVATE_GROUP_ID },
+  { id: PUBLIC_DEP_UUID_1, given_id: null, group_id: PUBLIC_GROUP_ID },
+  { id: PUBLIC_DEP_UUID_2, given_id: null, group_id: PUBLIC_GROUP_ID },
+  {
+    id: RESOLVED_UUID_V1,
+    given_id: "some_given_id",
+    group_id: PUBLIC_GROUP_ID,
+  },
+];
+
+async function init(
+  options: {
+    datasets?: typeof defaultDatasets;
+    breadboxVersion?: string;
+    maxBytes?: number;
+    reuseIndexedDB?: boolean;
+  } = {}
+) {
+  if (!options.reuseIndexedDB) {
+    (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
+  }
+
+  await initDatasetRegistry({
+    datasets: options.datasets ?? defaultDatasets,
+    breadboxVersion: options.breadboxVersion ?? "0.0.0-test",
+    maxBytes: options.maxBytes,
+  });
+}
+
+afterEach(() => {
+  __resetForTests();
+  jest.restoreAllMocks();
+});
+
+describe("buildPersistentKey", () => {
+  it("refuses everything before initDatasetRegistry has run", async () => {
+    const key = await buildPersistentKey(`GET /data/${PUBLIC_UUID}`, true);
+
+    expect(key).toBeNull();
+    expect(persistentCacheStats.refusedNotReady).toBe(1);
+  });
+
+  it("waits for a pending datasets promise instead of refusing", async () => {
+    // REGRESSION: the entry points call initDatasetRegistry synchronously with
+    // the still-pending getDatasets() promise. Requests issued during that
+    // round trip must wait for the registry, not refuse — refusing silently
+    // costs every early cache hit on every page load.
+    (globalThis as { indexedDB: IDBFactory }).indexedDB = new IDBFactory();
+
+    let resolveDatasets!: (d: typeof defaultDatasets) => void;
+    const pending = new Promise<typeof defaultDatasets>((resolve) => {
+      resolveDatasets = resolve;
+    });
+
+    initDatasetRegistry({ datasets: pending, breadboxVersion: "0.0.0-test" });
+
+    const keyPromise = buildPersistentKey(`GET /data/${PUBLIC_UUID}-{}`, true);
+    resolveDatasets(defaultDatasets);
+
+    expect(await keyPromise).toContain(PUBLIC_UUID);
+    expect(persistentCacheStats.refusedNotReady).toBe(0);
+  });
+
+  it("refuses a request that names no dataset", async () => {
+    await init();
+    const key = await buildPersistentKey("GET /some/other/endpoint-{}", true);
+
+    expect(key).toBeNull();
+    expect(persistentCacheStats.refusedNoDatasetAddress).toBe(1);
+  });
+
+  it("refuses a request naming a non-public dataset", async () => {
+    await init();
+    const key = await buildPersistentKey(`GET /data/${PRIVATE_UUID}`, true);
+
+    expect(key).toBeNull();
+    expect(persistentCacheStats.refusedNotPublic).toBe(1);
+  });
+
+  it("refuses an unresolvable declared dep", async () => {
+    await init();
+    const key = await buildPersistentKey(`GET /data/${PUBLIC_UUID}`, {
+      deps: ["retired_given_id"],
+    });
+
+    expect(key).toBeNull();
+    expect(persistentCacheStats.refusedUnresolvable).toBe(1);
+  });
+
+  it("builds a key for a public UUID-addressed request", async () => {
+    await init();
+    const cacheKey = `GET /data/${PUBLIC_UUID}-{}`;
+    const key = await buildPersistentKey(cacheKey, true);
+
+    expect(key).toContain(cacheKey);
+  });
+
+  it("appends the resolved UUID for a given_id-addressed request", async () => {
+    await init();
+    const cacheKey = "GET /data/some_given_id-{}";
+    const key = await buildPersistentKey(cacheKey, true);
+
+    expect(key).toContain(cacheKey);
+    expect(key).toContain(`some_given_id=${RESOLVED_UUID_V1}`);
+  });
+
+  it("produces a different key when a given_id resolves differently", async () => {
+    const cacheKey = "GET /data/some_given_id-{}";
+
+    await init();
+    const keyV1 = await buildPersistentKey(cacheKey, true);
+
+    __resetForTests();
+    await init({
+      datasets: [
+        {
+          id: RESOLVED_UUID_V2,
+          given_id: "some_given_id",
+          group_id: PUBLIC_GROUP_ID,
+        },
+      ],
+    });
+    const keyV2 = await buildPersistentKey(cacheKey, true);
+
+    expect(keyV1).not.toBeNull();
+    expect(keyV2).not.toBeNull();
+    expect(keyV1).not.toEqual(keyV2);
+  });
+
+  it("warns about and never persists a UUID-shaped given_id", async () => {
+    const warn = jest.spyOn(window.console, "warn").mockImplementation();
+    const uuidShapedGivenId = "12345678-1234-1234-1234-123456789abc";
+
+    await init({
+      datasets: [
+        {
+          id: PUBLIC_UUID,
+          given_id: uuidShapedGivenId,
+          group_id: PUBLIC_GROUP_ID,
+        },
+      ],
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining(uuidShapedGivenId)
+    );
+
+    // Dropped from the version map, it classifies as an unlisted UUID, which
+    // fails the public check — a miss, never a wrong hit.
+    const key = await buildPersistentKey(
+      `GET /data/${uuidShapedGivenId}`,
+      true
+    );
+    expect(key).toBeNull();
+  });
+
+  it("folds declared UUID deps into the key", async () => {
+    await init();
+    const cacheKey = `GET /data/${PUBLIC_UUID}-{}`;
+
+    const key1 = await buildPersistentKey(cacheKey, {
+      deps: [PUBLIC_DEP_UUID_1],
+    });
+    const key2 = await buildPersistentKey(cacheKey, {
+      deps: [PUBLIC_DEP_UUID_2],
+    });
+
+    expect(key1).toContain(PUBLIC_DEP_UUID_1);
+    expect(key2).toContain(PUBLIC_DEP_UUID_2);
+    expect(key1).not.toEqual(key2);
+  });
+});
+
+describe("persistentCacheGet / persistentCacheSet", () => {
+  it("round-trips a value", async () => {
+    await init();
+    await persistentCacheSet("v2:some-key", { hello: "world" }, true);
+
+    const result = await persistentCacheGet("v2:some-key");
+
+    expect(result.hit).toBe(true);
+    expect(result.value).toEqual({ hello: "world" });
+    expect(persistentCacheStats.writes).toBe(1);
+    expect(persistentCacheStats.hits).toBe(1);
+  });
+
+  it("refuses a single item over the per-item budget", async () => {
+    await init({ maxBytes: 10_000 });
+    await persistentCacheSet("v2:huge", "x".repeat(5_000), true);
+
+    expect(persistentCacheStats.refusedTooLarge).toBe(1);
+    expect((await persistentCacheGet("v2:huge")).hit).toBe(false);
+  });
+
+  it("evicts coldest-first when over budget", async () => {
+    // Deterministic lastAccessed ordering.
+    let fakeNow = 1_000_000;
+    jest.spyOn(Date, "now").mockImplementation(() => {
+      fakeNow += 1_000;
+      return fakeNow;
+    });
+
+    await init({ maxBytes: 10_000 });
+
+    // ~502 bytes each; 30 writes is ~15KB against a 10KB budget.
+    for (let i = 0; i < 30; i++) {
+      // eslint-disable-next-line no-await-in-loop
+      await persistentCacheSet(`v2:key-${i}`, "x".repeat(500), true);
+    }
+
+    expect(persistentCacheStats.evictions).toBeGreaterThan(0);
+
+    const info = await getPersistentApiCacheInfo();
+    expect(info.totalBytes).toBeLessThanOrEqual(10_000);
+
+    expect((await persistentCacheGet("v2:key-0")).hit).toBe(false);
+    expect((await persistentCacheGet("v2:key-29")).hit).toBe(true);
+  });
+
+  it("retries once after QuotaExceededError by making room", async () => {
+    await init({ maxBytes: 10_000 });
+
+    // Grab the object store prototype off a second connection to the same
+    // fake database so the engine's own `put` can be made to fail.
+    const proto = await getResponsesStorePrototype();
+    jest.spyOn(proto, "put").mockImplementationOnce(() => {
+      throw new DOMException("quota", "QuotaExceededError");
+    });
+
+    await persistentCacheSet("v2:quota-key", { ok: true }, true);
+
+    expect(persistentCacheStats.quotaErrors).toBe(1);
+    expect((await persistentCacheGet("v2:quota-key")).hit).toBe(true);
+    expect(isPersistentApiCacheEnabled()).toBe(true);
+  });
+
+  it("survives re-init under the same epoch, wipes when the Breadbox version changes", async () => {
+    await init({ breadboxVersion: "4.19.0" });
+    await persistentCacheSet("v2:epoch-key", { kept: true }, true);
+
+    // Same CACHE_VERSION + same Breadbox version: entries survive a "reload".
+    __resetForTests();
+    await init({ breadboxVersion: "4.19.0", reuseIndexedDB: true });
+    expect((await persistentCacheGet("v2:epoch-key")).hit).toBe(true);
+    expect(persistentCacheStats.epochWipes).toBe(0);
+
+    // A Breadbox release changes the epoch: the whole store is wiped.
+    __resetForTests();
+    await init({ breadboxVersion: "4.20.0", reuseIndexedDB: true });
+    expect((await persistentCacheGet("v2:epoch-key")).hit).toBe(false);
+    expect(persistentCacheStats.epochWipes).toBe(1);
+  });
+
+  it("disables itself when the quota retry also fails", async () => {
+    await init({ maxBytes: 10_000 });
+
+    const proto = await getResponsesStorePrototype();
+    jest.spyOn(proto, "put").mockImplementation(() => {
+      throw new DOMException("quota", "QuotaExceededError");
+    });
+
+    await persistentCacheSet("v2:doomed-key", { ok: true }, true);
+
+    expect(isPersistentApiCacheEnabled()).toBe(false);
+  });
+});
+
+async function getResponsesStorePrototype() {
+  const request = indexedDB.open("depmap-api-cache", 2);
+
+  const db = await new Promise<IDBDatabase>((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+
+  const tx = db.transaction("responses", "readonly");
+  const proto = Object.getPrototypeOf(tx.objectStore("responses"));
+  tx.abort();
+  db.close();
+
+  return proto;
+}

--- a/frontend/packages/@depmap/api/src/apiCacheDecorator.ts
+++ b/frontend/packages/@depmap/api/src/apiCacheDecorator.ts
@@ -1,19 +1,53 @@
 import { breadboxAPI } from "./breadboxAPI";
 import { legacyPortalAPI } from "./legacyPortalAPI";
 import { cacheOn, cacheOff } from "./createJsonClient";
+import type { PersistOption, RequestCacheContext } from "./persistentApiCache";
 
 type AnyApi = typeof breadboxAPI | typeof legacyPortalAPI;
 
-const wrapApiMethodsWithCache = <T extends AnyApi>(api: T): T => {
+export interface CachedOptions {
+  /**
+   * Opt this call into the cross-reload IndexedDB store.
+   *
+   * `true` asserts the response is immutable at its own address. Breadbox never
+   * mutates dataset data in place — a new version is a new row with a new UUID —
+   * so a response addressed by dataset is valid forever. The engine verifies the
+   * assertion by requiring a dataset address in the cache key; a call that turns
+   * out not to have one silently stays in memory.
+   *
+   * `{ deps: [...] }` is for responses that are immutable only given some other
+   * dataset. The deps are folded into the cache key, so when a dep changes the
+   * key changes and the old entry is orphaned rather than wrongly served.
+   */
+  persist?: PersistOption;
+}
+
+const wrapApiMethodsWithCache = <T extends AnyApi>(
+  api: T,
+  options: CachedOptions
+): T => {
   const wrapped: Partial<T> = {};
 
-  (Object.keys(api) as Array<keyof T>).forEach((name) => {
-    const originalFn = api[name];
+  // Always a real object, never null: in createJsonClient, a null ambient
+  // context means "not inside cached() at all" and disables the in-memory
+  // cache. Plain cached(api) must map to { persist: undefined } — in-memory
+  // caching on, persistence off.
+  const context: RequestCacheContext = { persist: options.persist };
 
-    if (typeof originalFn === "function") {
+  (Object.keys(api) as Array<keyof T>).forEach((name) => {
+    if (typeof api[name] === "function") {
       wrapped[name] = ((...args: unknown[]) => {
-        cacheOn();
-        const result = originalFn(...args);
+        // Resolve the target at CALL time, not wrap time. Wrappers are memoized
+        // for the life of the module, so capturing the function here would
+        // freeze it against whatever was installed when the wrapper was first
+        // created. Tests mock by reassigning methods on the module-level API
+        // object (see how-to-mock-api-functions.test.tsx), and jest is not
+        // configured with `resetModules`, so a mock installed after the first
+        // cached() call would otherwise be silently ignored.
+        const fn = (api[name] as unknown) as (...a: unknown[]) => unknown;
+
+        cacheOn(context);
+        const result = fn(...args);
         cacheOff();
 
         return result;
@@ -24,33 +58,59 @@ const wrapApiMethodsWithCache = <T extends AnyApi>(api: T): T => {
   return wrapped as T;
 };
 
-const wrappedAPIs = new Map<AnyApi, AnyApi>();
+// Keyed by API object, then by a canonical serialization of the options. See
+// the comment in `cached` for why the inner key is a string and not the object.
+const wrappedAPIs = new Map<AnyApi, Map<string, AnyApi>>();
 
 // Use this to cache responses from the API. Example:
 // `const datasets = await breadboxAPI.getDatasets();`
 // becomes
 // `const datasets = await cached(breadboxAPI).getDatasets();`
-export const cached = <T extends AnyApi>(api: T): T => {
+//
+// Pass `{ persist: true }` to additionally store the response in IndexedDB so
+// it survives a page reload:
+// `cached(breadboxAPI, { persist: true }).getMatrixDatasetData(id, args)`
+export const cached = <T extends AnyApi>(
+  api: T,
+  options?: CachedOptions
+): T => {
   // Edge case: if someone calls cached(cached(api)) don't wrap it again.
-  for (const [unwrapped, wrapped] of wrappedAPIs.entries()) {
-    if (api === wrapped) {
-      const name =
-        unwrapped === legacyPortalAPI ? "legacyPortalAPI" : "breadboxAPI";
+  for (const [unwrapped, byOptions] of wrappedAPIs.entries()) {
+    for (const wrapped of byOptions.values()) {
+      if (api === wrapped) {
+        const name =
+          unwrapped === legacyPortalAPI ? "legacyPortalAPI" : "breadboxAPI";
 
-      window.console.warn(
-        `cached() called on an already-cached version of ${name}!`
-      );
+        window.console.warn(
+          `cached() called on an already-cached version of ${name}!`
+        );
 
-      return api;
+        return api;
+      }
     }
   }
 
   // We store the wrapped objects in a Map so we don't create new wrappers each
   // time `cached` is called. That way you can use a method as a prop without
   // needing to wrap it with `useCallback`.
+  //
+  // The inner key is a *canonical string*, not the options object, which is what
+  // preserves that guarantee now that options exist: an inline literal written
+  // fresh on every render (`cached(api, { persist: true })`) serializes to the
+  // same string and so resolves to the same wrapper. Keying on object identity
+  // would hand back a new wrapper every render and break every dependency array
+  // downstream.
+  const optionsKey = JSON.stringify(options ?? {});
+
   if (!wrappedAPIs.has(api)) {
-    wrappedAPIs.set(api, wrapApiMethodsWithCache(api));
+    wrappedAPIs.set(api, new Map());
   }
 
-  return wrappedAPIs.get(api) as T;
+  const byOptions = wrappedAPIs.get(api) as Map<string, AnyApi>;
+
+  if (!byOptions.has(optionsKey)) {
+    byOptions.set(optionsKey, wrapApiMethodsWithCache(api, options ?? {}));
+  }
+
+  return byOptions.get(optionsKey) as T;
 };

--- a/frontend/packages/@depmap/api/src/breadboxAPI/index.ts
+++ b/frontend/packages/@depmap/api/src/breadboxAPI/index.ts
@@ -4,6 +4,7 @@ import * as dataset_v2 from "./resources/dataset_v2";
 import * as datasets from "./resources/datasets";
 import * as downloads from "./resources/downloads";
 import * as groups from "./resources/groups";
+import * as health_check from "./resources/health_check";
 import * as metadata from "./resources/metadata";
 import * as task from "./resources/task";
 import * as temp from "./resources/temp";
@@ -18,6 +19,7 @@ export const breadboxAPI = {
   ...datasets,
   ...downloads,
   ...groups,
+  ...health_check,
   ...metadata,
   ...task,
   ...temp,

--- a/frontend/packages/@depmap/api/src/breadboxAPI/resources/health_check.ts
+++ b/frontend/packages/@depmap/api/src/breadboxAPI/resources/health_check.ts
@@ -1,0 +1,18 @@
+import { getJson } from "../client";
+
+// The app version (from Breadbox's pyproject.toml, auto-bumped by commitizen
+// on every feat/fix(breadbox) commit). The entry points fold this into the
+// persistent cache's epoch, so a Breadbox deploy wipes cached responses
+// produced by the old server code. Never cache this method — it is the
+// epoch's input.
+export async function getBreadboxVersion() {
+  const response = await getJson<{ message: string; version?: string }>(
+    "/health_check/basic"
+  );
+
+  if (!response.version) {
+    throw new Error("Breadbox did not report a version");
+  }
+
+  return response.version;
+}

--- a/frontend/packages/@depmap/api/src/createJsonClient.ts
+++ b/frontend/packages/@depmap/api/src/createJsonClient.ts
@@ -1,20 +1,35 @@
 import qs from "qs";
 import { ErrorDetail, ErrorTypeError } from "@depmap/types";
 import {
-  isPersistentApiCacheEnabled,
   persistentCacheGet,
   persistentCacheSet,
+  buildPersistentKey,
 } from "./persistentApiCache";
+import type { RequestCacheContext } from "./persistentApiCache";
 
 const cache: Record<string, Promise<unknown> | null> = {};
-let useCache = false;
 
-export const cacheOn = () => {
-  useCache = true;
+// Ambient request context, set by the `cached(...)` decorator immediately before
+// it invokes an API method and cleared immediately after. `null` means "not
+// inside cached(...)"; a non-null value means the in-memory cache is on, and its
+// `persist` field says whether the response may also go to IndexedDB.
+//
+// This is dynamic scoping, and it only works because every layer between
+// cacheOn() and the getJson/postJson call below is synchronous up to the point
+// the request is issued. The API methods are `async`, but an async function body
+// runs synchronously until its first `await`, and none of them awaits anything
+// before delegating here. Read `cacheContext` into a local at the top of each
+// maker function; do not read it after an await.
+let cacheContext: RequestCacheContext = null;
+
+export const cacheOn = (
+  context: RequestCacheContext = { persist: undefined }
+) => {
+  cacheContext = context;
 };
 
 export const cacheOff = () => {
-  useCache = false;
+  cacheContext = null;
 };
 
 interface BreadboxCustomException {
@@ -102,26 +117,40 @@ async function request<T>(url: string, options: RequestInit): Promise<T> {
   return json as T;
 }
 
-// Reached only when `useCache` is on — i.e. inside a `cached(...)` call. If
-// persistent caching has been enabled, this layers a cross-reload IndexedDB
-// store underneath the in-memory promise cache: check the store first, and on
-// a miss run the request and write the result back. Otherwise it's a
-// passthrough and `cached(...)` behaves exactly as before (in-memory only).
+// Reached only from inside a `cached(...)` call. When that call opted into
+// persistence, this layers a cross-reload IndexedDB store underneath the
+// in-memory promise cache: check the store first, and on a miss run the request
+// and write the result back. Otherwise it's a passthrough and `cached(...)`
+// behaves exactly as before (in-memory only).
+//
+// `context` is passed in rather than read from the module global, because by the
+// time this runs the decorator has already called cacheOff().
 async function resolveWithPersistence<T>(
   cacheKey: string,
+  context: RequestCacheContext,
   producer: () => Promise<T>
 ): Promise<T> {
-  if (!isPersistentApiCacheEnabled()) {
+  if (context === null || context.persist === undefined) {
     return producer();
   }
 
-  const { hit, value } = await persistentCacheGet(cacheKey);
+  // The persistent key can differ from the in-memory one: for a given_id-
+  // addressed request it carries the resolved dataset UUID, and for a request
+  // with declared deps it carries those too. Returns null when the request
+  // isn't eligible for disk at all, in which case this degrades to in-memory.
+  const persistentKey = await buildPersistentKey(cacheKey, context.persist);
+
+  if (persistentKey === null) {
+    return producer();
+  }
+
+  const { hit, value } = await persistentCacheGet(persistentKey);
   if (hit) {
     return value as T;
   }
 
   const fresh = await producer();
-  await persistentCacheSet(cacheKey, fresh);
+  await persistentCacheSet(persistentKey, fresh, context.persist);
   return fresh;
 }
 
@@ -143,7 +172,10 @@ const makeGetJson = (urlPrefix: string) => <T>(
     return request<T>(fullUrl, { method: "GET", ...options });
   };
 
-  if (!useCache) {
+  // Captured synchronously: the decorator clears it as soon as this returns.
+  const context = cacheContext;
+
+  if (context === null) {
     return getJson();
   }
 
@@ -153,10 +185,12 @@ const makeGetJson = (urlPrefix: string) => <T>(
   const cacheKey = `${urlPrefix}${url}-${json}`;
 
   if (!cache[cacheKey]) {
-    cache[cacheKey] = resolveWithPersistence(cacheKey, getJson).catch((e) => {
-      delete cache[cacheKey];
-      throw e;
-    });
+    cache[cacheKey] = resolveWithPersistence(cacheKey, context, getJson).catch(
+      (e) => {
+        delete cache[cacheKey];
+        throw e;
+      }
+    );
   }
 
   return cache[cacheKey] as Promise<T>;
@@ -174,7 +208,10 @@ const makePostJson = (urlPrefix: string) => async <T>(
     });
   };
 
-  if (!useCache) {
+  // Captured synchronously: the decorator clears it as soon as this returns.
+  const context = cacheContext;
+
+  if (context === null) {
     return postJson();
   }
 
@@ -182,10 +219,12 @@ const makePostJson = (urlPrefix: string) => async <T>(
   const cacheKey = `${urlPrefix}${url}-${json}`;
 
   if (!cache[cacheKey]) {
-    cache[cacheKey] = resolveWithPersistence(cacheKey, postJson).catch((e) => {
-      delete cache[cacheKey];
-      throw e;
-    });
+    cache[cacheKey] = resolveWithPersistence(cacheKey, context, postJson).catch(
+      (e) => {
+        delete cache[cacheKey];
+        throw e;
+      }
+    );
   }
 
   return cache[cacheKey] as Promise<T>;
@@ -195,7 +234,7 @@ const makePatchJson = (urlPrefix: string) => async <T>(
   url: string,
   payload: unknown
 ): Promise<T> => {
-  if (useCache) {
+  if (cacheContext !== null) {
     window.console.warn("PATCH requests cannot be cached");
   }
 
@@ -210,7 +249,7 @@ const makeDeleteJson = (urlPrefix: string) => async <T>(
   url: string,
   payload?: unknown
 ): Promise<T> => {
-  if (useCache) {
+  if (cacheContext !== null) {
     window.console.warn("DELETE requests cannot be cached");
   }
 
@@ -233,7 +272,7 @@ const makePostMultipart = (urlPrefix: string) => async <T>(
     Blob | string | File | number | boolean | null | undefined
   >
 ): Promise<T> => {
-  if (useCache) {
+  if (cacheContext !== null) {
     window.console.warn("Multipart POST requests cannot be cached");
   }
 
@@ -258,7 +297,7 @@ const makePatchMultipart = (urlPrefix: string) => async <T>(
     Blob | string | File | number | boolean | null | undefined
   >
 ): Promise<T> => {
-  if (useCache) {
+  if (cacheContext !== null) {
     window.console.warn("Multipart PATCH requests cannot be cached");
   }
 

--- a/frontend/packages/@depmap/api/src/persistedFetches.ts
+++ b/frontend/packages/@depmap/api/src/persistedFetches.ts
@@ -1,0 +1,117 @@
+// Persist-enabled wrappers for methods whose responses depend on datasets the
+// request itself does not name. The engine would refuse `persist: true` for
+// these (no dataset address in the cache key), so each wrapper computes the
+// response's implicit dependencies — the metadata datasets behind the
+// dimension types involved — and declares them via `persist: { deps }`.
+// Breadbox guarantees dimension-type metadata datasets are always in the
+// public group and get a new UUID whenever their contents change (see
+// breadbox/service/dataset.py), so the declared deps are exact: a metadata
+// update changes the dep, which changes the key, which orphans the old entry.
+//
+// Both wrappers FALL BACK to plain in-memory caching whenever the dep set
+// cannot be fully enumerated. A fallback costs a cache hit, never correctness.
+
+import type { DataExplorerContextV2 } from "@depmap/types";
+import { breadboxAPI } from "./breadboxAPI";
+import { cached } from "./apiCacheDecorator";
+
+type NamelessContext = Omit<DataExplorerContextV2, "name">;
+
+// Resolve dimension type names to their metadata dataset UUIDs, or null if any
+// of them can't be resolved (unknown type, or no metadata dataset).
+async function resolveMetadataDatasetIds(
+  names: string[]
+): Promise<string[] | null> {
+  const dimensionTypes = await cached(breadboxAPI).getDimensionTypes();
+  const ids: string[] = [];
+
+  for (const name of names) {
+    const id = dimensionTypes.find((t) => t.name === name)?.metadata_dataset_id;
+
+    if (!id) {
+      return null;
+    }
+
+    ids.push(id);
+  }
+
+  return ids;
+}
+
+/**
+ * Unfiltered identifiers for a dimension type, persisted across reloads.
+ *
+ * Deliberately takes no filter params: the `data_type` /
+ * `show_only_dimensions_in_datasets` variants are access-filtered per user on
+ * the backend and must never be persisted. Call
+ * `cached(breadboxAPI).getDimensionTypeIdentifiers(...)` directly for those.
+ */
+export async function getDimensionTypeIdentifiersPersisted(
+  dimTypeName: string
+) {
+  const deps = await resolveMetadataDatasetIds([dimTypeName]);
+
+  return deps
+    ? cached(breadboxAPI, { persist: { deps } }).getDimensionTypeIdentifiers(
+        dimTypeName
+      )
+    : cached(breadboxAPI).getDimensionTypeIdentifiers(dimTypeName);
+}
+
+// Collect the dimension types whose metadata datasets a context result depends
+// on: the context's own and those of nested contexts, recursively. Returns
+// null when the dep set can't be fully enumerated — a var with
+// `reindex_through` maps between dimension spaces through metadata datasets
+// the request doesn't name.
+//
+// This walk must NEVER throw. Contexts arrive here from interactive editors
+// that evaluate partially-built trees (holes, undefined nested entries), and
+// throwing here is a behavior change from the plain `evaluateContext` call
+// this wraps. Anything malformed returns null, which downgrades to plain
+// in-memory caching — the request then succeeds or fails exactly as it did
+// before persistence existed.
+function collectDimensionTypeNames(context: NamelessContext): string[] | null {
+  const names = new Set<string>();
+  const queue: NamelessContext[] = [context];
+
+  for (let i = 0; i < queue.length; i += 1) {
+    const c = queue[i];
+
+    if (!c || typeof c.dimension_type !== "string") {
+      return null;
+    }
+
+    names.add(c.dimension_type);
+
+    for (const variable of Object.values(c.vars || {})) {
+      if (!variable || variable.reindex_through !== undefined) {
+        return null;
+      }
+    }
+
+    if (c.contexts) {
+      queue.push(...Object.values(c.contexts));
+    }
+  }
+
+  return Array.from(names);
+}
+
+/**
+ * Evaluate a context, persisting the result across reloads when its full
+ * dependency set can be determined.
+ *
+ * The datasets named by the context's vars are already part of the cache key
+ * (the POST body is the key), so the declared deps only need the implicit
+ * dependencies: the metadata dataset of the context's dimension type and of
+ * every nested context's dimension type. The engine independently requires
+ * every one of those datasets to be public, or the result is not persisted.
+ */
+export async function evaluateContextPersisted(context: NamelessContext) {
+  const names = collectDimensionTypeNames(context);
+  const deps = names ? await resolveMetadataDatasetIds(names) : null;
+
+  return deps
+    ? cached(breadboxAPI, { persist: { deps } }).evaluateContext(context)
+    : cached(breadboxAPI).evaluateContext(context);
+}

--- a/frontend/packages/@depmap/api/src/persistentApiCache.ts
+++ b/frontend/packages/@depmap/api/src/persistentApiCache.ts
@@ -1,209 +1,811 @@
 // Persistent (cross-reload) caching for @depmap/api.
 //
-// ⚠️  This is a PROTOTYPE-ONLY feature. ⚠️
+// CORRECTNESS ARGUMENT — the whole thing, in one paragraph:
 //
-// The normal @depmap/api cache (see createJsonClient.ts) lives only in memory,
-// so it clears itself every time the page reloads and never needs eviction.
-// This module lets you opt a *subset* of calls into a longer-lived cache:
-// when enabled, anything routed through the `cached(...)` decorator stores its
-// GET/POST response in IndexedDB and reuses it across reloads, with a TTL for
-// staleness. Calls that do NOT go through `cached(...)` are unaffected and stay
-// uncached, exactly as before.
+//   Breadbox never mutates dataset data in place. A new version of a dataset is
+//   a new row with a new UUID, and `PATCH /datasets/{id}` changes metadata only,
+//   never data, never the UUID. Therefore a response addressed by dataset UUID
+//   is immutable, and a cached copy of it is valid forever. There is no
+//   staleness to detect, so this module contains no invalidation logic — no
+//   version comparison on read, no TTL, no revalidation.
 //
-// `enablePersistentApiCache()` is a single global switch (call it once, e.g. at
-// the top level of a module that runs during app startup). It does not force
-// caching onto anything — it only changes what `cached(...)` does, swapping its
-// in-memory store for the persistent one. It still prints a loud banner,
-// because a developer elsewhere wrapping a call in `cached(...)` and expecting
-// per-session memory caching would instead get day-old data from disk.
+// Everything below is a consequence of that sentence:
 //
-// Why IndexedDB and not localStorage? The motivating use case is a page that
-// fetches many *large* payloads. localStorage caps out around 5MB per origin
-// and is synchronous (it blocks the main thread), so large responses would
-// blow the quota almost immediately. IndexedDB holds far more and is async.
-// If your payloads are reliably small and you'd rather have fewer moving
-// parts, the idbGet/idbSet helpers below are the only thing you'd need to swap.
+//   - given_ids are mutable pointers to "latest", so they cannot be cached as-is.
+//     The resolved UUID is *appended* to the key (never substituted into the
+//     request — the given_id is the caller's intent and must go on the wire). A
+//     new version resolves differently, so the key changes, so the old entry is
+//     orphaned rather than wrongly served. Self-invalidating by construction.
+//
+//   - Deletion needs no handling. Pickers are populated from a fresh
+//     `getDatasets()` every load, so a deleted dataset can't be selected and its
+//     entries are unreachable garbage. They go cold, and LRU reclaims them.
+//     LRU is the TTL.
+//
+//   - Only PUBLIC datasets are stored. IndexedDB is origin-global and
+//     user-agnostic: a shared lab machine, a logout, or a user switch all expose
+//     whatever is on disk. Restricting to public data makes that a non-issue,
+//     because the next user was entitled to those bytes anyway. Enforced here in
+//     `persistentCacheSet` rather than at call sites, so it cannot be forgotten.
+//
+// The module FAILS CLOSED. Until `initDatasetRegistry` has been called with the
+// current dataset listing, `buildPersistentKey` returns null for everything and
+// nothing is read or written. A wiring mistake costs cache hits, never
+// correctness and never a privacy leak.
 
-const CACHE_VERSION = 1;
 const DB_NAME = "depmap-api-cache";
-const STORE_NAME = "responses";
-const DB_VERSION = 1;
+const DB_VERSION = 2;
+const RESPONSES = "responses";
+const META = "meta";
+const EPOCH_KEY = "epoch";
+const BYTES_KEY = "totalBytes";
 
-const DEFAULT_TTL_MS = 24 * 60 * 60 * 1000; // 1 day
+// The manual reset knob. Bump this when the key scheme changes OR when
+// shipping a frontend-side fix for anything that may have written bad entries
+// (key construction, deps computation). Bumping moves every key into a fresh
+// namespace AND wipes every user's store on their next page load.
+//
+// The full epoch (see enforceEpoch) is this constant composed with the
+// Breadbox app version, so backend changes wipe automatically: any
+// feat/fix(breadbox) commit bumps that version via commitizen, and cached
+// responses produced by the old server code are cleared on next load. Only
+// deploys that ship no Breadbox change leave caches warm.
+const CACHE_VERSION = 2;
+
+// Breadbox's well-known public group. See breadbox/crud/access_control.py.
+export const PUBLIC_GROUP_ID = "00000000-0000-0000-0000-000000000000";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUID_SCAN_RE = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
+
+const DEFAULT_MAX_BYTES = 250 * 1024 * 1024;
+// Evict down to this fraction of budget so we aren't evicting on every write.
+const EVICT_WATERMARK = 0.9;
+// Never store a single item larger than this fraction of budget, or one huge
+// response can cursor away the entire store and still not fit.
+const MAX_ITEM_FRACTION = 0.1;
+const TOUCH_FLUSH_MS = 15_000;
+
+/**
+ * `true` asserts the response is immutable at its own dataset address.
+ * `{ deps }` additionally names datasets the response depends on but is not
+ * addressed by; they are folded into the key.
+ */
+export type PersistOption = true | { deps: string[] };
+
+/** Ambient context threaded from the decorator through createJsonClient. */
+export type RequestCacheContext = { persist?: PersistOption } | null;
 
 interface CacheEntry {
+  key: string;
   value: unknown;
-  timestamp: number;
+  createdAt: number;
+  lastAccessed: number;
+  size: number;
 }
 
-let persistentCacheEnabled = false;
-let ttlMs = DEFAULT_TTL_MS;
+type Status = "uninitialized" | "ready" | "disabled";
 
-// Namespacing the stored key with a version lets you invalidate everything at
-// once by bumping CACHE_VERSION: old keys simply become unreachable.
-const versionedKey = (key: string) => `v${CACHE_VERSION}:${key}`;
+let status: Status = "uninitialized";
+let db: IDBDatabase | null = null;
+let openPromise: Promise<void> | null = null;
+let maxBytes = DEFAULT_MAX_BYTES;
+
+/** given_id -> UUID for every dataset visible this session. */
+let versionMap: Map<string, string> | null = null;
+/** UUIDs of datasets in the public group. Nothing else may be written. */
+let publicUuids: Set<string> | null = null;
+
+const touched = new Set<string>();
+let touchTimer: ReturnType<typeof setInterval> | null = null;
+
+export const persistentCacheStats = {
+  hits: 0,
+  misses: 0,
+  writes: 0,
+  bytesWritten: 0,
+  evictions: 0,
+  bytesEvicted: 0,
+  refusedNotPublic: 0,
+  refusedNoDatasetAddress: 0,
+  refusedUnresolvable: 0,
+  refusedTooLarge: 0,
+  refusedNotReady: 0,
+  quotaErrors: 0,
+  epochWipes: 0,
+  // Which branch of address classification each request took. If
+  // `unresolvable` is large you have dead bookmarks; if `unlistedUuid` is
+  // large your dataset listing is narrower than what requests can reach.
+  addressKinds: {
+    givenId: 0,
+    listedUuid: 0,
+    unlistedUuid: 0,
+    unresolvable: 0,
+  },
+};
 
 // ---------------------------------------------------------------------------
-// Minimal promise-based IndexedDB key/value store (no dependencies).
+// Registry — the public set and the given_id resolution map
 // ---------------------------------------------------------------------------
 
-let dbPromise: Promise<IDBDatabase> | null = null;
+export interface DatasetRegistryEntry {
+  id: string;
+  given_id?: string | null;
+  group_id?: string | null;
+}
 
-function openDb(): Promise<IDBDatabase> {
-  if (typeof indexedDB === "undefined") {
-    return Promise.reject(new Error("IndexedDB is not available"));
+/**
+ * Seed the module from the current dataset listing, then open the store.
+ *
+ * Call once per page load with the (promise of the) result of an uncached
+ * `getDatasets()`, plus the (promise of the) Breadbox app version from an
+ * uncached `getBreadboxVersion()`. Call it SYNCHRONOUSLY at entry-point time,
+ * passing the pending promises rather than awaiting them first: `openPromise`
+ * must exist before the page's first persisted request, or that request sees
+ * an uninitialized engine and refuses — silently costing every cache hit
+ * issued during those round trips, on every page load.
+ *
+ * The epoch is composed internally from `CACHE_VERSION` and `breadboxVersion`;
+ * a change to either wipes every user's store on their next load.
+ */
+export function initDatasetRegistry(options: {
+  datasets: DatasetRegistryEntry[] | Promise<DatasetRegistryEntry[]>;
+  breadboxVersion: string | Promise<string>;
+  maxBytes?: number;
+}): Promise<void> {
+  if (openPromise) {
+    return openPromise;
   }
 
-  if (!dbPromise) {
-    dbPromise = new Promise((resolve, reject) => {
-      const openRequest = indexedDB.open(DB_NAME, DB_VERSION);
+  maxBytes = options.maxBytes ?? DEFAULT_MAX_BYTES;
 
-      openRequest.onupgradeneeded = () => {
-        if (!openRequest.result.objectStoreNames.contains(STORE_NAME)) {
-          openRequest.result.createObjectStore(STORE_NAME);
+  openPromise = (async () => {
+    try {
+      const [datasets, breadboxVersion] = await Promise.all([
+        options.datasets,
+        options.breadboxVersion,
+      ]);
+
+      const nextVersionMap = new Map<string, string>();
+      const nextPublicUuids = new Set<string>();
+
+      for (const d of datasets) {
+        if (d.given_id) {
+          nextVersionMap.set(d.given_id, d.id);
         }
-      };
+        if (d.group_id === PUBLIC_GROUP_ID) {
+          nextPublicUuids.add(d.id);
+        }
+      }
 
-      openRequest.onsuccess = () => resolve(openRequest.result);
-      openRequest.onerror = () => reject(openRequest.error);
-    });
-  }
+      // A given_id shaped like a UUID would be classified as a UUID by
+      // `classifyAddress` and skip resolution, pinning it to whatever version
+      // it first fetched. Cheap to detect, so detect it rather than reason
+      // about it.
+      for (const givenId of nextVersionMap.keys()) {
+        if (UUID_RE.test(givenId)) {
+          window.console.warn(
+            `[persistent-api-cache] given_id "${givenId}" is UUID-shaped, ` +
+              `which defeats version resolution. It will not be persisted.`
+          );
+          nextVersionMap.delete(givenId);
+        }
+      }
 
-  return dbPromise;
+      versionMap = nextVersionMap;
+      publicUuids = nextPublicUuids;
+
+      const idb = await openDb();
+      await enforceEpoch(idb, `v${CACHE_VERSION}:bb${breadboxVersion}`);
+
+      // Clamp to what the browser will actually grant. Safari denies writes
+      // well under 250MB. Done once, off the hot path.
+      if (navigator.storage && navigator.storage.estimate) {
+        const { quota } = await navigator.storage.estimate();
+        if (quota) {
+          maxBytes = Math.min(maxBytes, Math.floor(quota * 0.2));
+        }
+      }
+
+      db = idb;
+      status = "ready";
+      startTouchFlushing();
+    } catch (e) {
+      // Never let cache setup break the page. Degrade to in-memory only.
+      window.console.warn("[persistent-api-cache] disabled:", e);
+      status = "disabled";
+      db = null;
+    }
+  })();
+
+  return openPromise;
 }
-
-function idbGet<T>(key: string): Promise<T | undefined> {
-  return openDb().then(
-    (db) =>
-      new Promise<T | undefined>((resolve, reject) => {
-        const tx = db.transaction(STORE_NAME, "readonly");
-        const req = tx.objectStore(STORE_NAME).get(key);
-        req.onsuccess = () => resolve(req.result as T | undefined);
-        req.onerror = () => reject(req.error);
-      })
-  );
-}
-
-function idbSet(key: string, value: unknown): Promise<void> {
-  return openDb().then(
-    (db) =>
-      new Promise<void>((resolve, reject) => {
-        const tx = db.transaction(STORE_NAME, "readwrite");
-        tx.objectStore(STORE_NAME).put(value, key);
-        tx.oncomplete = () => resolve();
-        tx.onerror = () => reject(tx.error);
-      })
-  );
-}
-
-function idbClear(): Promise<void> {
-  return openDb().then(
-    (db) =>
-      new Promise<void>((resolve, reject) => {
-        const tx = db.transaction(STORE_NAME, "readwrite");
-        tx.objectStore(STORE_NAME).clear();
-        tx.oncomplete = () => resolve();
-        tx.onerror = () => reject(tx.error);
-      })
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Internal surface consumed by createJsonClient.ts
-// ---------------------------------------------------------------------------
 
 export function isPersistentApiCacheEnabled(): boolean {
-  return persistentCacheEnabled;
+  return status === "ready";
 }
 
-// Returns { hit: false } on a miss, an expired entry, or any storage error.
-// Errors are swallowed (and warned) so a flaky cache never breaks a request.
+// ---------------------------------------------------------------------------
+// Key construction — where all the safety lives
+// ---------------------------------------------------------------------------
+
+type Address =
+  | { kind: "givenId"; raw: string; uuid: string }
+  | { kind: "uuid"; raw: string }
+  | { kind: "unresolvable"; raw: string };
+
+/**
+ * Classify a dataset address.
+ *
+ * The map is authoritative and checked FIRST, so a UUID-shaped given_id can
+ * never be misread as a UUID. The regex only covers a UUID that is valid on the
+ * server but absent from our listing (uploaded in another tab, or filtered out
+ * of the listing) — real and cacheable, just unlisted.
+ *
+ * Misclassification is safe by construction: the classification is an input to
+ * key *construction*, not a claim stored in the entry. A wrong classification
+ * computes a key that no correctly-classified request would compute, so the
+ * result is a miss and a refetch. There is no misclassification that yields a
+ * wrong hit.
+ */
+function classifyAddress(raw: string): Address {
+  const resolved = versionMap ? versionMap.get(raw) : undefined;
+
+  if (resolved !== undefined) {
+    persistentCacheStats.addressKinds.givenId += 1;
+    return { kind: "givenId", raw, uuid: resolved };
+  }
+
+  if (publicUuids && publicUuids.has(raw)) {
+    persistentCacheStats.addressKinds.listedUuid += 1;
+    return { kind: "uuid", raw };
+  }
+
+  if (UUID_RE.test(raw)) {
+    persistentCacheStats.addressKinds.unlistedUuid += 1;
+    return { kind: "uuid", raw };
+  }
+
+  // Neither a known given_id nor UUID-shaped: a retired given_id from an old
+  // bookmark or a stale context. Breadbox won't resolve it either, so the
+  // response will be an error. Nothing worth storing.
+  persistentCacheStats.addressKinds.unresolvable += 1;
+  return { kind: "unresolvable", raw };
+}
+
+/**
+ * Every dataset-shaped token in the in-memory cache key. The key is built from
+ * the URL and the serialized params/payload, so a dataset address appears in it
+ * whenever the request names one — in the path for the matrix/tabular/features/
+ * samples endpoints, and in the body for `getDimensionData`.
+ */
+function extractAddresses(cacheKey: string): string[] {
+  const found = new Set<string>();
+
+  for (const m of cacheKey.match(UUID_SCAN_RE) ?? []) {
+    found.add(m);
+  }
+
+  if (versionMap) {
+    for (const givenId of versionMap.keys()) {
+      // given_ids reach the key via `uri`, which percent-encodes them.
+      if (
+        cacheKey.includes(givenId) ||
+        cacheKey.includes(encodeURIComponent(givenId))
+      ) {
+        found.add(givenId);
+      }
+    }
+  }
+
+  return Array.from(found);
+}
+
+/**
+ * Turn an in-memory cache key into a persistent one, or return null if this
+ * request must not touch disk.
+ *
+ * Returning null is always the safe answer, and this function returns it
+ * whenever anything is unclear: registry not seeded, no dataset address in the
+ * key, an address we can't resolve, or any dataset involved that isn't public.
+ */
+export async function buildPersistentKey(
+  cacheKey: string,
+  persist: PersistOption
+): Promise<string | null> {
+  if (openPromise) {
+    await openPromise;
+  }
+
+  if (status !== "ready" || versionMap === null || publicUuids === null) {
+    persistentCacheStats.refusedNotReady += 1;
+    return null;
+  }
+
+  const declaredDeps = persist === true ? [] : persist.deps;
+  const addresses = extractAddresses(cacheKey);
+
+  if (addresses.length === 0 && declaredDeps.length === 0) {
+    // The call site asserted immutability, but nothing in the request names a
+    // dataset, so the assertion can't be checked. Refuse rather than trust it.
+    persistentCacheStats.refusedNoDatasetAddress += 1;
+    return null;
+  }
+
+  const resolvedSuffixes: string[] = [];
+  const involvedUuids: string[] = [];
+
+  for (const raw of addresses) {
+    const address = classifyAddress(raw);
+
+    if (address.kind === "unresolvable") {
+      persistentCacheStats.refusedUnresolvable += 1;
+      return null;
+    }
+
+    if (address.kind === "givenId") {
+      // Append, never substitute. Appending keeps the raw given_id in the key,
+      // so given_id-addressed and UUID-addressed requests occupy disjoint key
+      // spaces and a "latest" entry can never collide with a version-pinned one.
+      resolvedSuffixes.push(`${address.raw}=${address.uuid}`);
+      involvedUuids.push(address.uuid);
+    } else {
+      // Already part of cacheKey; nothing to append.
+      involvedUuids.push(address.raw);
+    }
+  }
+
+  for (const raw of declaredDeps) {
+    const address = classifyAddress(raw);
+
+    if (address.kind === "unresolvable") {
+      persistentCacheStats.refusedUnresolvable += 1;
+      return null;
+    }
+
+    // Unlike an extracted address, a declared dep appears nowhere in cacheKey,
+    // so it must ALWAYS be folded into the suffix — a UUID dep included. When
+    // the dep changes (a metadata dataset re-uploaded under a new UUID), the
+    // key changes and the old entry is orphaned rather than wrongly served.
+    if (address.kind === "givenId") {
+      resolvedSuffixes.push(`${address.raw}=${address.uuid}`);
+      involvedUuids.push(address.uuid);
+    } else {
+      resolvedSuffixes.push(address.raw);
+      involvedUuids.push(address.raw);
+    }
+  }
+
+  // Hard requirement: every dataset contributing to this response must be
+  // public. Checked here, once, for both addresses and declared deps.
+  for (const uuid of involvedUuids) {
+    if (!publicUuids.has(uuid)) {
+      persistentCacheStats.refusedNotPublic += 1;
+      return null;
+    }
+  }
+
+  resolvedSuffixes.sort();
+  const suffix = resolvedSuffixes.length
+    ? `|@${resolvedSuffixes.join(",")}`
+    : "";
+
+  return `v${CACHE_VERSION}:${cacheKey}${suffix}`;
+}
+
+// ---------------------------------------------------------------------------
+// IndexedDB plumbing
+// ---------------------------------------------------------------------------
+
+function promisify<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+function txDone(tx: IDBTransaction): Promise<void> {
+  return new Promise((resolve, reject) => {
+    /* eslint-disable no-param-reassign */
+    tx.oncomplete = () => resolve();
+    tx.onerror = () => reject(tx.error);
+    tx.onabort = () => reject(tx.error);
+    /* eslint-enable no-param-reassign */
+  });
+}
+
+function openDb(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    if (typeof indexedDB === "undefined") {
+      reject(new Error("IndexedDB is not available"));
+      return;
+    }
+
+    const req = indexedDB.open(DB_NAME, DB_VERSION);
+
+    req.onupgradeneeded = () => {
+      const idb = req.result;
+
+      // Destructive upgrade. Everything in v1 was <=24h-TTL prototype data
+      // written under the old key scheme; none of it is worth migrating.
+      if (idb.objectStoreNames.contains(RESPONSES)) {
+        idb.deleteObjectStore(RESPONSES);
+      }
+      if (idb.objectStoreNames.contains(META)) {
+        idb.deleteObjectStore(META);
+      }
+
+      const store = idb.createObjectStore(RESPONSES, { keyPath: "key" });
+      store.createIndex("lastAccessed", "lastAccessed", { unique: false });
+      idb.createObjectStore(META, { keyPath: "key" });
+    };
+
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+    req.onblocked = () => reject(new Error("IndexedDB upgrade blocked"));
+  });
+}
+
+async function readMetaNumber(
+  store: IDBObjectStore,
+  key: string
+): Promise<number> {
+  const rec = await promisify(
+    store.get(key) as IDBRequest<{ key: string; value: number } | undefined>
+  );
+  return rec ? rec.value : 0;
+}
+
+/**
+ * The kill switch. A persistent cache is the first thing in the stack where
+ * "just reload" doesn't clear a bad state, so it needs explicit wipe paths:
+ * ship a `CACHE_VERSION` bump (frontend-side fixes) or any Breadbox release
+ * (the app version is part of the epoch), and every store clears on next load.
+ */
+async function enforceEpoch(idb: IDBDatabase, epoch: string): Promise<void> {
+  const tx = idb.transaction([RESPONSES, META], "readwrite");
+  const meta = tx.objectStore(META);
+  const rec = await promisify(
+    meta.get(EPOCH_KEY) as IDBRequest<
+      { key: string; value: string } | undefined
+    >
+  );
+
+  if (!rec || rec.value !== epoch) {
+    tx.objectStore(RESPONSES).clear();
+    meta.put({ key: EPOCH_KEY, value: epoch });
+    meta.put({ key: BYTES_KEY, value: 0 });
+    if (rec) {
+      persistentCacheStats.epochWipes += 1;
+    }
+  }
+
+  await txDone(tx);
+}
+
+// ---------------------------------------------------------------------------
+// Read / write, consumed by createJsonClient.ts
+// ---------------------------------------------------------------------------
+
 export async function persistentCacheGet(
   key: string
 ): Promise<{ hit: boolean; value?: unknown }> {
+  if (status !== "ready" || !db) {
+    return { hit: false };
+  }
+
   try {
-    const entry = await idbGet<CacheEntry>(versionedKey(key));
+    const tx = db.transaction(RESPONSES, "readonly");
+    const entry = await promisify(
+      tx.objectStore(RESPONSES).get(key) as IDBRequest<CacheEntry | undefined>
+    );
 
     if (!entry) {
+      persistentCacheStats.misses += 1;
       return { hit: false };
     }
 
-    if (Date.now() - entry.timestamp > ttlMs) {
-      // Stale. Treat as a miss; the fresh value overwrites it on the next set.
-      return { hit: false };
-    }
-
+    // No TTL check and no validation. If it's here, it's valid — the key
+    // already encodes everything the response depends on.
+    persistentCacheStats.hits += 1;
+    touched.add(key);
     return { hit: true, value: entry.value };
   } catch (e) {
     window.console.warn("[persistent-api-cache] read failed:", e);
+    persistentCacheStats.misses += 1;
     return { hit: false };
   }
 }
 
 export async function persistentCacheSet(
   key: string,
-  value: unknown
+  value: unknown,
+  // Accepted for symmetry with the read path and so future policies have a
+  // hook; eligibility was already decided in buildPersistentKey.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _persist: PersistOption
 ): Promise<void> {
-  try {
-    const entry: CacheEntry = { value, timestamp: Date.now() };
-    await idbSet(versionedKey(key), entry);
-  } catch (e) {
-    window.console.warn("[persistent-api-cache] write failed:", e);
+  if (status !== "ready" || !db) {
+    return;
   }
+
+  // A cheap byte proxy. `JSON.stringify().length` counts UTF-16 code units of
+  // JSON text while IndexedDB stores a structured clone, so this over-estimates
+  // numeric payloads — conservative in the right direction for a budget.
+  let size: number;
+  try {
+    size = JSON.stringify(value).length;
+  } catch {
+    return;
+  }
+
+  if (size > maxBytes * MAX_ITEM_FRACTION) {
+    persistentCacheStats.refusedTooLarge += 1;
+    return;
+  }
+
+  try {
+    await writeEntry(key, value, size);
+  } catch (e) {
+    if (e instanceof DOMException && e.name === "QuotaExceededError") {
+      // Our accounting and the browser's can disagree. Make room, retry once.
+      persistentCacheStats.quotaErrors += 1;
+      try {
+        await evictTo(maxBytes * 0.5);
+        await writeEntry(key, value, size);
+      } catch {
+        status = "disabled";
+        return;
+      }
+    } else {
+      window.console.warn("[persistent-api-cache] write failed:", e);
+      return;
+    }
+  }
+
+  await maybeEvict();
+}
+
+async function writeEntry(
+  key: string,
+  value: unknown,
+  size: number
+): Promise<void> {
+  if (!db) return;
+
+  const tx = db.transaction([RESPONSES, META], "readwrite");
+  const store = tx.objectStore(RESPONSES);
+  const meta = tx.objectStore(META);
+
+  const now = Date.now();
+  const prior = await promisify(
+    store.get(key) as IDBRequest<CacheEntry | undefined>
+  );
+
+  store.put({ key, value, createdAt: now, lastAccessed: now, size });
+
+  // Read-modify-write of the byte total happens inside this same transaction.
+  // IndexedDB serializes readwrite transactions, so the total stays correct
+  // across tabs and needs no periodic recompute sweep.
+  const total = await readMetaNumber(meta, BYTES_KEY);
+  meta.put({ key: BYTES_KEY, value: total + size - (prior ? prior.size : 0) });
+
+  await txDone(tx);
+
+  persistentCacheStats.writes += 1;
+  persistentCacheStats.bytesWritten += size;
+}
+
+async function maybeEvict(): Promise<void> {
+  if (!db) return;
+
+  const tx = db.transaction(META, "readonly");
+  const total = await readMetaNumber(tx.objectStore(META), BYTES_KEY);
+
+  if (total > maxBytes) {
+    await evictTo(maxBytes * EVICT_WATERMARK);
+  }
+}
+
+/** Walk the lastAccessed index coldest-first, deleting until under `target`. */
+async function evictTo(target: number): Promise<void> {
+  if (!db) return;
+
+  // Flush pending touches first, or we evict on timestamps up to
+  // TOUCH_FLUSH_MS stale and drop something that was read seconds ago.
+  await flushTouches();
+  if (!db) return;
+
+  const tx = db.transaction([RESPONSES, META], "readwrite");
+  const store = tx.objectStore(RESPONSES);
+  const meta = tx.objectStore(META);
+
+  let total = await readMetaNumber(meta, BYTES_KEY);
+  if (total <= target) {
+    return;
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    const cursorReq = store.index("lastAccessed").openCursor();
+
+    cursorReq.onsuccess = () => {
+      const cursor = cursorReq.result;
+      if (!cursor || total <= target) {
+        resolve();
+        return;
+      }
+
+      const entry = cursor.value as CacheEntry;
+      cursor.delete();
+      total -= entry.size;
+      persistentCacheStats.evictions += 1;
+      persistentCacheStats.bytesEvicted += entry.size;
+      cursor.continue();
+    };
+
+    cursorReq.onerror = () => reject(cursorReq.error);
+  });
+
+  meta.put({ key: BYTES_KEY, value: Math.max(0, total) });
+  await txDone(tx);
+}
+
+// ---------------------------------------------------------------------------
+// lastAccessed batching
+// ---------------------------------------------------------------------------
+
+/**
+ * Reads accumulate keys in memory; one readwrite transaction flushes them
+ * periodically. A lost flush costs eviction precision and nothing else.
+ */
+async function flushTouches(): Promise<void> {
+  if (!db || touched.size === 0) {
+    return;
+  }
+
+  const keys = Array.from(touched);
+  touched.clear();
+
+  try {
+    const tx = db.transaction(RESPONSES, "readwrite");
+    const store = tx.objectStore(RESPONSES);
+    const now = Date.now();
+
+    await Promise.all(
+      keys.map(async (key) => {
+        const entry = await promisify(
+          store.get(key) as IDBRequest<CacheEntry | undefined>
+        );
+        if (entry) {
+          entry.lastAccessed = now;
+          store.put(entry);
+        }
+      })
+    );
+
+    await txDone(tx);
+  } catch {
+    // Eviction precision only; nothing to recover.
+  }
+}
+
+function startTouchFlushing(): void {
+  if (touchTimer !== null) {
+    return;
+  }
+
+  // flushTouches never rejects (it swallows errors internally), so these
+  // fire-and-forget calls are safe.
+  touchTimer = setInterval(() => {
+    flushTouches();
+  }, TOUCH_FLUSH_MS);
+
+  window.addEventListener("pagehide", () => {
+    flushTouches();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test support
+// ---------------------------------------------------------------------------
+
+/**
+ * Return the module to its pristine (uninitialized, fail-closed) state.
+ *
+ * FOR TESTS ONLY. This module holds state for the life of the module (`status`,
+ * `db`, `versionMap`, `publicUuids`, ...), jest is not configured with
+ * `resetModules`, and module registries are shared across tests in a file — so
+ * without an explicit reset, the first test to call `initDatasetRegistry`
+ * leaks a "ready" engine into every later test in the file. Call this in
+ * `beforeEach`/`afterEach`. It does not touch IndexedDB contents; pair it with
+ * a fresh `fake-indexeddb` per test for full isolation.
+ */
+export function __resetForTests(): void {
+  if (touchTimer !== null) {
+    clearInterval(touchTimer);
+    touchTimer = null;
+  }
+  if (db) {
+    db.close();
+  }
+
+  status = "uninitialized";
+  db = null;
+  openPromise = null;
+  maxBytes = DEFAULT_MAX_BYTES;
+  versionMap = null;
+  publicUuids = null;
+  touched.clear();
+
+  persistentCacheStats.hits = 0;
+  persistentCacheStats.misses = 0;
+  persistentCacheStats.writes = 0;
+  persistentCacheStats.bytesWritten = 0;
+  persistentCacheStats.evictions = 0;
+  persistentCacheStats.bytesEvicted = 0;
+  persistentCacheStats.refusedNotPublic = 0;
+  persistentCacheStats.refusedNoDatasetAddress = 0;
+  persistentCacheStats.refusedUnresolvable = 0;
+  persistentCacheStats.refusedTooLarge = 0;
+  persistentCacheStats.refusedNotReady = 0;
+  persistentCacheStats.quotaErrors = 0;
+  persistentCacheStats.epochWipes = 0;
+  persistentCacheStats.addressKinds.givenId = 0;
+  persistentCacheStats.addressKinds.listedUuid = 0;
+  persistentCacheStats.addressKinds.unlistedUuid = 0;
+  persistentCacheStats.addressKinds.unresolvable = 0;
 }
 
 // ---------------------------------------------------------------------------
 // Public surface for app code
 // ---------------------------------------------------------------------------
 
-// Wipe every cached response. Use this if you need a clean slate without
-// waiting for the TTL to expire.
+/** Wipe every cached response without waiting for an epoch change. */
 export async function clearPersistentApiCache(): Promise<void> {
+  if (openPromise) {
+    await openPromise;
+  }
+
+  if (!db) return;
+
   try {
-    await idbClear();
+    const tx = db.transaction([RESPONSES, META], "readwrite");
+    tx.objectStore(RESPONSES).clear();
+    tx.objectStore(META).put({ key: BYTES_KEY, value: 0 });
+    touched.clear();
+    await txDone(tx);
     window.console.warn("[persistent-api-cache] cleared.");
   } catch (e) {
     window.console.warn("[persistent-api-cache] clear failed:", e);
   }
 }
 
-// Make the `cached(...)` decorator use a persistent (cross-reload) store
-// instead of its in-memory cache, for the whole app. Intended to be called
-// once, at module load. This does NOT enable caching on its own — only calls
-// that already go through `cached(...)` are affected. `ttlMs` controls how long
-// a stored response is served before it is considered stale (default: 1 day).
-export function enablePersistentApiCache(options?: { ttlMs?: number }): void {
-  persistentCacheEnabled = true;
-
-  if (options && typeof options.ttlMs === "number") {
-    ttlMs = options.ttlMs;
+/**
+ * Counters for tuning. You cannot pick `maxBytes` or judge whether this feature
+ * earns its complexity without hit rate, eviction rate, and refusal rate.
+ */
+export async function getPersistentApiCacheInfo(): Promise<{
+  status: Status;
+  maxBytes: number;
+  totalBytes: number;
+  publicDatasets: number;
+  stats: typeof persistentCacheStats;
+}> {
+  if (openPromise) {
+    await openPromise;
   }
 
-  announce(ttlMs);
-}
+  let totalBytes = 0;
+  if (db) {
+    const tx = db.transaction(META, "readonly");
+    totalBytes = await readMetaNumber(tx.objectStore(META), BYTES_KEY);
+  }
 
-function announce(activeTtlMs: number): void {
-  const hours = activeTtlMs / (60 * 60 * 1000);
-  const ttlLabel = Number.isInteger(hours)
-    ? `${hours}h`
-    : `${hours.toFixed(1)}h`;
-
-  window.console.warn(
-    "%c⚠ PERSISTENT API CACHE ENABLED ⚠",
-    "font-size:16px;font-weight:bold;color:#fff;background:#c0392b;padding:6px 10px;border-radius:3px;"
-  );
-
-  window.console.warn(
-    [
-      "[persistent-api-cache] Any @depmap/api call routed through cached(...)",
-      `now saves its response to IndexedDB ("${DB_NAME}") and reuses it across`,
-      `page reloads for up to ${ttlLabel}. Calls NOT wrapped in cached(...) are`,
-      "unaffected. If you wrapped a call in cached(...) expecting per-session",
-      "memory caching and are seeing stale data, THIS IS WHY.",
-      "",
-      "To reset: call clearPersistentApiCache(), or delete the",
-      `"${DB_NAME}" database under Application > IndexedDB in devtools.`,
-      "To disable: remove the enablePersistentApiCache() call and reload.",
-    ].join("\n")
-  );
+  return {
+    status,
+    maxBytes,
+    totalBytes,
+    publicDatasets: publicUuids ? publicUuids.size : 0,
+    stats: { ...persistentCacheStats },
+  };
 }

--- a/frontend/packages/@depmap/custom-analyses/src/api/runPearsonCorrelationAnalysis.ts
+++ b/frontend/packages/@depmap/custom-analyses/src/api/runPearsonCorrelationAnalysis.ts
@@ -1,4 +1,4 @@
-import { breadboxAPI, cached } from "@depmap/api";
+import { breadboxAPI, evaluateContextPersisted } from "@depmap/api";
 import { DataExplorerContextV2, SliceQuery } from "@depmap/types";
 
 interface Parameters {
@@ -15,7 +15,7 @@ async function runPearsonCorrelationAnalysis({
   let queryCellLines: string[] | null = null;
 
   if (filterByContext) {
-    const result = await cached(breadboxAPI).evaluateContext(filterByContext);
+    const result = await evaluateContextPersisted(filterByContext);
     queryCellLines = result.ids;
   }
 

--- a/frontend/packages/@depmap/custom-analyses/src/api/runTwoClassComparisonAnalysis.ts
+++ b/frontend/packages/@depmap/custom-analyses/src/api/runTwoClassComparisonAnalysis.ts
@@ -1,4 +1,4 @@
-import { breadboxAPI, cached } from "@depmap/api";
+import { breadboxAPI, cached, evaluateContextPersisted } from "@depmap/api";
 import { DataExplorerContextV2 } from "@depmap/types";
 
 interface Parameters {
@@ -12,21 +12,19 @@ async function runTwoClassComparisonAnalysis({
   inGroupContext,
   outGroupContext,
 }: Parameters) {
-  const inGroupIdentifiers = await cached(breadboxAPI).evaluateContext(
-    inGroupContext
-  );
+  const inGroupIdentifiers = await evaluateContextPersisted(inGroupContext);
 
   const queryIds = await (async () => {
     if (!outGroupContext) {
-      const allIdentifiers = await cached(breadboxAPI).getDatasetSamples(
-        datasetId
-      );
+      const allIdentifiers = await cached(breadboxAPI, {
+        persist: true,
+      }).getDatasetSamples(datasetId);
 
       return allIdentifiers.map(({ id }) => id);
     }
 
     const outGroupIdentifiers = outGroupContext
-      ? await cached(breadboxAPI).evaluateContext(outGroupContext)
+      ? await evaluateContextPersisted(outGroupContext)
       : { ids: [] };
 
     return new Set([...inGroupIdentifiers.ids, ...outGroupIdentifiers.ids]);

--- a/frontend/packages/@depmap/custom-analyses/src/components/AnalysisConfigurationPanel/sections/OverlappingIdentifiersWarning.tsx
+++ b/frontend/packages/@depmap/custom-analyses/src/components/AnalysisConfigurationPanel/sections/OverlappingIdentifiersWarning.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import { Alert } from "react-bootstrap";
-import { breadboxAPI, cached } from "@depmap/api";
+import { evaluateContextPersisted } from "@depmap/api";
 import { DataExplorerContextV2 } from "@depmap/types";
 
 interface Props {
@@ -23,10 +23,8 @@ function OverlappingIdentifiersWarning({
     }
 
     (async () => {
-      const inGroupIdentifiers = await cached(breadboxAPI).evaluateContext(
-        inGroupContext
-      );
-      const outGroupIdentifiers = await cached(breadboxAPI).evaluateContext(
+      const inGroupIdentifiers = await evaluateContextPersisted(inGroupContext);
+      const outGroupIdentifiers = await evaluateContextPersisted(
         outGroupContext
       );
 

--- a/frontend/packages/@depmap/custom-analyses/src/hooks/useValidator.ts
+++ b/frontend/packages/@depmap/custom-analyses/src/hooks/useValidator.ts
@@ -23,7 +23,9 @@ function useValidator(analysis: Partial<AnalysisConfiguration>) {
       if (analysis.kind === "pearson_correlation") {
         if (analysis.sliceQuery) {
           try {
-            await cached(breadboxAPI).getDimensionData(analysis.sliceQuery);
+            await cached(breadboxAPI, { persist: true }).getDimensionData(
+              analysis.sliceQuery
+            );
             isSliceValid = true;
           } catch (e) {
             isSliceValid = false;

--- a/frontend/packages/@depmap/custom-analyses/src/utils/convertSliceQueryToDimension.ts
+++ b/frontend/packages/@depmap/custom-analyses/src/utils/convertSliceQueryToDimension.ts
@@ -1,4 +1,8 @@
-import { breadboxAPI, cached } from "@depmap/api";
+import {
+  breadboxAPI,
+  cached,
+  getDimensionTypeIdentifiersPersisted,
+} from "@depmap/api";
 import {
   isValidSliceQuery,
   SliceQuery,
@@ -37,9 +41,9 @@ async function convertSliceQueryToDimension(
     identifier_type !== "sample_label" &&
     identifier_type !== "feature_label"
   ) {
-    const allIdentifiers = await cached(
-      breadboxAPI
-    ).getDimensionTypeIdentifiers(slice_type);
+    const allIdentifiers = await getDimensionTypeIdentifiersPersisted(
+      slice_type
+    );
 
     const match = allIdentifiers.find(({ id }) => id === identifier);
     identifierLabel = match ? match.label : identifier;

--- a/frontend/packages/@depmap/custom-analyses/src/utils/getDataExplorerLink.ts
+++ b/frontend/packages/@depmap/custom-analyses/src/utils/getDataExplorerLink.ts
@@ -1,5 +1,5 @@
 import qs from "qs";
-import { breadboxAPI, cached } from "@depmap/api";
+import { breadboxAPI, cached, evaluateContextPersisted } from "@depmap/api";
 import { persistContext } from "@depmap/data-explorer-2";
 import { isPortal } from "@depmap/globals";
 import { ComputeResponseResult, DataExplorerContextV2 } from "@depmap/types";
@@ -29,9 +29,9 @@ async function getDataExplorerLink(
       ? await persistContext(filterByContext)
       : undefined;
 
-    const features = await cached(breadboxAPI).getDatasetFeatures(
-      sliceQuery.dataset_id
-    );
+    const features = await cached(breadboxAPI, {
+      persist: true,
+    }).getDatasetFeatures(sliceQuery.dataset_id);
 
     let identifierLabel = "";
 
@@ -68,10 +68,8 @@ async function getDataExplorerLink(
     if (outGroupContext) {
       color2 = await persistContext(outGroupContext);
 
-      const inGroup = await cached(breadboxAPI).evaluateContext(inGroupContext);
-      const outGroup = await cached(breadboxAPI).evaluateContext(
-        outGroupContext
-      );
+      const inGroup = await evaluateContextPersisted(inGroupContext);
+      const outGroup = await evaluateContextPersisted(outGroupContext);
 
       if (inGroup.ids.length + outGroup.ids.length < inGroup.num_candidates) {
         const combinedIds = [...new Set([...inGroup.ids, ...outGroup.ids])];

--- a/frontend/packages/@depmap/data-explorer-2/docs/adr/0008-persistent-api-cache-opt-in.md
+++ b/frontend/packages/@depmap/data-explorer-2/docs/adr/0008-persistent-api-cache-opt-in.md
@@ -1,0 +1,167 @@
+# ADR 0008 — Persisting API responses is a per-call-site assertion
+
+- **Status:** Accepted
+- **Applies to:** every consumer of `@depmap/api` — Data Explorer most of all, but the
+  decision is portal-wide. Recorded here because this is where design decisions live and
+  because new Data Explorer call sites are where the question will keep coming up.
+- **Key symbols:** `cached(api, { persist })`, `PersistOption`, `initDatasetRegistry`,
+  `buildPersistentKey`, `CACHE_VERSION`, `evaluateContextPersisted`,
+  `getDimensionTypeIdentifiersPersisted`, `getPersistentApiCacheInfo`
+
+---
+
+## Context
+
+`cached()` has always deduplicated requests in memory, for the life of a page. It now
+additionally supports persisting responses to IndexedDB, so they survive reloads. The
+whole design derives from one paragraph:
+
+> Breadbox never mutates dataset data in place. A new version of a dataset is a new row
+> with a new UUID, and `PATCH /datasets/{id}` changes metadata only — never data, never
+> the UUID. Therefore a response addressed by dataset UUID is immutable, and a cached
+> copy of it is valid forever.
+
+Consequently the engine (`@depmap/api/src/persistentApiCache.ts`) has **no invalidation
+logic** — no TTL, no revalidation, no version comparison on read. Everything a response
+depends on is folded into its _key_: a given_id (a mutable pointer to "latest") gets its
+resolved UUID appended, and declared deps are appended likewise, so when a dependency
+changes the key changes and the old entry is orphaned — a miss, never a wrong hit. LRU is
+the TTL. Only datasets in the public group are ever written, because IndexedDB is
+origin-global and user-agnostic (shared machines, logout, user switching). Until the
+entry points seed the registry from a fresh `getDatasets()`, the engine fails closed.
+
+A persistent cache is the first thing in this stack where "just reload" does not clear a
+bad state. Every rule below exists to keep wrong entries from being _written_, because
+nothing ages them out.
+
+## Decision
+
+**Persistence is opted into at each call site, and the opt-in is an assertion: "every
+dataset contributing to this response is named in the request or declared in `deps`."**
+
+```ts
+cached(breadboxAPI, { persist: true }).getMatrixDatasetData(id, args);
+```
+
+### 1. Why per-site, not per-method
+
+A method-name registry ("always persist `getMatrixDatasetData`") would cover today's
+call sites with six entries. It was rejected because the engine cannot always tell when
+the assertion is false. The canonical counterexample is `fetchAssociations`: its cache
+key contains a dataset address, but its response is assembled from
+`PrecomputedAssociation` rows with independent lifecycles plus label lookups against
+another dimension type's metadata — none of which is named in the request. A registry
+would silently persist every future call to a listed method, wherever it appears; a
+per-site option makes a human affirm the assertion each time.
+
+The accepted cost: **a new call site defaults to not persisting.** That is the safe
+direction. When you add a Data Explorer call site, decide explicitly.
+
+### 2. How to decide for a new call site
+
+- **The request names its dataset(s)** (matrix/tabular/features/samples/dimension-data
+  endpoints): add `{ persist: true }`. The engine independently verifies there is a
+  dataset address in the key and that every involved dataset is public; if not, it
+  quietly stays in-memory only.
+- **`evaluateContext`:** call `evaluateContextPersisted(context)` instead of
+  `cached(breadboxAPI).evaluateContext(context)`. The var `dataset_id`s are already in
+  the key (the POST body is the key); the helper declares the _implicit_ dependencies —
+  the metadata dataset behind the context's `dimension_type`, and nested contexts',
+  recursively — and bails to plain in-memory caching when it can't enumerate them
+  (`reindex_through`, a type with no metadata dataset, or a malformed tree). The bail
+  path must never throw: interactive editors (Context Builder) evaluate
+  partially-built contexts with holes and undefined nested entries, and the plain
+  call this wraps would have sent those to the server and let them fail there.
+- **Unfiltered `getDimensionTypeIdentifiers`:** call
+  `getDimensionTypeIdentifiersPersisted(name)`. Its response depends only on the
+  dimension type's metadata dataset, which Breadbox guarantees is public and gets a new
+  UUID on every content change — so the declared dep is exact.
+- **Filtered `getDimensionTypeIdentifiers`** (`data_type`,
+  `show_only_dimensions_in_datasets`): **never persist.** The backend filters through
+  the _user's_ accessible datasets, so the response is per-user. Keep plain `cached()`.
+- **Never persist:** `fetchAssociations` (see above), `getContextDatasetCoverage`
+  (next bullet), `getTaskStatus` (mutable by nature), and the bootstrap methods
+  `getDatasets` / `getDimensionTypes` / `getDataset`. The last three are not merely
+  "not worth it": the correctness argument
+  _requires_ `getDatasets` to be fresh every load (it seeds the registry and populates
+  pickers — deletion handling exists only because of this), `getDimensionTypes` is the
+  source the persisted helpers resolve deps from, and `getDataset` returns metadata
+  that is PATCH-able under a stable UUID.
+- **`getContextDatasetCoverage` is the sharpest counterexample on record.** Its
+  request is the same Context body `evaluateContext` takes and it runs the same
+  evaluator, so the analogy invites "upgrading" it to a persisted helper someday.
+  Don't. The assertion fails on the _response_ side, twice over. First, coverage is
+  computed across the caller's entire accessible catalog — datasets named nowhere in
+  the request — and user identity arrives via proxy headers the cache key can never
+  see; the enumerated dataset ids would disclose private datasets' existence to the
+  next user of a shared store. Second, its answer depends on what exists _right now_:
+  datasets are uploaded at runtime, between deploys, where the epoch offers no
+  protection, so even a public-only variant would serve coverage that silently omits
+  new datasets. Plain in-memory `cached()` is exactly right for it — a page belongs
+  to one user and one moment in catalog time, which are the two dimensions the
+  persistent key cannot express.
+
+Misclassifying in the safe direction (not persisting something immutable) costs a cache
+hit. Misclassifying in the unsafe direction is the only real hazard, and the engine's
+refusal checks cannot catch every case — that is precisely why the opt-in is a human
+assertion.
+
+### 3. The kill switch
+
+The epoch is `v${CACHE_VERSION}:bb${breadboxVersion}`, compared once per page load; any
+mismatch wipes the whole store.
+
+- The **Breadbox app version** (from `GET /health_check/basic`, auto-bumped by
+  commitizen on every `feat`/`fix(breadbox)` commit) handles backend changes
+  automatically: if the server code that produced the cached bytes changed, the cache
+  is gone on next load. A change to response _semantics under an identical request_
+  (e.g. how an aggregation is computed) is covered as long as it ships as a
+  version-bumping commit type.
+- **`CACHE_VERSION`** in `persistentApiCache.ts` is the manual knob for frontend-side
+  cache fixes: key-scheme changes, deps-computation bugs, anything that may have
+  _written_ bad entries. Bump it in the same commit as the fix.
+- There is deliberately **no feature flag and no operator value**. Rollback is
+  reverting the code; frontend-only deploys leave caches warm.
+
+Rule of thumb: _same request, different answer → something must bump; different
+request → the key already did the work._
+
+### 4. Traps that are already contained (do not "simplify" them away)
+
+- The ambient `cacheOn`/`cacheOff` context is dynamic scoping. It works because every
+  layer between the decorator and `getJson`/`postJson` is synchronous up to the point
+  the request is issued, and `createJsonClient` captures the context into a local
+  before any `await`. Keep it that way.
+- `evaluateContext` has a client-side fast path that issues
+  `getTabularDatasetData`/`getDimensionTypeIdentifiers` before its first `await`, so
+  those inner calls inherit the outer persist context. This is safe _because_
+  eligibility is judged per-request from each call's own key, not from what the outer
+  call claimed — and it is where much of `evaluateContextPersisted`'s value lives, since
+  locally-evaluated contexts make no `/temp/context` round trip at all.
+- A plain `cached(api)` call maps to a context of `{ persist: undefined }`, never
+  `null` — `null` means "not inside `cached()` at all" and disables the in-memory
+  cache entirely. (This was once wrong, and every non-persisted request on every page
+  refetched on each use.)
+- The entry points call `initDatasetRegistry` synchronously with the _pending_
+  `getDatasets()` promise, not the resolved listing. The engine's init promise must
+  exist before the page's first persisted request; otherwise every request issued
+  during that round trip sees an uninitialized engine and refuses — silently, on
+  every load, which is how it originally shipped. `refusedNotReady` climbing is the
+  symptom.
+- The seed goes through `cached(breadboxAPI).getDatasets()` so it shares one request
+  (and one listing) with every app caller. That is safe only while `getDatasets`
+  never gains a `persist` option: a persisted call awaits the registry this very
+  promise seeds, which would deadlock. An earlier comment called the shared form
+  "circular" outright — the circularity is real only for the persisted path, which
+  the never-persist rule above already forbids.
+
+## Consequences
+
+- New Data Explorer fetches get cross-reload caching by adding one option or calling
+  one helper — but only if the author remembers; the default is in-memory only.
+- `getPersistentApiCacheInfo()` (importable from `@depmap/api`, callable in a console)
+  reports hit/miss/eviction/refusal counters; the `refused*` stats are the first place
+  to look when an expected persist isn't happening.
+- Tests live in `@depmap/api/src/__tests__/` and pin the refusal branches, key
+  augmentation, LRU/quota behavior, epoch wipes, and the helpers' bail conditions. The
+  engine holds module-level state; use `__resetForTests()` when testing against it.

--- a/frontend/packages/@depmap/data-explorer-2/jest-setup.ts
+++ b/frontend/packages/@depmap/data-explorer-2/jest-setup.ts
@@ -56,21 +56,33 @@ const createApiMock = (
   });
 };
 
-jest.mock("@depmap/api", () => ({
-  cached: (api: unknown) => api,
-
-  legacyPortalAPI: createApiMock(
-    "Portal API",
-    "legacyPortalAPI",
-    portalApiProxyTarget
-  ),
-
-  breadboxAPI: createApiMock(
+jest.mock("@depmap/api", () => {
+  const breadboxAPI = createApiMock(
     "Breadbox API",
     "breadboxAPI",
     breadboxApiProxyTarget
-  ),
-}));
+  ) as Record<string, (...args: unknown[]) => unknown>;
+
+  return {
+    cached: (api: unknown) => api,
+
+    legacyPortalAPI: createApiMock(
+      "Portal API",
+      "legacyPortalAPI",
+      portalApiProxyTarget
+    ),
+
+    breadboxAPI,
+
+    // The persisted wrappers delegate to the mocked breadboxAPI so tests mock
+    // the underlying method exactly as they would for a direct call.
+    evaluateContextPersisted: (context: unknown) =>
+      breadboxAPI.evaluateContext(context),
+
+    getDimensionTypeIdentifiersPersisted: (dimTypeName: string) =>
+      breadboxAPI.getDimensionTypeIdentifiers(dimTypeName),
+  };
+});
 
 afterEach(() => {
   for (const key of Object.keys(portalApiProxyTarget)) {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/hooks/useMatches.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextBuilderV2/hooks/useMatches.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { breadboxAPI, cached } from "@depmap/api";
+import { evaluateContextPersisted } from "@depmap/api";
 import {
   DataExplorerContextExpression,
   DataExplorerContextV2,
@@ -64,7 +64,7 @@ function useMatches(expr: Expr) {
 
     (async () => {
       try {
-        const result = await cached(breadboxAPI).evaluateContext(
+        const result = await evaluateContextPersisted(
           simplifyVarNames({
             dimension_type,
             expr: flattenExpr(expr) as DataExplorerContextExpression,

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextManager/showDownloadContextModal.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextManager/showDownloadContextModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { breadboxAPI, cached } from "@depmap/api";
+import { evaluateContextPersisted } from "@depmap/api";
 import { showInfoModal } from "@depmap/common-components";
 import SliceTable from "@depmap/slice-table";
 import { isV2Context } from "../../utils/context";
@@ -35,9 +35,7 @@ function DownloadTable({
         context = await convertContextV1toV2(context);
       }
 
-      const { ids, num_candidates } = await cached(breadboxAPI).evaluateContext(
-        context
-      );
+      const { ids, num_candidates } = await evaluateContextPersisted(context);
       setContextIds(new Set(ids));
       setTotal(num_candidates);
     })();

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextSelectorV2/promptForParentContext.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextSelectorV2/promptForParentContext.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from "react";
-import { breadboxAPI, cached } from "@depmap/api";
+import { breadboxAPI, cached, evaluateContextPersisted } from "@depmap/api";
 import {
   promptForValue,
   PromptComponentProps,
@@ -179,7 +179,7 @@ export default async function promptForParentContext(
         let ids: string[];
 
         try {
-          ({ ids } = await cached(breadboxAPI).evaluateContext(nextContext));
+          ({ ids } = await evaluateContextPersisted(nextContext));
         } catch (e) {
           window.console.error(e);
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/ContextSelectorV2/useChangeHandler.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/ContextSelectorV2/useChangeHandler.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { breadboxAPI, cached } from "@depmap/api";
+import { evaluateContextPersisted } from "@depmap/api";
 import { getConfirmation, showInfoModal } from "@depmap/common-components";
 import { DepMap } from "@depmap/globals";
 import { DataExplorerContext, DataExplorerContextV2 } from "@depmap/types";
@@ -84,9 +84,7 @@ const handleDefaultCase = async (
     let success = false;
 
     try {
-      const result = await cached(breadboxAPI).evaluateContext(
-        convertedContext
-      );
+      const result = await evaluateContextPersisted(convertedContext);
       success = result.ids.length > 0;
     } catch (e) {
       success = false;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/AnalysisResult.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/AnalysisResult.tsx
@@ -211,9 +211,10 @@ function AnalysisResult({ plot, dispatch }: Props) {
                 const vars: Record<string, object> = {};
 
                 if (sliceType !== null) {
-                  const bb = cached(breadboxAPI);
-                  const datasets = await bb.getDatasets();
-                  const dimTypes = await bb.getDimensionTypes();
+                  const datasets = await cached(breadboxAPI).getDatasets();
+                  const dimTypes = await cached(
+                    breadboxAPI
+                  ).getDimensionTypes();
                   const metadataDataset = resolveMetadataGivenId(
                     sliceType,
                     dimTypes,

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/PrecomputedAssociations/useLabelToIdMap.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/PrecomputedAssociations/useLabelToIdMap.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { breadboxAPI, cached } from "@depmap/api";
+import { getDimensionTypeIdentifiersPersisted } from "@depmap/api";
 
 // Builds a label → id map for a given dimension type. Used by
 // `PrecomputedAssociations` to resolve a legacy `entity_label`-style
@@ -17,17 +17,15 @@ function useLabelToIdMap(dimension_type: string | undefined) {
       return;
     }
 
-    cached(breadboxAPI)
-      .getDimensionTypeIdentifiers(dimension_type)
-      .then((identifiers) => {
-        const map: Record<string, string> = {};
+    getDimensionTypeIdentifiersPersisted(dimension_type).then((identifiers) => {
+      const map: Record<string, string> = {};
 
-        identifiers.forEach(({ id, label }) => {
-          map[label] = id;
-        });
-
-        setMapping(map);
+      identifiers.forEach(({ id, label }) => {
+        map[label] = id;
       });
+
+      setMapping(map);
+    });
   }, [dimension_type]);
 
   return mapping;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/promptForExpansionMembers.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/promptForExpansionMembers.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from "react";
-import { breadboxAPI, cached } from "@depmap/api";
+import { evaluateContextPersisted } from "@depmap/api";
 import {
   promptForValue,
   PromptComponentProps,
@@ -409,7 +409,7 @@ export default async function promptForExpansionMembers({
   PlotlyLoader: ReturnType<typeof usePlotlyLoader>;
 }): Promise<ExpansionMembersChoice | undefined> {
   const [{ ids }, cap] = await Promise.all([
-    cached(breadboxAPI).evaluateContext(context),
+    evaluateContextPersisted(context),
     maxExpansionMembersFor(index_type, dataset_id),
   ]);
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/promptForSelectionFromContext.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/promptForSelectionFromContext.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { breadboxAPI, cached } from "@depmap/api";
+import { evaluateContextPersisted } from "@depmap/api";
 import {
   promptForValue,
   PromptComponentProps,
@@ -10,7 +10,7 @@ import { DepMap } from "@depmap/globals";
 import { DataExplorerContextV2, DataExplorerPlotResponse } from "@depmap/types";
 
 const resolveToIds = async (context: DataExplorerContextV2) => {
-  const result = await cached(breadboxAPI).evaluateContext(context);
+  const result = await evaluateContextPersisted(context);
   return result.ids;
 };
 
@@ -75,10 +75,7 @@ export default async function promptForSelectionFromContext(
 
         const hiddenByFilters = data.index_ids
           .map((id, i) => {
-            return [
-              id,
-              datasetIds.has(id) && filter ? filter.values[i] : true,
-            ];
+            return [id, datasetIds.has(id) && filter ? filter.values[i] : true];
           })
           .filter(([id]) => contextIds.has(id as string))
           .filter(([, visible]) => !visible).length;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/api-helpers.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/api-helpers.ts
@@ -37,8 +37,12 @@ export async function fetchDatasetIdentifiers(
   }
 
   const result = isFeature
-    ? await cached(breadboxAPI).getDatasetFeatures(dataset_id)
-    : await cached(breadboxAPI).getDatasetSamples(dataset_id);
+    ? await cached(breadboxAPI, { persist: true }).getDatasetFeatures(
+        dataset_id
+      )
+    : await cached(breadboxAPI, { persist: true }).getDatasetSamples(
+        dataset_id
+      );
 
   if ("detail" in result) {
     throw new Error(JSON.stringify(result.detail));

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/breadboxMethods.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/breadboxMethods.ts
@@ -1,4 +1,9 @@
-import { breadboxAPI, cached } from "@depmap/api";
+import {
+  breadboxAPI,
+  cached,
+  evaluateContextPersisted,
+  getDimensionTypeIdentifiersPersisted,
+} from "@depmap/api";
 import {
   correlationMatrix,
   linregress,
@@ -77,7 +82,7 @@ export async function fetchAxisLabel(
 
   const { aggregation } = dimension;
 
-  const { ids } = await cached(breadboxAPI).evaluateContext(
+  const { ids } = await evaluateContextPersisted(
     (context as unknown) as DataExplorerContextV2
   );
 
@@ -387,7 +392,7 @@ export async function fetchPlotDimensions(
     let ids: string[] = [];
 
     try {
-      const result = await cached(breadboxAPI).evaluateContext(
+      const result = await evaluateContextPersisted(
         (context as unknown) as DataExplorerContextV2
       );
 
@@ -404,16 +409,15 @@ export async function fetchPlotDimensions(
       dataset_id
     );
 
-    const response = await cached(breadboxAPI).getMatrixDatasetData(
-      dataset_id,
-      {
-        sample_identifier: "id",
-        feature_identifier: "id",
-        samples: aggregate_by === "samples" ? ids : null,
-        features: aggregate_by === "features" ? ids : null,
-        aggregate: { aggregate_by, aggregation },
-      }
-    );
+    const response = await cached(breadboxAPI, {
+      persist: true,
+    }).getMatrixDatasetData(dataset_id, {
+      sample_identifier: "id",
+      feature_identifier: "id",
+      samples: aggregate_by === "samples" ? ids : null,
+      features: aggregate_by === "features" ? ids : null,
+      aggregate: { aggregate_by, aggregation },
+    });
 
     const indexed_values = {} as Record<string, number | null>;
 
@@ -441,8 +445,7 @@ export async function fetchPlotDimensions(
     ...filterKeys.map((key) => {
       const filter = (filters![key] as unknown) as DataExplorerContextV2;
 
-      return cached(breadboxAPI)
-        .evaluateContext(filter)
+      return evaluateContextPersisted(filter)
         .then((result) => {
           const indexed_values: Record<string, true> = {};
 
@@ -578,9 +581,9 @@ export async function fetchPlotDimensions(
           return;
         }
 
-        const identifiers = await cached(
-          breadboxAPI
-        ).getDimensionTypeIdentifiers(dimTypeName);
+        const identifiers = await getDimensionTypeIdentifiersPersisted(
+          dimTypeName
+        );
 
         metadataIdToLabel[key] = Object.fromEntries(
           identifiers.map(({ id, label }) => [id, label])
@@ -996,10 +999,8 @@ const correlateDimension = memoize(
       filterIdentifiers,
       dataset_label,
     ] = await Promise.all([
-      cached(breadboxAPI).evaluateContext(
-        (context as unknown) as DataExplorerContextV2
-      ),
-      filter ? cached(breadboxAPI).evaluateContext(filter) : null,
+      evaluateContextPersisted((context as unknown) as DataExplorerContextV2),
+      filter ? evaluateContextPersisted(filter) : null,
       fetchDatasetLabel(dataset_id),
     ]);
 
@@ -1035,10 +1036,9 @@ const correlateDimension = memoize(
           : filterIdentifiers?.labels || null,
     };
 
-    const response = await cached(breadboxAPI).getMatrixDatasetData(
-      dataset_id,
-      requestParams
-    );
+    const response = await cached(breadboxAPI, {
+      persist: true,
+    }).getMatrixDatasetData(dataset_id, requestParams);
     let data = {} as Record<string, number[]>;
 
     // The /datasets/matrix/<id> endpoint always returns an object where features

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/expandedPlot.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/expandedPlot.ts
@@ -1,4 +1,9 @@
-import { breadboxAPI, cached } from "@depmap/api";
+import {
+  breadboxAPI,
+  cached,
+  evaluateContextPersisted,
+  getDimensionTypeIdentifiersPersisted,
+} from "@depmap/api";
 import {
   DataExplorerContextV2,
   DataExplorerContextVariable,
@@ -148,9 +153,10 @@ export async function fetchExpandedPlot(
 
   // Resolve the expansion list once. For gene/transcript this is e.g.
   // "transcripts of CD44" → ids + labels of length M.
-  const { ids: allExpIds, labels: allExpLabels } = await cached(
-    breadboxAPI
-  ).evaluateContext(expansionContext);
+  const {
+    ids: allExpIds,
+    labels: allExpLabels,
+  } = await evaluateContextPersisted(expansionContext);
 
   if (allExpIds.length === 0) {
     throw new Error(
@@ -379,15 +385,14 @@ export async function fetchExpandedPlot(
       dataset_id
     );
 
-    const response = await cached(breadboxAPI).getMatrixDatasetData(
-      dataset_id,
-      {
-        sample_identifier: "id",
-        feature_identifier: "id",
-        samples: sliceIsSampleType ? expIds : null,
-        features: sliceIsSampleType ? null : expIds,
-      }
-    );
+    const response = await cached(breadboxAPI, {
+      persist: true,
+    }).getMatrixDatasetData(dataset_id, {
+      sample_identifier: "id",
+      feature_identifier: "id",
+      samples: sliceIsSampleType ? expIds : null,
+      features: sliceIsSampleType ? null : expIds,
+    });
 
     // Matrix responses are always Record<feature_id, Record<sample_id, value>>:
     //   - expansion-on-feature-axis: response[expId][indexId]
@@ -565,7 +570,7 @@ export async function fetchExpandedPlot(
 
     let ctxIds: string[] = [];
     try {
-      const result = await cached(breadboxAPI).evaluateContext(
+      const result = await evaluateContextPersisted(
         (context as unknown) as DataExplorerContextV2
       );
       ctxIds = result.ids;
@@ -581,16 +586,15 @@ export async function fetchExpandedPlot(
       dataset_id
     );
 
-    const response = await cached(breadboxAPI).getMatrixDatasetData(
-      dataset_id,
-      {
-        sample_identifier: "id",
-        feature_identifier: "id",
-        samples: aggregate_by === "samples" ? ctxIds : null,
-        features: aggregate_by === "features" ? ctxIds : null,
-        aggregate: { aggregate_by, aggregation },
-      }
-    );
+    const response = await cached(breadboxAPI, {
+      persist: true,
+    }).getMatrixDatasetData(dataset_id, {
+      sample_identifier: "id",
+      feature_identifier: "id",
+      samples: aggregate_by === "samples" ? ctxIds : null,
+      features: aggregate_by === "features" ? ctxIds : null,
+      aggregate: { aggregate_by, aggregation },
+    });
 
     const indexed_values: Record<string, number | null> = {};
     indexIdentifiers.forEach(({ id }) => {
@@ -607,7 +611,7 @@ export async function fetchExpandedPlot(
     const filter = (filters![filterKey] as unknown) as DataExplorerContextV2;
 
     try {
-      const result = await cached(breadboxAPI).evaluateContext(filter);
+      const result = await evaluateContextPersisted(filter);
 
       const indexed_values: Record<string, true> = {};
       for (let i = 0; i < result.ids.length; i += 1) {
@@ -822,7 +826,7 @@ export async function fetchExpandedPlot(
           ? dataset.feature_type_name
           : dataset.sample_type_name;
       if (!dimTypeName) return;
-      const identifiers = await cached(breadboxAPI).getDimensionTypeIdentifiers(
+      const identifiers = await getDimensionTypeIdentifiersPersisted(
         dimTypeName
       );
       metadataIdToLabel[key] = Object.fromEntries(

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/expansionMembers.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/expansionMembers.ts
@@ -1,4 +1,4 @@
-import { breadboxAPI, cached } from "@depmap/api";
+import { breadboxAPI, cached, evaluateContextPersisted } from "@depmap/api";
 import { DataExplorerContextV2 } from "@depmap/types";
 import { isSampleType } from "../../utils/misc";
 import { fetchDatasetIdentifiers } from "./identifiers";
@@ -253,7 +253,7 @@ async function resolveRankingIndex(
     return indexIds;
   }
 
-  const { ids } = await cached(breadboxAPI).evaluateContext(visibleFilter);
+  const { ids } = await evaluateContextPersisted(visibleFilter);
   const visible = new Set(ids);
   const narrowed = indexIds.filter((id) => visible.has(id));
 
@@ -308,7 +308,9 @@ export async function fetchExpansionMemberStats({
     visibleFilter
   );
 
-  const response = await cached(breadboxAPI).getMatrixDatasetData(dataset_id, {
+  const response = await cached(breadboxAPI, {
+    persist: true,
+  }).getMatrixDatasetData(dataset_id, {
     sample_identifier: "id",
     feature_identifier: "id",
     // Members sit on the slice axis, the cohort on the other one.

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/helpers.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/helpers.ts
@@ -14,17 +14,18 @@ export async function getDimensionDataWithoutLabels(slice: SliceQuery) {
   // need, but chain queries are metadata/annotation columns in practice — not
   // 100K-element transcript slices — so the overhead is acceptable.
   if (slice.reindex_through) {
-    const { ids, values } = await cached(breadboxAPI).getDimensionData(slice);
+    const { ids, values } = await cached(breadboxAPI, {
+      persist: true,
+    }).getDimensionData(slice);
     return { ids, values };
   }
 
   if (slice.identifier_type === "column") {
-    const wrapper = await cached(breadboxAPI).getTabularDatasetData(
-      slice.dataset_id,
-      {
-        columns: [slice.identifier],
-      }
-    );
+    const wrapper = await cached(breadboxAPI, {
+      persist: true,
+    }).getTabularDatasetData(slice.dataset_id, {
+      columns: [slice.identifier],
+    });
 
     const indexedData = wrapper[slice.identifier];
 
@@ -41,14 +42,13 @@ export async function getDimensionDataWithoutLabels(slice: SliceQuery) {
   }
 
   if (["feature_id", "feature_label"].includes(slice.identifier_type)) {
-    const features = await cached(breadboxAPI).getMatrixDatasetData(
-      slice.dataset_id,
-      {
-        feature_identifier:
-          slice.identifier_type === "feature_id" ? "id" : "label",
-        features: [slice.identifier],
-      }
-    );
+    const features = await cached(breadboxAPI, {
+      persist: true,
+    }).getMatrixDatasetData(slice.dataset_id, {
+      feature_identifier:
+        slice.identifier_type === "feature_id" ? "id" : "label",
+      features: [slice.identifier],
+    });
 
     if (Object.keys(features).length === 0) {
       return { ids: [] as string[], values: [] as any[] };
@@ -66,14 +66,12 @@ export async function getDimensionDataWithoutLabels(slice: SliceQuery) {
   }
 
   if (["sample_id", "sample_label"].includes(slice.identifier_type)) {
-    const features = await cached(breadboxAPI).getMatrixDatasetData(
-      slice.dataset_id,
-      {
-        sample_identifier:
-          slice.identifier_type === "sample_id" ? "id" : "label",
-        samples: [slice.identifier],
-      }
-    );
+    const features = await cached(breadboxAPI, {
+      persist: true,
+    }).getMatrixDatasetData(slice.dataset_id, {
+      sample_identifier: slice.identifier_type === "sample_id" ? "id" : "label",
+      samples: [slice.identifier],
+    });
 
     if (Object.keys(features).length === 0) {
       return { ids: [] as string[], values: [] as any[] };

--- a/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/identifiers.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/services/dataExplorerAPI/identifiers.ts
@@ -12,8 +12,8 @@ export async function fetchDatasetIdentifiers(
   }
 
   return dimType.axis === "feature"
-    ? cached(breadboxAPI).getDatasetFeatures(dataset_id)
-    : cached(breadboxAPI).getDatasetSamples(dataset_id);
+    ? cached(breadboxAPI, { persist: true }).getDatasetFeatures(dataset_id)
+    : cached(breadboxAPI, { persist: true }).getDatasetSamples(dataset_id);
 }
 
 export async function fetchDimensionIdentifiers(

--- a/frontend/packages/@depmap/data-explorer-2/src/utils/expansionRoutes.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/expansionRoutes.ts
@@ -1,4 +1,8 @@
-import { breadboxAPI, cached } from "@depmap/api";
+import {
+  breadboxAPI,
+  cached,
+  getDimensionTypeIdentifiersPersisted,
+} from "@depmap/api";
 import { DataExplorerContextV2 } from "@depmap/types";
 import { capitalize, getDimensionTypeLabel, pluralize } from "./misc";
 
@@ -365,7 +369,7 @@ export async function resolveParentLabel(
     return selection;
   }
 
-  const identifiers = await cached(breadboxAPI).getDimensionTypeIdentifiers(
+  const identifiers = await getDimensionTypeIdentifiersPersisted(
     route.parentType
   );
 

--- a/frontend/packages/@depmap/selects/src/components/SliceSelect/api-helpers.ts
+++ b/frontend/packages/@depmap/selects/src/components/SliceSelect/api-helpers.ts
@@ -30,8 +30,12 @@ export async function fetchDatasetIdentifiers(
   const isFeature = dimType.axis === "feature";
 
   const result = isFeature
-    ? await cached(breadboxAPI).getDatasetFeatures(dataset_id)
-    : await cached(breadboxAPI).getDatasetSamples(dataset_id);
+    ? await cached(breadboxAPI, { persist: true }).getDatasetFeatures(
+        dataset_id
+      )
+    : await cached(breadboxAPI, { persist: true }).getDatasetSamples(
+        dataset_id
+      );
 
   if ("detail" in result) {
     throw new Error(JSON.stringify(result.detail));
@@ -45,7 +49,9 @@ export async function fetchDatasetIdentifiers(
  * Used by DatasetSpecificSliceSelect where the dataset's features are generic.
  */
 export async function fetchDatasetFeatures(dataset_id: string) {
-  const result = await cached(breadboxAPI).getDatasetFeatures(dataset_id);
+  const result = await cached(breadboxAPI, {
+    persist: true,
+  }).getDatasetFeatures(dataset_id);
 
   if ("detail" in result) {
     throw new Error(JSON.stringify(result.detail));

--- a/frontend/packages/@depmap/slice-table/src/__tests__/transformToTableData.test.ts
+++ b/frontend/packages/@depmap/slice-table/src/__tests__/transformToTableData.test.ts
@@ -164,6 +164,74 @@ describe("transformToTableData", () => {
 
     expect(consoleErrorSpy).not.toHaveBeenCalled();
   });
+
+  it("stubs a column whose dataset no longer exists instead of throwing", () => {
+    const labelResponse: SliceResponse = {
+      ids: ["A", "B"],
+      labels: ["A", "B"],
+      values: ["alpha", "beta"],
+    };
+    const emptyResponse: SliceResponse = { ids: [], labels: [], values: [] };
+
+    const deadSlice: SliceQuery = {
+      dataset_id: "retired_ds",
+      identifier_type: "column",
+      identifier: "old_score",
+    };
+
+    const { data, columns } = transformToTableData(
+      [labelResponse, emptyResponse],
+      ["label", "old_score"],
+      [labelSlice, deadSlice],
+      undefined,
+      datasets, // does not contain "retired_ds"
+      indexType,
+      "antibody_id",
+      "label",
+      {}
+    );
+
+    // The table still renders: full row set, stub column present.
+    expect(data).toHaveLength(2);
+
+    const stub = columns.find((c) => c.meta.idLabel === "old_score")!;
+    expect(stub.meta.loadFailure).toBe("dataset_removed");
+    // Editable so the existing "Remove column" affordances work on it.
+    expect(stub.meta.isEditable).toBe(true);
+    expect(stub.meta.isViewable).toBe(false);
+    // Opted out of CSV export.
+    expect(stub.meta.csvHeader).toBe("");
+    // Cells are coverage holes, not values.
+    expect(data[0][stub.id]).toBeUndefined();
+  });
+
+  it("stubs a column marked fetch_failed, keeping its dataset name", () => {
+    const labelResponse: SliceResponse = {
+      ids: ["A", "B"],
+      labels: ["A", "B"],
+      values: ["alpha", "beta"],
+    };
+    const emptyResponse: SliceResponse = { ids: [], labels: [], values: [] };
+
+    const { columns } = transformToTableData(
+      [labelResponse, emptyResponse],
+      ["label", "Score"],
+      [labelSlice, dataSlice],
+      undefined,
+      datasets,
+      indexType,
+      "antibody_id",
+      "label",
+      {},
+      undefined,
+      [null, "fetch_failed"]
+    );
+
+    const stub = columns.find((c) => c.meta.idLabel === "Score")!;
+    expect(stub.meta.loadFailure).toBe("fetch_failed");
+    // The dataset still exists, so its name is still shown.
+    expect(stub.meta.datasetName).toBe("Data");
+  });
 });
 
 describe("resolveDisplayLabel", () => {

--- a/frontend/packages/@depmap/slice-table/src/components/chooseDataSlice/AddColumnDimensionSelect.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/chooseDataSlice/AddColumnDimensionSelect.tsx
@@ -37,12 +37,16 @@ async function convertSliceQueryToDataExplorerDimension(
 
   if (identifier_type.startsWith("feature")) {
     slice_type = dataset.feature_type_name;
-    const features = await cached(breadboxAPI).getDatasetFeatures(dataset_id);
+    const features = await cached(breadboxAPI, {
+      persist: true,
+    }).getDatasetFeatures(dataset_id);
     name =
       features.find((f) => f[idOrLabel] === identifier)?.label || "unknown";
   } else {
     slice_type = dataset.sample_type_name;
-    const samples = await cached(breadboxAPI).getDatasetSamples(dataset_id);
+    const samples = await cached(breadboxAPI, {
+      persist: true,
+    }).getDatasetSamples(dataset_id);
     name = samples.find((f) => f[idOrLabel] === identifier)?.label || "unknown";
   }
 

--- a/frontend/packages/@depmap/slice-table/src/components/useData.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/useData.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useState, useRef, useCallback } from "react";
-import { breadboxAPI, cached } from "@depmap/api";
+import {
+  breadboxAPI,
+  cached,
+  getDimensionTypeIdentifiersPersisted,
+} from "@depmap/api";
 import { ExternalLink, WordBreaker } from "@depmap/common-components";
 import { isPortal, toPortalLink } from "@depmap/globals";
 import { serializeSliceQuery } from "@depmap/selects";
@@ -36,6 +40,15 @@ export type SliceResponse = {
 };
 type ColumnRenames = Record<string, string>;
 
+// Why a slice column has no data. "dataset_removed" means the dataset no
+// longer appears in the listing (a remembered column outliving a Breadbox
+// release that retired its dataset, most commonly) and the column can never
+// load again. "fetch_failed" means the dataset exists but its request failed,
+// which may well be transient. The distinction drives the UI: a removed
+// dataset's column offers removal inline; a transient failure does not, so
+// users aren't trained to delete columns that would come back on reload.
+export type SliceLoadFailure = "dataset_removed" | "fetch_failed";
+
 export interface RowFilters {
   hideUnselectedRows: boolean;
   hideIncompleteRows: boolean;
@@ -56,6 +69,7 @@ interface AlignedData {
       sliceQuery: SliceQuery;
       isEditable: boolean;
       isViewable: boolean;
+      loadFailure?: SliceLoadFailure;
       numericPrecision?: number;
       headerMenuItems?: (
         | {
@@ -240,7 +254,7 @@ function buildSlicesToFetch(
  * the backend's dimension data endpoint.
  */
 function createDataFetchPromise(slice: SliceQuery): Promise<SliceResponse> {
-  return cached(breadboxAPI).getDimensionData(slice);
+  return cached(breadboxAPI, { persist: true }).getDimensionData(slice);
 }
 
 /**
@@ -299,12 +313,31 @@ async function resolveLeafLabel(slice: SliceQuery): Promise<string> {
 
   const isFeatureAxis = slice.identifier_type.startsWith("feature");
   const metadata = isFeatureAxis
-    ? await cached(breadboxAPI).getDatasetFeatures(slice.dataset_id)
-    : await cached(breadboxAPI).getDatasetSamples(slice.dataset_id);
+    ? await cached(breadboxAPI, { persist: true }).getDatasetFeatures(
+        slice.dataset_id
+      )
+    : await cached(breadboxAPI, { persist: true }).getDatasetSamples(
+        slice.dataset_id
+      );
 
   const idOrLabel = slice.identifier_type.endsWith("_id") ? "id" : "label";
   const match = metadata.find((item) => item[idOrLabel] === slice.identifier);
   return match?.label || slice.identifier;
+}
+
+// What resolveDisplayLabel would show, minus any lookups: raw identifiers
+// only. Used for slices that failed to load, where a metadata fetch would
+// just be another doomed request.
+function fallbackDisplayLabel(slice: SliceQuery): string {
+  const hops: string[] = [];
+  let current = slice.reindex_through;
+
+  while (current) {
+    hops.push(current.identifier);
+    current = current.reindex_through;
+  }
+
+  return [...hops.reverse(), slice.identifier].join(" › ");
 }
 
 const truncateMiddle = (str: string, maxLength = 45): string => {
@@ -341,7 +374,10 @@ export function transformToTableData(
   idColumnDisplayName: string,
   labelColumnDisplayName: string,
   idToLabelMappings: Record<string, Record<string, string>>,
-  getColumnDisplayOptions?: Parameters["getColumnDisplayOptions"]
+  getColumnDisplayOptions?: Parameters["getColumnDisplayOptions"],
+  // Aligned with `slices`. A failed slice gets a stub column (header names
+  // the problem, cells stay empty) rather than failing the whole table.
+  failures?: (SliceLoadFailure | null)[]
 ) {
   // Step 1: Create unique column keys, validate IDs, and key data by ID.
   //
@@ -466,7 +502,51 @@ export function transformToTableData(
       (d) => d.given_id === slice.dataset_id || d.id === slice.dataset_id
     );
 
+    // A slice can outlive its dataset (a remembered column pointing at a
+    // dataset retired by a newer Breadbox release). Render a stub column
+    // instead of failing the whole table: the header names the problem, and
+    // the removal affordances still work because the stub keeps its
+    // sliceQuery.
+    const loadFailure =
+      failures?.[index] ?? (dataset ? null : ("dataset_removed" as const));
+
+    if (loadFailure) {
+      const failureLabel = displayLabel || slice.identifier;
+
+      return {
+        size: undefined as number | undefined,
+        id: columnKey,
+        meta: {
+          isEditable: columnKey !== "label" && !viewOnlySlices?.has(slice),
+          isViewable: false,
+          idLabel: failureLabel,
+          units: "",
+          value_type: null,
+          datasetName: dataset?.name || "",
+          // An empty csvHeader opts the column out of CSV export.
+          csvHeader: "",
+          sliceQuery: slice,
+          loadFailure,
+        },
+        accessorFn: (row: Record<string, unknown>) => row[columnKey],
+        header: () => (
+          <div>
+            <WordBreaker text={truncateMiddle(failureLabel)} />
+            <br />
+            <i>
+              {loadFailure === "dataset_removed"
+                ? "dataset no longer available"
+                : "failed to load"}
+            </i>
+          </div>
+        ),
+        cell: () => <></>,
+      };
+    }
+
     if (!dataset) {
+      // Unreachable (a missing dataset is classified as a failure above);
+      // this exists so TypeScript can narrow `dataset` below.
       throw new Error(`Unknown dataset "${slice.dataset_id}"`);
     }
 
@@ -611,7 +691,12 @@ export default function useAlignedData({
   const [state, setState] = useState<AlignedData>({
     columns: [],
     data: [],
-    loading: false,
+    // True from the start: the mount effect always begins a load, but effects
+    // run after the first paint, so initializing to false painted one frame
+    // of "There are no rows to display" before the spinner. That frame was
+    // invisible when every load took a network round trip; with persistent-
+    // cache hits it can be most of what the user sees.
+    loading: true,
     error: null,
     entityLabel: "",
     exportToCsv: () => "",
@@ -759,27 +844,71 @@ export default function useAlignedData({
         indexTypeRef.current = indexType;
         idColumnDisplayNameRef.current = idColumnDisplayName;
 
-        // Step 2: Load data if we have slices to fetch
-        const slicesToFetch = buildSlicesToFetch(indexType, slices);
-
-        // Create all the fetch promises
-        const dataPromises = slicesToFetch.map((slice) =>
-          createDataFetchPromise(slice)
-        );
-
-        const datasetsPromise = cached(breadboxAPI).getDatasets();
-
-        // Execute all fetches in parallel
-        const [dataResponses, datasets] = await Promise.all([
-          Promise.all(dataPromises),
-          datasetsPromise,
-        ]);
+        // Step 2: Figure out which slices still point at a dataset that
+        // exists. A slice can outlive its dataset (a remembered column
+        // pointing at a dataset retired by a newer Breadbox release); those
+        // become stub columns instead of doomed fetches.
+        const datasets = await cached(breadboxAPI).getDatasets();
 
         if (isCancelled) return;
 
-        // Resolve display labels for each slice
+        const slicesToFetch = buildSlicesToFetch(indexType, slices);
+
+        const datasetExists = (dataset_id: string) =>
+          datasets.some(
+            (d) => d.id === dataset_id || d.given_id === dataset_id
+          );
+
+        // Index 0 is the label slice from the index type's own metadata;
+        // without it there are no rows at all, so it keeps the hard-failure
+        // behavior below.
+        const failures: (SliceLoadFailure | null)[] = slicesToFetch.map(
+          (slice, i) =>
+            i > 0 && !datasetExists(slice.dataset_id) ? "dataset_removed" : null
+        );
+
+        const EMPTY_RESPONSE: SliceResponse = {
+          ids: [],
+          labels: [],
+          values: [],
+        };
+
+        // Step 3: Load data. A single slice's failure degrades to a stub
+        // column rather than rejecting the whole table.
+        const dataResponses = await Promise.all(
+          slicesToFetch.map((slice, i) => {
+            if (failures[i]) {
+              return Promise.resolve(EMPTY_RESPONSE);
+            }
+
+            if (i === 0) {
+              return createDataFetchPromise(slice);
+            }
+
+            return createDataFetchPromise(slice).catch((e) => {
+              window.console.warn(
+                "[SliceTable] failed to load slice",
+                slice,
+                e
+              );
+              failures[i] = "fetch_failed";
+              return EMPTY_RESPONSE;
+            });
+          })
+        );
+
+        if (isCancelled) return;
+
+        // Resolve display labels for each slice. Failed slices fall back to
+        // their raw identifiers rather than issuing more doomed requests.
         const displayLabels = await Promise.all(
-          slicesToFetch.map((slice) => resolveDisplayLabel(slice, indexType))
+          slicesToFetch.map((slice, i) =>
+            failures[i]
+              ? Promise.resolve(fallbackDisplayLabel(slice))
+              : resolveDisplayLabel(slice, indexType).catch(() =>
+                  fallbackDisplayLabel(slice)
+                )
+          )
         );
 
         if (isCancelled) return;
@@ -803,9 +932,9 @@ export default function useAlignedData({
 
           if (references && !(references in idToLabelMappings)) {
             // eslint-disable-next-line no-await-in-loop
-            const identifiers = await cached(
-              breadboxAPI
-            ).getDimensionTypeIdentifiers(references);
+            const identifiers = await getDimensionTypeIdentifiersPersisted(
+              references
+            );
 
             idToLabelMappings[references] = {};
 
@@ -826,7 +955,8 @@ export default function useAlignedData({
           idColumnDisplayName,
           labelColumnDisplayName,
           idToLabelMappings,
-          getColumnDisplayOptions
+          getColumnDisplayOptions,
+          failures
         );
 
         setState((prev) => ({

--- a/frontend/packages/@depmap/slice-table/src/components/useSliceTableState.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/useSliceTableState.tsx
@@ -531,21 +531,57 @@ export function useSliceTableState({
     ]
   );
 
+  const removeColumn = useCallback(
+    (column: { meta: { sliceQuery: SliceQuery } }) => {
+      setSlices((prev) =>
+        prev.filter(
+          (slice) => !areSliceQueriesEqual(slice, column.meta.sliceQuery)
+        )
+      );
+    },
+    []
+  );
+
   const extendedColumns = useMemo(() => {
     const OFFSET = columns.length - slices.length;
 
     const sliceColumns = columns.map((column, colIndex) => ({
       ...column,
+      // A column whose dataset was removed can never load again, so the fix
+      // goes right where the failure is shown, not only in the header menu.
+      // A transient failure deliberately does NOT get this: its column would
+      // come back on reload, and an inline remove would train users to
+      // delete it.
+      ...(column.meta.loadFailure === "dataset_removed" &&
+        column.meta.isEditable && {
+          header: () => (
+            <div>
+              {column.header()}
+              <button
+                type="button"
+                className="btn btn-default btn-xs"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  removeColumn(column);
+                }}
+              >
+                Remove column
+              </button>
+            </div>
+          ),
+        }),
       meta: {
         ...column.meta,
         headerMenuItems: [
-          column.meta.isEditable && {
-            label: "View distribution",
-            icon: "glyphicon-eye-open",
-            onClick: () => handleClickEditColumn(column),
-          },
+          !column.meta.loadFailure &&
+            column.meta.isEditable && {
+              label: "View distribution",
+              icon: "glyphicon-eye-open",
+              onClick: () => handleClickEditColumn(column),
+            },
 
-          !column.meta.isEditable &&
+          !column.meta.loadFailure &&
+            !column.meta.isEditable &&
             column.meta.isViewable && {
               label: "View distribution",
               icon: "glyphicon-eye-open",
@@ -598,6 +634,14 @@ export function useSliceTableState({
             label: "Remove column",
             icon: "glyphicon-remove-sign",
             onClick: async () => {
+              // The confirmation exists to protect a working column. A
+              // column whose dataset no longer exists has nothing to lose,
+              // and its header already explains why it's being removed.
+              if (column.meta.loadFailure === "dataset_removed") {
+                removeColumn(column);
+                return;
+              }
+
               const confirmed = await getConfirmation({
                 message: (
                   <div>
@@ -610,14 +654,7 @@ export function useSliceTableState({
               });
 
               if (confirmed) {
-                setTimeout(() => {
-                  setSlices((prev) => {
-                    return prev.filter(
-                      (slice) =>
-                        !areSliceQueriesEqual(slice, column.meta.sliceQuery)
-                    );
-                  });
-                });
+                setTimeout(() => removeColumn(column));
               }
             },
           },
@@ -671,6 +708,7 @@ export function useSliceTableState({
     customColumnPlacement,
     handleClickEditColumn,
     handleClickViewColumn,
+    removeColumn,
     slices.length,
   ]);
 

--- a/frontend/packages/elara-frontend/jest-setup.ts
+++ b/frontend/packages/elara-frontend/jest-setup.ts
@@ -51,34 +51,46 @@ const createApiMock = (
   });
 };
 
-jest.mock("@depmap/api", () => ({
-  breadboxAPI: createApiMock(
+jest.mock("@depmap/api", () => {
+  const breadboxAPI = createApiMock(
     "Breadbox API",
     "breadboxAPI",
     breadboxApiProxyTarget
-  ),
+  ) as Record<string, (...args: unknown[]) => unknown>;
 
-  legacyPortalAPI: new Proxy(
-    {},
-    {
-      get(target, prop) {
-        const message = [
-          "*".repeat(80),
-          "Some application code is trying to access the legacy Portal API",
-          "from Elara! This should never happen because Elara is intended to",
-          "be deployed in environments where the legacy Portal backend does",
-          "not exist.",
-          "",
-          `Please remove any instances of legacyPortalAPI.${String(prop)}()`,
-          "from the Elara codebase.",
-          "*".repeat(80),
-        ].join("\n");
+  return {
+    breadboxAPI,
 
-        throw new Error(message);
-      },
-    }
-  ),
-}));
+    // The persisted wrappers delegate to the mocked breadboxAPI so tests mock
+    // the underlying method exactly as they would for a direct call.
+    evaluateContextPersisted: (context: unknown) =>
+      breadboxAPI.evaluateContext(context),
+
+    getDimensionTypeIdentifiersPersisted: (dimTypeName: string) =>
+      breadboxAPI.getDimensionTypeIdentifiers(dimTypeName),
+
+    legacyPortalAPI: new Proxy(
+      {},
+      {
+        get(target, prop) {
+          const message = [
+            "*".repeat(80),
+            "Some application code is trying to access the legacy Portal API",
+            "from Elara! This should never happen because Elara is intended to",
+            "be deployed in environments where the legacy Portal backend does",
+            "not exist.",
+            "",
+            `Please remove any instances of legacyPortalAPI.${String(prop)}()`,
+            "from the Elara codebase.",
+            "*".repeat(80),
+          ].join("\n");
+
+          throw new Error(message);
+        },
+      }
+    ),
+  };
+});
 
 afterEach(() => {
   for (const key of Object.keys(breadboxApiProxyTarget)) {

--- a/frontend/packages/elara-frontend/src/index.tsx
+++ b/frontend/packages/elara-frontend/src/index.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import ReactDOM from "react-dom";
-import { breadboxAPI } from "@depmap/api";
+import { breadboxAPI, cached, initDatasetRegistry } from "@depmap/api";
 import { BrowserRouter, Navigate, Routes, Route } from "react-router-dom";
 import ErrorBoundary from "src/common/components/ErrorBoundary";
 import NotFound from "src/pages/NotFound";
@@ -26,6 +26,21 @@ const CustomDownloads = React.lazy(
 );
 const GroupsPage = React.lazy(() => import("@depmap/groups-manager"));
 const Metadata = React.lazy(() => import("src/pages/Metadata/Metadata"));
+
+// Seed the persistent-cache dataset registry. Called synchronously (with the
+// pending promises, not the resolved values) so requests issued during these
+// round trips wait for it instead of refusing to persist. Never blocks first
+// paint, and never rejects — the engine degrades to in-memory caching on any
+// failure.
+//
+// getDatasets goes through cached() so the seed SHARES one request (and one
+// listing) with every app caller. That is safe only while getDatasets never
+// gains a persist option: a persisted call awaits the registry this promise
+// seeds, which would deadlock. ADR 0008 forbids persisting it independently.
+initDatasetRegistry({
+  datasets: cached(breadboxAPI).getDatasets(),
+  breadboxVersion: breadboxAPI.getBreadboxVersion(),
+});
 
 const container = document.getElementById("root");
 

--- a/frontend/packages/portal-frontend/jest-setup.ts
+++ b/frontend/packages/portal-frontend/jest-setup.ts
@@ -56,21 +56,33 @@ const createApiMock = (
   });
 };
 
-jest.mock("@depmap/api", () => ({
-  cached: (api: unknown) => api,
-
-  legacyPortalAPI: createApiMock(
-    "Portal API",
-    "legacyPortalAPI",
-    portalApiProxyTarget
-  ),
-
-  breadboxAPI: createApiMock(
+jest.mock("@depmap/api", () => {
+  const breadboxAPI = createApiMock(
     "Breadbox API",
     "breadboxAPI",
     breadboxApiProxyTarget
-  ),
-}));
+  ) as Record<string, (...args: unknown[]) => unknown>;
+
+  return {
+    cached: (api: unknown) => api,
+
+    legacyPortalAPI: createApiMock(
+      "Portal API",
+      "legacyPortalAPI",
+      portalApiProxyTarget
+    ),
+
+    breadboxAPI,
+
+    // The persisted wrappers delegate to the mocked breadboxAPI so tests mock
+    // the underlying method exactly as they would for a direct call.
+    evaluateContextPersisted: (context: unknown) =>
+      breadboxAPI.evaluateContext(context),
+
+    getDimensionTypeIdentifiersPersisted: (dimTypeName: string) =>
+      breadboxAPI.getDimensionTypeIdentifiers(dimTypeName),
+  };
+});
 
 afterEach(() => {
   for (const key of Object.keys(portalApiProxyTarget)) {

--- a/frontend/packages/portal-frontend/src/cellLine/hooks/usePairedScreensData.ts
+++ b/frontend/packages/portal-frontend/src/cellLine/hooks/usePairedScreensData.ts
@@ -44,10 +44,10 @@ export interface PairedScreensState {
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
-const bb = cached(breadboxAPI);
-
 const getAnchorScreenTable = async () => {
-  const data = await bb.getTabularDatasetData("PairedAnchorScreenTable", {
+  const data = await cached(breadboxAPI, {
+    persist: true,
+  }).getTabularDatasetData("PairedAnchorScreenTable", {
     columns: ["ModelID"],
   });
 

--- a/frontend/packages/portal-frontend/src/cellLine/utilities/getResistanceScreenTable.ts
+++ b/frontend/packages/portal-frontend/src/cellLine/utilities/getResistanceScreenTable.ts
@@ -16,20 +16,19 @@ export interface ResistanceRow {
 }
 
 const getResistanceScreenTable = async () => {
-  const data = await cached(breadboxAPI).getTabularDatasetData(
-    "PairedResScreenTable",
-    {
-      columns: [
-        "CtrlArmModelID",
-        "CtrlArmStrippedCellLineName",
-        "TestArmModelID",
-        "TestArmStrippedCellLineName",
-        "CulturedDrugResistance",
-        "EngineeredModelDetails",
-        "ComparisonType",
-      ],
-    }
-  );
+  const data = await cached(breadboxAPI, {
+    persist: true,
+  }).getTabularDatasetData("PairedResScreenTable", {
+    columns: [
+      "CtrlArmModelID",
+      "CtrlArmStrippedCellLineName",
+      "TestArmModelID",
+      "TestArmStrippedCellLineName",
+      "CulturedDrugResistance",
+      "EngineeredModelDetails",
+      "ComparisonType",
+    ],
+  });
 
   return Object.keys(data.ComparisonType).map((PairID) => ({
     PairID,

--- a/frontend/packages/portal-frontend/src/compound/compoundPagePromptForSelectionFromContext.tsx
+++ b/frontend/packages/portal-frontend/src/compound/compoundPagePromptForSelectionFromContext.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { breadboxAPI, cached } from "@depmap/api";
+import { evaluateContextPersisted } from "@depmap/api";
 import {
   promptForValue,
   PromptComponentProps,
@@ -48,7 +48,7 @@ export default async function compoundPagePromptForSelectionFromContext(
           return;
         }
 
-        const { ids } = await cached(breadboxAPI).evaluateContext(nextContext);
+        const { ids } = await evaluateContextPersisted(nextContext);
         const contextIds = new Set(ids);
 
         const found = [...allPossibleIds].filter((label) => {
@@ -116,7 +116,7 @@ export default async function compoundPagePromptForSelectionFromContext(
     return null;
   }
 
-  const { ids } = await cached(breadboxAPI).evaluateContext(context);
+  const { ids } = await evaluateContextPersisted(context);
   const contextIds = new Set(ids);
   const matchingIds = [...allPossibleIds].filter((id) => {
     return contextIds.has(id);

--- a/frontend/packages/portal-frontend/src/compound/fetchDataHelpers.ts
+++ b/frontend/packages/portal-frontend/src/compound/fetchDataHelpers.ts
@@ -4,10 +4,9 @@ export async function fetchMetadata<T>(
   typeName: string,
   indices: string[] | null,
   columns: string[] | null,
-  bbapi: typeof breadboxAPI,
   identifier: "label" | "id" = "id"
 ) {
-  const dimType = await cached(bbapi).getDimensionType(typeName);
+  const dimType = await cached(breadboxAPI).getDimensionType(typeName);
   if (!dimType?.metadata_dataset_id) {
     throw new Error(`No metadata for ${typeName}`);
   }
@@ -18,7 +17,7 @@ export async function fetchMetadata<T>(
   } else {
     args = { indices: null, identifier: null, columns };
   }
-  return cached(bbapi).getTabularDatasetData(
+  return cached(breadboxAPI, { persist: true }).getTabularDatasetData(
     dimType.metadata_dataset_id,
     args
   ) as Promise<T>;

--- a/frontend/packages/portal-frontend/src/compound/hooks/useCorrelatedDependenciesData.ts
+++ b/frontend/packages/portal-frontend/src/compound/hooks/useCorrelatedDependenciesData.ts
@@ -8,8 +8,6 @@ function useCorrelatedDependenciesData(
   datasetId: string,
   compoundLabel: string
 ) {
-  const bapi = cached(breadboxAPI);
-
   const [error, setError] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [datasetName, setDatasetName] = useState<string>("");
@@ -30,26 +28,26 @@ function useCorrelatedDependenciesData(
         setIsLoading(true);
 
         // get compound dataset name
-        const compoundDataset = await bapi.getDataset(datasetId);
+        const compoundDataset = await cached(breadboxAPI).getDataset(datasetId);
         setDatasetName(compoundDataset.name);
 
         // get compound id by label
-        const compoundDimType = await bapi.getDimensionType("compound_v2");
+        const compoundDimType = await cached(breadboxAPI).getDimensionType(
+          "compound_v2"
+        );
         if (compoundDimType.metadata_dataset_id) {
-          const allCompoundMetadata = await bapi.getTabularDatasetData(
-            compoundDimType.metadata_dataset_id,
-            {
-              identifier: "label",
-              columns: ["CompoundID", "EntrezIDsOfTargets"],
-            }
-          );
+          const allCompoundMetadata = await cached(breadboxAPI, {
+            persist: true,
+          }).getTabularDatasetData(compoundDimType.metadata_dataset_id, {
+            identifier: "label",
+            columns: ["CompoundID", "EntrezIDsOfTargets"],
+          });
           const compoundID = allCompoundMetadata.CompoundID[compoundLabel];
 
           const geneMetadata = await fetchMetadata<any>(
             "gene",
             null,
             ["label"],
-            breadboxAPI,
             "id"
           );
 
@@ -60,7 +58,9 @@ function useCorrelatedDependenciesData(
           setGeneTargets(genes);
 
           // Fetching the correlation data for the given dataset and compound and filtering by associated dataset IDs
-          const datasetAssociations = await bapi.fetchAssociations(
+          const datasetAssociations = await cached(
+            breadboxAPI
+          ).fetchAssociations(
             {
               dataset_id: datasetId,
               identifier: compoundID,

--- a/frontend/packages/portal-frontend/src/compound/hooks/useCorrelatedExpressionData.tsx
+++ b/frontend/packages/portal-frontend/src/compound/hooks/useCorrelatedExpressionData.tsx
@@ -9,8 +9,6 @@ function useCorrelatedExpressionData(
   compoundLabel: string,
   associationDatasetId: string
 ) {
-  const bapi = cached(breadboxAPI);
-
   const [error, setError] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [datasetName, setDatasetName] = useState<string>("");
@@ -26,26 +24,26 @@ function useCorrelatedExpressionData(
         setIsLoading(true);
 
         // get compound dataset name
-        const compoundDataset = await bapi.getDataset(datasetId);
+        const compoundDataset = await cached(breadboxAPI).getDataset(datasetId);
         setDatasetName(compoundDataset.name);
 
         // get compound id by label
-        const compoundDimType = await bapi.getDimensionType("compound_v2");
+        const compoundDimType = await cached(breadboxAPI).getDimensionType(
+          "compound_v2"
+        );
         if (compoundDimType.metadata_dataset_id) {
-          const allCompoundMetadata = await bapi.getTabularDatasetData(
-            compoundDimType.metadata_dataset_id,
-            {
-              identifier: "label",
-              columns: ["CompoundID", "EntrezIDsOfTargets"],
-            }
-          );
+          const allCompoundMetadata = await cached(breadboxAPI, {
+            persist: true,
+          }).getTabularDatasetData(compoundDimType.metadata_dataset_id, {
+            identifier: "label",
+            columns: ["CompoundID", "EntrezIDsOfTargets"],
+          });
           const compoundID = allCompoundMetadata.CompoundID[compoundLabel];
 
           const geneMetadata = await fetchMetadata<any>(
             "gene",
             null,
             ["label"],
-            breadboxAPI,
             "id"
           );
 
@@ -56,7 +54,9 @@ function useCorrelatedExpressionData(
           setGeneTargets(genes);
 
           // Fetching the correlation data for the given dataset and compound and filtering by associated dataset IDs
-          const datasetAssociations = await bapi.fetchAssociations(
+          const datasetAssociations = await cached(
+            breadboxAPI
+          ).fetchAssociations(
             {
               dataset_id: datasetId,
               identifier: compoundID,
@@ -79,7 +79,7 @@ function useCorrelatedExpressionData(
         setIsLoading(false);
       }
     })();
-  }, [associationDatasetId, correlationData, compoundLabel, bapi, datasetId]);
+  }, [associationDatasetId, correlationData, compoundLabel, datasetId]);
   return {
     datasetName,
     correlationData,

--- a/frontend/packages/portal-frontend/src/compound/hooks/useDoseViabilityData.ts
+++ b/frontend/packages/portal-frontend/src/compound/hooks/useDoseViabilityData.ts
@@ -129,13 +129,11 @@ export default function useDoseViabilityData(
       setIsLoading(true);
       setError(false);
       try {
-        const bbapi = breadboxAPI;
-
         // Get the compound dose viability features by fetching the compound dose metadata. Will
         // be like {CompoundID: "viability_feature_id": "compound_id"}
         const doseCompoundMetadata = await fetchMetadata<{
           CompoundID: Record<string, string>;
-        }>("compound_dose", null, ["CompoundID"], bbapi);
+        }>("compound_dose", null, ["CompoundID"]);
 
         // All of the viability features relevant to this particular compound will be the list of keys
         // with a value equal to this compoundId.
@@ -156,7 +154,7 @@ export default function useDoseViabilityData(
           doseCurvesResponse,
         ] = await Promise.all([
           // For getting the values for the dose viability table dose columns and the heatmap.
-          cached(bbapi).getMatrixDatasetData(
+          cached(breadboxAPI, { persist: true }).getMatrixDatasetData(
             dataset.viability_dataset_given_id,
             {
               features: viabilityFeatureIds,
@@ -166,19 +164,21 @@ export default function useDoseViabilityData(
           fetchMetadata<{
             Dose: Record<string, number>;
             DoseUnit: Record<string, string>;
-          }>("compound_dose", viabilityFeatureIds, ["Dose", "DoseUnit"], bbapi),
+          }>("compound_dose", viabilityFeatureIds, ["Dose", "DoseUnit"]),
           // For getting model id --> cell line name
           fetchMetadata<{ CellLineName: Record<string, string> }>(
             "depmap_model",
             null,
-            ["CellLineName"],
-            bbapi
+            ["CellLineName"]
           ),
           // For getting the AUC column of the dose viability table.
-          cached(bbapi).getMatrixDatasetData(dataset.auc_dataset_given_id, {
-            features: [compoundId],
-            feature_identifier: "id",
-          }),
+          cached(breadboxAPI, { persist: true }).getMatrixDatasetData(
+            dataset.auc_dataset_given_id,
+            {
+              features: [compoundId],
+              feature_identifier: "id",
+            }
+          ),
           // For getting dose curves plot data, including replicates. Curve_params are also
           // added to the dose viability table below.
           fetchCompoundDoseCurveData(

--- a/frontend/packages/portal-frontend/src/compound/hooks/useRelatedCompoundsData.ts
+++ b/frontend/packages/portal-frontend/src/compound/hooks/useRelatedCompoundsData.ts
@@ -128,8 +128,6 @@ export default function useRelatedCompoundsData(
   compoundId: string,
   datasetToDataTypeMap: Record<string, "CRISPR" | "RNAi">
 ) {
-  const bapi = cached(breadboxAPI);
-
   const [state, setState] = useState({
     isLoading: true,
     hasError: false,
@@ -146,15 +144,14 @@ export default function useRelatedCompoundsData(
 
         // 1: Metadata Fetching
         const [compoundDataset, allMetadata, geneMetadata] = await Promise.all([
-          bapi.getDataset(datasetId),
+          cached(breadboxAPI).getDataset(datasetId),
           fetchMetadata<CompoundMetadata>(
             "compound_v2",
             null,
-            ["label", "EntrezIDsOfTargets"],
-            breadboxAPI, // fetchMetadata uses cache wrapper internally, so pass in uncached breadboxAPI
+            ["label", "EntrezIDsOfTargets"], // fetchMetadata uses cache wrapper internally, so pass in uncached breadboxAPI
             "id"
           ),
-          fetchMetadata<any>("gene", null, ["label"], breadboxAPI, "id"),
+          fetchMetadata<any>("gene", null, ["label"], "id"),
         ]);
 
         // selected -> defined by the compound page the user is currently on.
@@ -171,7 +168,7 @@ export default function useRelatedCompoundsData(
 
         const associations = await Promise.allSettled(
           queryPairs.map((p) =>
-            bapi.fetchAssociations(
+            cached(breadboxAPI).fetchAssociations(
               {
                 dataset_id: p.dataset,
                 identifier: p.gene,
@@ -221,7 +218,7 @@ export default function useRelatedCompoundsData(
         setState((prev) => ({ ...prev, isLoading: false, hasError: true }));
       }
     })();
-  }, [datasetId, compoundId, datasetToDataTypeMap, bapi]);
+  }, [datasetId, compoundId, datasetToDataTypeMap]);
 
   return state;
 }

--- a/frontend/packages/portal-frontend/src/compound/tiles/hooks/useDataAvailabilityTileData.tsx
+++ b/frontend/packages/portal-frontend/src/compound/tiles/hooks/useDataAvailabilityTileData.tsx
@@ -33,8 +33,6 @@ const getPrioritizedData = async (
   datasets: MatrixDataset[],
   metadataMap: DataAvailByAUCDatasetMetadataMap
 ): Promise<DatasetAvailability[]> => {
-  const bbapi = breadboxAPI;
-
   // 1. Map Breadbox datasets by ID
   const breadboxDatasetLookup = Object.fromEntries(
     datasets.map((ds) => [ds.given_id || ds.id, ds])
@@ -47,7 +45,7 @@ const getPrioritizedData = async (
   // 2. Fetch ALL dose metadata for this compound once.
   const doseCompoundMetadata = await fetchMetadata<{
     CompoundID: Record<string, string>;
-  }>("compound_dose", null, ["CompoundID"], bbapi);
+  }>("compound_dose", null, ["CompoundID"]);
 
   const allViabilityFeatureIds = getKeysByValue(
     doseCompoundMetadata.CompoundID,
@@ -62,7 +60,7 @@ const getPrioritizedData = async (
   const globalDoseMetadata = await fetchMetadata<{
     Dose: Record<string, number>;
     DoseUnit: Record<string, string>;
-  }>("compound_dose", allViabilityFeatureIds, ["Dose", "DoseUnit"], bbapi);
+  }>("compound_dose", allViabilityFeatureIds, ["Dose", "DoseUnit"]);
 
   // 3. Process each dataset record
   return Promise.all(
@@ -73,7 +71,9 @@ const getPrioritizedData = async (
 
       try {
         // Filter the global metadata to only include features found in this specific viability dataset
-        const features = await cached(bbapi).getDatasetFeatures(viabilityId);
+        const features = await cached(breadboxAPI, {
+          persist: true,
+        }).getDatasetFeatures(viabilityId);
         const localFeatureIds = features
           .filter((f: any) => f.id.includes(compoundId))
           .map((f: any) => f.id);
@@ -88,7 +88,9 @@ const getPrioritizedData = async (
         };
 
         const doseRange = getDoseRangeLabel(localDoseMeta);
-        const sliceData = await cached(bbapi).getMatrixDatasetData(aucId, {
+        const sliceData = await cached(breadboxAPI, {
+          persist: true,
+        }).getMatrixDatasetData(aucId, {
           features: [compoundId],
           feature_identifier: "id",
         });

--- a/frontend/packages/portal-frontend/src/compound/tiles/hooks/useSensitivityTileData.tsx
+++ b/frontend/packages/portal-frontend/src/compound/tiles/hooks/useSensitivityTileData.tsx
@@ -21,15 +21,12 @@ export default function useSensitivityTileData(
       setIsLoading(true);
       setError(false);
       try {
-        const bbapi = breadboxAPI;
-
-        const sliceData = await cached(bbapi).getMatrixDatasetData(
-          datasetGivenId,
-          {
-            features: [compoundId],
-            feature_identifier: "id",
-          }
-        );
+        const sliceData = await cached(breadboxAPI, {
+          persist: true,
+        }).getMatrixDatasetData(datasetGivenId, {
+          features: [compoundId],
+          feature_identifier: "id",
+        });
 
         const record: Record<string, any> = sliceData[compoundId] || {};
 

--- a/frontend/packages/portal-frontend/src/compound/tiles/hooks/useStructureAndDetailData.tsx
+++ b/frontend/packages/portal-frontend/src/compound/tiles/hooks/useStructureAndDetailData.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useState } from "react";
-import { breadboxAPI } from "@depmap/api";
 import { fetchMetadata } from "src/compound/fetchDataHelpers";
 import { compoundImageBaseURL, pythonQuote } from "src/compound/utils";
 
@@ -87,8 +86,6 @@ export default function useStructureAndDetailData(compoundId: string) {
       setIsLoading(true);
       setError(false);
       try {
-        const bbapi = breadboxAPI;
-
         const columnsOfInterest = [
           "EntrezIDsOfTargets",
           "TargetOrMechanism",
@@ -102,7 +99,6 @@ export default function useStructureAndDetailData(compoundId: string) {
           "gene",
           null,
           ["label"],
-          breadboxAPI,
           "id"
         );
 
@@ -111,7 +107,6 @@ export default function useStructureAndDetailData(compoundId: string) {
           "compound_v2",
           [compoundId],
           columnsOfInterest,
-          bbapi,
           "id"
         );
 

--- a/frontend/packages/portal-frontend/src/correlationAnalysis/hooks/useCorrelationAnalysisData.ts
+++ b/frontend/packages/portal-frontend/src/correlationAnalysis/hooks/useCorrelationAnalysisData.ts
@@ -22,7 +22,6 @@ export function useGeneCorrelationData(
   featureId: string,
   featureName: string
 ) {
-  const bapi = cached(breadboxAPI);
   const [state, setState] = useState<CorrelationResult>({
     correlationAnalysisData: [],
     correlatedDatasets: [],
@@ -38,7 +37,7 @@ export function useGeneCorrelationData(
       try {
         setState((s) => ({ ...s, isLoading: true, hasError: false }));
 
-        const res = await bapi.fetchAssociations({
+        const res = await cached(breadboxAPI).fetchAssociations({
           dataset_id: selectedDataset.datasetId,
           identifier: String(featureId),
           identifier_type: "feature_id",
@@ -105,7 +104,7 @@ export function useGeneCorrelationData(
     return () => {
       isCurrent = false;
     };
-  }, [selectedDataset, featureId, featureName, bapi]);
+  }, [selectedDataset, featureId, featureName]);
 
   return { ...state };
 }
@@ -115,7 +114,6 @@ export function useCompoundCorrelationData(
   featureId: string,
   featureName: string
 ): CorrelationResult {
-  const bapi = cached(breadboxAPI);
   const [state, setState] = useState<CorrelationResult>({
     correlationAnalysisData: [],
     correlatedDatasets: [],
@@ -137,7 +135,9 @@ export function useCompoundCorrelationData(
         const compoundDoseToDose = new Map<string, string>();
         const fetchTasks: [string, string][] = [[featureId, aucId]];
 
-        const features = await bapi.getDatasetFeatures(doseId);
+        const features = await cached(breadboxAPI, {
+          persist: true,
+        }).getDatasetFeatures(doseId);
         features
           .filter((f: any) => f.id.includes(featureId))
           .forEach((f: any) => {
@@ -156,7 +156,7 @@ export function useCompoundCorrelationData(
 
         const allRes = await Promise.all(
           fetchTasks.map(([feature_id, dataset_id]) =>
-            bapi.fetchAssociations({
+            cached(breadboxAPI).fetchAssociations({
               dataset_id,
               identifier: feature_id,
               identifier_type: "feature_id",
@@ -233,7 +233,7 @@ export function useCompoundCorrelationData(
     return () => {
       isCurrent = false;
     };
-  }, [selectedDataset, featureId, featureName, bapi]);
+  }, [selectedDataset, featureId, featureName]);
 
   return state;
 }

--- a/frontend/packages/portal-frontend/src/genePage/hooks/useTopCoDependenciesData.tsx
+++ b/frontend/packages/portal-frontend/src/genePage/hooks/useTopCoDependenciesData.tsx
@@ -7,8 +7,6 @@ function useTopCoDependenciesData(
   geneEntrezId: string,
   associationDatasetIds: string[]
 ) {
-  const bapi = cached(breadboxAPI);
-
   const [error, setError] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [datasetName, setDatasetName] = useState<string>("");
@@ -22,11 +20,13 @@ function useTopCoDependenciesData(
       try {
         setIsLoading(true);
 
-        const dataset = await bapi.getDataset(datasetId);
+        const dataset = await cached(breadboxAPI).getDataset(datasetId);
         setDatasetName(dataset.name);
 
         if (dataset.given_id) {
-          const datasetAssociations = await bapi.fetchAssociations(
+          const datasetAssociations = await cached(
+            breadboxAPI
+          ).fetchAssociations(
             {
               dataset_id: dataset.given_id,
               identifier: geneEntrezId,
@@ -45,7 +45,7 @@ function useTopCoDependenciesData(
         setIsLoading(false);
       }
     })();
-  }, [correlationData, geneEntrezId, bapi, datasetId, associationDatasetIds]);
+  }, [correlationData, geneEntrezId, datasetId, associationDatasetIds]);
   return {
     datasetName,
     correlationData,

--- a/frontend/packages/portal-frontend/src/genePage/utils.ts
+++ b/frontend/packages/portal-frontend/src/genePage/utils.ts
@@ -80,13 +80,7 @@ export async function downloadTopCorrelations(
   datasetDisplayName: string,
   correlationsData: AssociatedFeatures[]
 ) {
-  const geneMetadata = await fetchMetadata<any>(
-    "gene",
-    null,
-    ["label"],
-    breadboxAPI,
-    "id"
-  );
+  const geneMetadata = await fetchMetadata<any>("gene", null, ["label"], "id");
   // 1. Create lookup map for the Join
   const geneMap = new Map(
     Object.entries(geneMetadata.label).map(([entrez_id, label]) => [

--- a/frontend/packages/portal-frontend/src/geneTea/components/GeneTea.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/GeneTea.tsx
@@ -7,7 +7,6 @@ import "src/common/styles/typeahead_fix.scss";
 import styles from "../styles/GeneTea.scss";
 import SearchOptionsContainer from "./SearchOptionsContainer";
 import { useGeneTeaFiltersContext } from "../context/GeneTeaFiltersContext";
-import { breadboxAPI } from "@depmap/api";
 import { fetchMetadata } from "../utils";
 import glossary from "src/geneTea/json/glossary.json";
 import Glossary from "src/common/components/Glossary";
@@ -30,7 +29,6 @@ function GeneTea() {
         "gene",
         null,
         ["label"],
-        breadboxAPI,
         "id"
       );
 

--- a/frontend/packages/portal-frontend/src/geneTea/components/LoadFromGeneContextSection.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/LoadFromGeneContextSection.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { breadboxAPI, cached } from "@depmap/api";
+import { evaluateContextPersisted } from "@depmap/api";
 import {
   ContextSelectorV2,
   getDimensionTypeLabel,
@@ -49,7 +49,7 @@ const LoadFromGeneContextSection: React.FC = () => {
       return;
     }
 
-    const { labels } = await cached(breadboxAPI).evaluateContext(nextContext);
+    const { labels } = await evaluateContextPersisted(nextContext);
     const contextLabels = new Set(labels);
 
     handleSetGeneSymbolSelections(contextLabels);

--- a/frontend/packages/portal-frontend/src/geneTea/components/promptForSelectionFromContext.tsx
+++ b/frontend/packages/portal-frontend/src/geneTea/components/promptForSelectionFromContext.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { breadboxAPI, cached } from "@depmap/api";
+import { evaluateContextPersisted } from "@depmap/api";
 import {
   promptForValue,
   PromptComponentProps,
@@ -48,9 +48,7 @@ export default async function promptForSelectionFromContext(
           return;
         }
 
-        const { labels } = await cached(breadboxAPI).evaluateContext(
-          nextContext
-        );
+        const { labels } = await evaluateContextPersisted(nextContext);
         const contextLabels = new Set(labels);
 
         const found = [...allPossibleLabels].filter((label) => {
@@ -118,7 +116,7 @@ export default async function promptForSelectionFromContext(
     return null;
   }
 
-  const { labels } = await cached(breadboxAPI).evaluateContext(context);
+  const { labels } = await evaluateContextPersisted(context);
   const contextLabels = new Set(labels);
   const matchingLabels = [...allPossibleLabels].filter((label) => {
     return allPossibleLabels.has(label) && contextLabels.has(label);

--- a/frontend/packages/portal-frontend/src/geneTea/utils.ts
+++ b/frontend/packages/portal-frontend/src/geneTea/utils.ts
@@ -49,10 +49,9 @@ export async function fetchMetadata<T>(
   typeName: string,
   indices: string[] | null,
   columns: string[] | null,
-  bbapi: typeof breadboxAPI,
   identifier: "label" | "id" = "id"
 ) {
-  const dimType = await cached(bbapi).getDimensionType(typeName);
+  const dimType = await cached(breadboxAPI).getDimensionType(typeName);
   if (!dimType?.metadata_dataset_id) {
     throw new Error(`No metadata for ${typeName}`);
   }
@@ -63,7 +62,7 @@ export async function fetchMetadata<T>(
   } else {
     args = { indices: null, identifier: null, columns };
   }
-  return cached(bbapi).getTabularDatasetData(
+  return cached(breadboxAPI, { persist: true }).getTabularDatasetData(
     dimType.metadata_dataset_id,
     args
   ) as Promise<T>;

--- a/frontend/packages/portal-frontend/src/index.tsx
+++ b/frontend/packages/portal-frontend/src/index.tsx
@@ -2,7 +2,12 @@ import "src/public-path";
 
 import React from "react";
 import ReactDOM from "react-dom";
-import { LegacyPortalApiResponse } from "@depmap/api";
+import {
+  breadboxAPI,
+  cached,
+  initDatasetRegistry,
+  LegacyPortalApiResponse,
+} from "@depmap/api";
 import { CustomList } from "@depmap/cell-line-selector";
 
 import { getQueryParams, sortByNumberOrNull } from "@depmap/utils";
@@ -36,6 +41,21 @@ type EntitySummaryResponse = LegacyPortalApiResponse["getEntitySummary"];
 if (["dev.cds.team", "127.0.0.1:5000"].includes(window.location.host)) {
   initializeDevContexts();
 }
+
+// Seed the persistent-cache dataset registry. Called synchronously (with the
+// pending promises, not the resolved values) so requests issued during these
+// round trips wait for it instead of refusing to persist. Never blocks first
+// paint, and never rejects — the engine degrades to in-memory caching on any
+// failure.
+//
+// getDatasets goes through cached() so the seed SHARES one request (and one
+// listing) with every app caller. That is safe only while getDatasets never
+// gains a persist option: a persisted call awaits the registry this promise
+// seeds, which would deadlock. ADR 0008 forbids persisting it independently.
+initDatasetRegistry({
+  datasets: cached(breadboxAPI).getDatasets(),
+  breadboxVersion: breadboxAPI.getBreadboxVersion(),
+});
 
 const CorrelatedDependenciesTile = React.lazy(
   () =>

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptExpansionSelect/GeneSelect.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/TranscriptExpansionSelect/GeneSelect.tsx
@@ -13,7 +13,7 @@ function GeneSelect({ value, onChange }: Props) {
   const [options, setOptions] = useState<any[]>([]);
 
   useEffect(() => {
-    cached(breadboxAPI)
+    cached(breadboxAPI, { persist: true })
       .getTabularDatasetData("transcript_metadata", {
         columns: ["Gene"],
       })

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/useContextResult.ts
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/TranscriptConfigPanel/useContextResult.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { breadboxAPI, cached, BreadboxApiResponse } from "@depmap/api";
+import { BreadboxApiResponse, evaluateContextPersisted } from "@depmap/api";
 import { DataExplorerContextV2 } from "@depmap/types";
 
 function useContextResult(context?: DataExplorerContextV2 | null) {
@@ -13,12 +13,10 @@ function useContextResult(context?: DataExplorerContextV2 | null) {
     if (context) {
       setIsLoading(true);
 
-      cached(breadboxAPI)
-        .evaluateContext(context)
-        .then((nextResult) => {
-          setResult(nextResult);
-          setIsLoading(false);
-        });
+      evaluateContextPersisted(context).then((nextResult) => {
+        setResult(nextResult);
+        setIsLoading(false);
+      });
     } else {
       setResult(null);
       setIsLoading(false);

--- a/frontend/packages/portal-frontend/src/transcriptExplorer/components/index.tsx
+++ b/frontend/packages/portal-frontend/src/transcriptExplorer/components/index.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from "react";
-import { enablePersistentApiCache } from "@depmap/api";
 import { PartialDataExplorerPlotConfig } from "@depmap/types";
 import {
   DEFAULT_EMPTY_PLOT,
@@ -9,11 +8,6 @@ import SpinnerOverlay from "@depmap/data-explorer-2/src/components/DataExplorerP
 import { EMPTY_TRANSCRIPT_PLOT, focusWhenElementReady } from "./utils";
 import MainContent from "./MainContent";
 import styles from "../styles/TranscriptPlotConfig.scss";
-
-// *** This is an experimental feature that causes `cached()` to persist data
-// to the browser's cache. Transcript data is quite heavy so this makes it a little
-// easier to work with. ***
-enablePersistentApiCache();
 
 interface Props {
   feedbackUrl: string | null;

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8147,6 +8147,11 @@ extract-zip@^1.6.6:
     mkdirp "^0.5.4"
     yauzl "^2.10.0"
 
+fake-indexeddb@^6.0.0:
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz#74285b6821467d6c102af092f0a4517ad5521613"
+  integrity sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==
+
 falafel@^2.1.0:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/falafel/-/falafel-2.2.5.tgz#3ccb4970a09b094e9e54fead2deee64b4a589d56"


### PR DESCRIPTION
cached() can now store responses in IndexedDB so they survive reloads (see ADR 0008). Breadbox never mutates dataset data in place — a new version is a new UUID — so a response addressed by dataset is immutable and cacheable forever: no TTL, no revalidation. Everything a response depends on is folded into its key, LRU handles eviction, only public datasets are ever written, and the engine fails closed until seeded from a fresh getDatasets().

Persistence is a per-call-site assertion, never a blanket rule: 37 call sites opt in with { persist: true }, and evaluateContext plus unfiltered getDimensionTypeIdentifiers persist through helpers that declare their implicit metadata-dataset deps. The kill switch is an epoch composed of CACHE_VERSION (a manual knob for frontend-side cache fixes) and the Breadbox app version (wipes automatically on any Breadbox release, via /health_check/basic).

The rules for future call sites — what may persist, what never may, and the traps already contained — are recorded in
frontend/packages/@depmap/data-explorer-2/docs/adr/0008-persistent-api-cache-opt-in.md