### PR TITLE
fix(breadbox): Tabular upload memory usage

### DIFF
--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -319,7 +319,6 @@ def add_tabular_dimensions(
     Adds tabular dataset dimensions to database.
     """
     dimensions = []
-    values = []
 
     for col in data_df.columns:
         annotation_id = str(uuid4())
@@ -335,24 +334,27 @@ def add_tabular_dimensions(
                 references_dimension_type_name=columns_metadata[col].references,
             )
         )
-        values.extend(
-            [
-                TabularCell(
-                    tabular_column_id=annotation_id,
-                    dimension_given_id=index,
-                    value=None
-                    if pd.isnull(val)
-                    else str(val),  # Val could be pd.NA. Store null as None
-                    group_id=group_id,
-                )
-                for index, val in zip(data_df[dimension_type.id_column], data_df[col],)
-            ]
-        )
 
     db.bulk_save_objects(dimensions)
     db.flush()
-    db.bulk_save_objects(values)
-    db.flush()
+
+    # Build and flush one column's worth of cells at a time so we never hold more
+    # than a single column's cells in memory (a long table can have millions of cells
+    # across all columns combined).
+    for col, column in zip(data_df.columns, dimensions):
+        values = [
+            TabularCell(
+                tabular_column_id=column.id,
+                dimension_given_id=index,
+                value=None
+                if pd.isnull(val)
+                else str(val),  # Val could be pd.NA. Store null as None
+                group_id=group_id,
+            )
+            for index, val in zip(data_df[dimension_type.id_column], data_df[col],)
+        ]
+        db.bulk_save_objects(values)
+        db.flush()
 
 
 def _find_datasets_referencing(

--- a/breadbox/breadbox/crud/dataset.py
+++ b/breadbox/breadbox/crud/dataset.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Optional, List, Type, Union, Tuple, Set
 from uuid import UUID, uuid4
 
 import pandas as pd
-from sqlalchemy import and_, func, or_, select, true
+from sqlalchemy import and_, func, insert, or_, select, true
 from sqlalchemy.sql import distinct
 from sqlalchemy.sql.elements import ColumnElement
 from sqlalchemy.orm import aliased, with_polymorphic
@@ -338,23 +338,24 @@ def add_tabular_dimensions(
     db.bulk_save_objects(dimensions)
     db.flush()
 
-    # Build and flush one column's worth of cells at a time so we never hold more
+    # Build and insert one column's worth of cells at a time so we never hold more
     # than a single column's cells in memory (a long table can have millions of cells
-    # across all columns combined).
+    # across all columns combined). Insert as plain dicts via Core rather than
+    # TabularCell(...) ORM instances, which carry far more per-row overhead.
     for col, column in zip(data_df.columns, dimensions):
         values = [
-            TabularCell(
-                tabular_column_id=column.id,
-                dimension_given_id=index,
-                value=None
+            {
+                "tabular_column_id": column.id,
+                "dimension_given_id": index,
+                "value": None
                 if pd.isnull(val)
                 else str(val),  # Val could be pd.NA. Store null as None
-                group_id=group_id,
-            )
+                "group_id": group_id,
+            }
             for index, val in zip(data_df[dimension_type.id_column], data_df[col],)
         ]
-        db.bulk_save_objects(values)
-        db.flush()
+        db.execute(insert(TabularCell), values)
+    db.flush()
 
 
 def _find_datasets_referencing(


### PR DESCRIPTION
**Background**: We now have larger tabular datasets than ever (now up to 300,000 rows and 12 columns), which means we are now uploading millions of cells of data at a time. This created issues in our staging environment, where the upload is currently failing to run because of memory issues. 

**Debugging**: I ran the process locally with real data and did some profiling using `memray`. With our current implementation, the loading of the this metadata consumes ~6.6GB of memory, most of which can be traced back to the `add_tabular_dimensions` function in `breadbox/crud/dataset.py`. 

**The solution:** 
1. Loading and saving `TabularCells` one column at a time (and saving/flushing things to the DB after each column) 
2. Bulk inserting dictionary values instead of defining ORM instances of TabularCell. This dramatically cuts down on memory usage because we do still have ~300k TabularCells per column

_Performance before/after this change_: 
* Before: The background worker's process consumed ~6.6GB of memory
* After: The background worker's process only used ~0.5GB of memory

**Potential Future Concerns**: There may be other parts of our code which load all of the TabularCells into memory at once, which would likely also overload our staging environment. I will need to do some follow-up work to check whether that's the case. 
