### PR TITLE
various faceting-related and transcript-related improvements

### DIFF
--- a/frontend/packages/@depmap/api/src/__tests__/persistentApiCache.test.ts
+++ b/frontend/packages/@depmap/api/src/__tests__/persistentApiCache.test.ts
@@ -193,6 +193,43 @@ describe("buildPersistentKey", () => {
     expect(key2).toContain(PUBLIC_DEP_UUID_2);
     expect(key1).not.toEqual(key2);
   });
+
+  it("refuses a wholeCatalog response when any visible dataset is private", async () => {
+    // defaultDatasets includes PRIVATE_UUID, so this caller's catalog is not
+    // entirely public — the response would contain private-derived bytes, and
+    // no keying scheme makes those safe in a wholesale-readable store.
+    await init();
+    const key = await buildPersistentKey("POST /temp/context/coverage-{}", {
+      wholeCatalog: true,
+    });
+
+    expect(key).toBeNull();
+    expect(persistentCacheStats.refusedPrivateCatalog).toBe(1);
+  });
+
+  it("keys a wholeCatalog response by the catalog fingerprint", async () => {
+    const allPublic = defaultDatasets.filter(
+      (d) => d.group_id === PUBLIC_GROUP_ID
+    );
+
+    // No dataset address in the request — the catalog itself is the declared
+    // dependency, so the no-address refusal does not apply.
+    const cacheKey = "POST /temp/context/coverage-{}";
+
+    await init({ datasets: allPublic });
+    const key1 = await buildPersistentKey(cacheKey, { wholeCatalog: true });
+
+    __resetForTests();
+    await init({ datasets: allPublic.slice(0, -1) });
+    const key2 = await buildPersistentKey(cacheKey, { wholeCatalog: true });
+
+    expect(key1).not.toBeNull();
+    expect(key2).not.toBeNull();
+    expect(key1).toContain(cacheKey);
+    // A different catalog produces a different key, so entries orphan rather
+    // than serve coverage missing a newly-listed dataset.
+    expect(key1).not.toEqual(key2);
+  });
 });
 
 describe("persistentCacheGet / persistentCacheSet", () => {

--- a/frontend/packages/@depmap/api/src/apiCacheDecorator.ts
+++ b/frontend/packages/@depmap/api/src/apiCacheDecorator.ts
@@ -18,6 +18,11 @@ export interface CachedOptions {
    * `{ deps: [...] }` is for responses that are immutable only given some other
    * dataset. The deps are folded into the cache key, so when a dep changes the
    * key changes and the old entry is orphaned rather than wrongly served.
+   *
+   * `{ wholeCatalog: true }` is for responses that depend on every dataset the
+   * caller can see. The engine persists these only when that catalog is
+   * entirely public, keyed by a fingerprint of the listing; anyone who can see
+   * a private dataset silently stays in memory. See ADR 0008.
    */
   persist?: PersistOption;
 }

--- a/frontend/packages/@depmap/api/src/persistentApiCache.ts
+++ b/frontend/packages/@depmap/api/src/persistentApiCache.ts
@@ -33,6 +33,8 @@
 // nothing is read or written. A wiring mistake costs cache hits, never
 // correctness and never a privacy leak.
 
+import SparkMD5 from "spark-md5";
+
 const DB_NAME = "depmap-api-cache";
 const DB_VERSION = 2;
 const RESPONSES = "responses";
@@ -70,8 +72,13 @@ const TOUCH_FLUSH_MS = 15_000;
  * `true` asserts the response is immutable at its own dataset address.
  * `{ deps }` additionally names datasets the response depends on but is not
  * addressed by; they are folded into the key.
+ * `{ wholeCatalog: true }` asserts the response depends on every dataset the
+ * caller can see. It persists ONLY when that catalog is entirely public — the
+ * bytes on disk are then derived from public data alone — keyed by a
+ * fingerprint of the listing, so any catalog change rotates the key on the
+ * next load.
  */
-export type PersistOption = true | { deps: string[] };
+export type PersistOption = true | { deps: string[] } | { wholeCatalog: true };
 
 /** Ambient context threaded from the decorator through createJsonClient. */
 export type RequestCacheContext = { persist?: PersistOption } | null;
@@ -95,6 +102,14 @@ let maxBytes = DEFAULT_MAX_BYTES;
 let versionMap: Map<string, string> | null = null;
 /** UUIDs of datasets in the public group. Nothing else may be written. */
 let publicUuids: Set<string> | null = null;
+/**
+ * Whether every dataset in this session's listing is public, and a fingerprint
+ * of that listing. Together they make `wholeCatalog` responses expressible on
+ * disk: all-public means the bytes are public-derived, and the fingerprint —
+ * since UUIDs pin contents — pins the entire input that produced them.
+ */
+let catalogIsAllPublic = false;
+let catalogFingerprint = "";
 
 const touched = new Set<string>();
 let touchTimer: ReturnType<typeof setInterval> | null = null;
@@ -108,6 +123,7 @@ export const persistentCacheStats = {
   bytesEvicted: 0,
   refusedNotPublic: 0,
   refusedNoDatasetAddress: 0,
+  refusedPrivateCatalog: 0,
   refusedUnresolvable: 0,
   refusedTooLarge: 0,
   refusedNotReady: 0,
@@ -194,6 +210,16 @@ export function initDatasetRegistry(options: {
 
       versionMap = nextVersionMap;
       publicUuids = nextPublicUuids;
+
+      catalogIsAllPublic = datasets.every(
+        (d) => d.group_id === PUBLIC_GROUP_ID
+      );
+      catalogFingerprint = SparkMD5.hash(
+        datasets
+          .map((d) => d.id)
+          .sort()
+          .join(",")
+      );
 
       const idb = await openDb();
       await enforceEpoch(idb, `v${CACHE_VERSION}:bb${breadboxVersion}`);
@@ -322,12 +348,16 @@ export async function buildPersistentKey(
     return null;
   }
 
-  const declaredDeps = persist === true ? [] : persist.deps;
+  const wholeCatalog = persist !== true && "wholeCatalog" in persist;
+  const declaredDeps =
+    persist !== true && "deps" in persist ? persist.deps : [];
   const addresses = extractAddresses(cacheKey);
 
-  if (addresses.length === 0 && declaredDeps.length === 0) {
+  if (addresses.length === 0 && declaredDeps.length === 0 && !wholeCatalog) {
     // The call site asserted immutability, but nothing in the request names a
     // dataset, so the assertion can't be checked. Refuse rather than trust it.
+    // (A wholeCatalog assertion is exempt: its dependency is the catalog
+    // itself, checked and folded into the key below.)
     persistentCacheStats.refusedNoDatasetAddress += 1;
     return null;
   }
@@ -383,6 +413,22 @@ export async function buildPersistentKey(
       persistentCacheStats.refusedNotPublic += 1;
       return null;
     }
+  }
+
+  // A wholeCatalog response depends on every dataset the caller can see, so
+  // it is expressible on disk only when that catalog is entirely public — the
+  // stored bytes are then derived from public data alone. This is about
+  // BYTES, not keys: IndexedDB is readable wholesale, so no keying scheme can
+  // make a private-derived response safe to store. The fingerprint pins which
+  // datasets (and, since UUIDs pin contents, which bytes) produced the
+  // response; any listing change rotates the key on the next page load.
+  if (wholeCatalog) {
+    if (!catalogIsAllPublic) {
+      persistentCacheStats.refusedPrivateCatalog += 1;
+      return null;
+    }
+
+    resolvedSuffixes.push(`catalog=${catalogFingerprint}`);
   }
 
   resolvedSuffixes.sort();
@@ -735,6 +781,8 @@ export function __resetForTests(): void {
   maxBytes = DEFAULT_MAX_BYTES;
   versionMap = null;
   publicUuids = null;
+  catalogIsAllPublic = false;
+  catalogFingerprint = "";
   touched.clear();
 
   persistentCacheStats.hits = 0;
@@ -745,6 +793,7 @@ export function __resetForTests(): void {
   persistentCacheStats.bytesEvicted = 0;
   persistentCacheStats.refusedNotPublic = 0;
   persistentCacheStats.refusedNoDatasetAddress = 0;
+  persistentCacheStats.refusedPrivateCatalog = 0;
   persistentCacheStats.refusedUnresolvable = 0;
   persistentCacheStats.refusedTooLarge = 0;
   persistentCacheStats.refusedNotReady = 0;

--- a/frontend/packages/@depmap/data-explorer-2/docs/adr/0008-persistent-api-cache-opt-in.md
+++ b/frontend/packages/@depmap/data-explorer-2/docs/adr/0008-persistent-api-cache-opt-in.md
@@ -79,27 +79,41 @@ direction. When you add a Data Explorer call site, decide explicitly.
 - **Filtered `getDimensionTypeIdentifiers`** (`data_type`,
   `show_only_dimensions_in_datasets`): **never persist.** The backend filters through
   the _user's_ accessible datasets, so the response is per-user. Keep plain `cached()`.
-- **Never persist:** `fetchAssociations` (see above), `getContextDatasetCoverage`
-  (next bullet), `getTaskStatus` (mutable by nature), and the bootstrap methods
+- **Never persist:** `fetchAssociations` (see above), `getTaskStatus` (mutable by
+  nature), and the bootstrap methods
   `getDatasets` / `getDimensionTypes` / `getDataset`. The last three are not merely
   "not worth it": the correctness argument
   _requires_ `getDatasets` to be fresh every load (it seeds the registry and populates
   pickers — deletion handling exists only because of this), `getDimensionTypes` is the
   source the persisted helpers resolve deps from, and `getDataset` returns metadata
   that is PATCH-able under a stable UUID.
-- **`getContextDatasetCoverage` is the sharpest counterexample on record.** Its
-  request is the same Context body `evaluateContext` takes and it runs the same
-  evaluator, so the analogy invites "upgrading" it to a persisted helper someday.
-  Don't. The assertion fails on the _response_ side, twice over. First, coverage is
-  computed across the caller's entire accessible catalog — datasets named nowhere in
-  the request — and user identity arrives via proxy headers the cache key can never
-  see; the enumerated dataset ids would disclose private datasets' existence to the
-  next user of a shared store. Second, its answer depends on what exists _right now_:
-  datasets are uploaded at runtime, between deploys, where the epoch offers no
-  protection, so even a public-only variant would serve coverage that silently omits
-  new datasets. Plain in-memory `cached()` is exactly right for it — a page belongs
-  to one user and one moment in catalog time, which are the two dimensions the
-  persistent key cannot express.
+- **`getContextDatasetCoverage` — the whole-catalog case, and what it taught us.**
+  Its request is the same Context body `evaluateContext` takes and it runs the same
+  evaluator, so the analogy invites `persist: true` someday. Don't: the assertion
+  fails on the _response_ side. Coverage is computed across the caller's entire
+  accessible catalog — datasets named nowhere in the request — and user identity
+  arrives via proxy headers the cache key can never see. It persists via
+  `persist: { wholeCatalog: true }` instead, which makes the dependency explicit
+  and lets the engine decide per session:
+
+  - **Only when the caller's entire visible catalog is public.** This is the
+    load-bearing invariant, and it is about BYTES, not keys: IndexedDB is
+    readable wholesale (devtools, shared machines), so no keying scheme can make
+    a private-derived response safe to store. For an all-public caller the full
+    response is derived from public data alone, so storing it discloses nothing.
+    Anyone who can see a private dataset stays in-memory only, permanently.
+  - **Keyed by a fingerprint of the listing.** Coverage depends on what exists
+    _right now_, and datasets are uploaded at runtime where the epoch offers no
+    protection — but the registry is rebuilt from a fresh `getDatasets()` every
+    page load, so folding a hash of the sorted listing UUIDs into the key makes
+    entries self-invalidate on any catalog change, the same way given_id keys
+    do. (Since UUIDs pin contents, the fingerprint pins the entire input.)
+
+  An earlier revision of this bullet presented both objections as absolute. Only
+  the bytes-on-disk one is; the catalog-time one is answerable by the key. If a
+  future endpoint needs full-fidelity persistence for private-visible users too,
+  that requires server-side changes (a public/private scope split) — the client
+  alone cannot express it.
 
 Misclassifying in the safe direction (not persisting something immutable) costs a cache
 hit. Misclassifying in the unsafe direction is the only real hazard, and the engine's

--- a/frontend/packages/@depmap/data-explorer-2/index.ts
+++ b/frontend/packages/@depmap/data-explorer-2/index.ts
@@ -22,6 +22,7 @@ export {
 // that reopening one doesn't mean re-picking them. See the module for why the
 // scope is part of the key.
 export {
+  forgetRememberedColumns,
   loadRememberedColumns,
   rememberColumns,
 } from "./src/utils/rememberedTableColumns";

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/promptForExpansionMembers.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/promptForExpansionMembers.tsx
@@ -21,6 +21,7 @@ import {
   varianceLowerBound,
 } from "../../../../services/dataExplorerAPI/expansionMembers";
 import {
+  forgetRememberedColumns,
   loadRememberedColumns,
   rememberColumns,
 } from "../../../../utils/rememberedTableColumns";
@@ -345,6 +346,17 @@ function MembersTable({
           })}
           onChangeSlices={(nextSlices: SliceQuery[]) =>
             rememberColumns("expansion-members", slice_type, nextSlices)
+          }
+          // Each remembered column is a full fetch of every entity of the type
+          // (see the implicitFilter HACK above), so a set someone built up over
+          // several sittings can arrive as enough concurrent load for Breadbox
+          // to refuse the batch outright. That failure is deterministic —
+          // reopening or refreshing replays the identical requests — so the
+          // memory has to go for the retry to have any chance. Dropping it puts
+          // the table back to id and label, which is what a first-time open
+          // would have loaded.
+          onLoadError={() =>
+            forgetRememberedColumns("expansion-members", slice_type)
           }
           onChangeRowSelection={(nextSelection) => {
             const ids = candidateIds.filter((id) => nextSelection[id]);

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/computeOptions.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DimensionSelectV2/useDimensionStateManager/computeOptions.ts
@@ -93,7 +93,13 @@ async function fetchContextCoverage(dimension: State["dimension"]) {
   }
 
   try {
-    return await cached(breadboxAPI).getContextDatasetCoverage(
+    // wholeCatalog, not persist: true — the response spans every dataset the
+    // caller can see, so the engine persists it only for callers whose whole
+    // catalog is public (keyed by a fingerprint of the listing) and keeps it
+    // in-memory-only for anyone who can see a private dataset. See ADR 0008.
+    return await cached(breadboxAPI, {
+      persist: { wholeCatalog: true },
+    }).getContextDatasetCoverage(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       dimension.context as any
     );

--- a/frontend/packages/@depmap/data-explorer-2/src/utils/__tests__/rememberedTableColumns.test.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/__tests__/rememberedTableColumns.test.ts
@@ -1,4 +1,5 @@
 import {
+  forgetRememberedColumns,
   loadRememberedColumns,
   rememberColumns,
 } from "../rememberedTableColumns";
@@ -96,6 +97,32 @@ test("drops slices that have stopped being well-formed", () => {
   expect(loadRememberedColumns("gene-transcripts", "transcript")).toEqual([
     TPM,
   ]);
+});
+
+test("forgetting reads as never-stored, not as an empty set", () => {
+  rememberColumns("expansion-members", "transcript", [TPM, GENE]);
+  forgetRememberedColumns("expansion-members", "transcript");
+
+  // Null rather than [] specifically so the caller's defaults come back — the
+  // whole point of forgetting a set that couldn't be loaded.
+  expect(loadRememberedColumns("expansion-members", "transcript")).toBeNull();
+});
+
+test("forgetting leaves other entries alone", () => {
+  rememberColumns("expansion-members", "transcript", [TPM]);
+  rememberColumns("gene-transcripts", "transcript", [GENE]);
+
+  forgetRememberedColumns("expansion-members", "transcript");
+
+  expect(loadRememberedColumns("gene-transcripts", "transcript")).toEqual([
+    GENE,
+  ]);
+});
+
+test("forgetting something never stored is a no-op", () => {
+  expect(() =>
+    forgetRememberedColumns("expansion-members", "transcript")
+  ).not.toThrow();
 });
 
 test("survives storage holding something that isn't JSON", () => {

--- a/frontend/packages/@depmap/data-explorer-2/src/utils/rememberedTableColumns.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/utils/rememberedTableColumns.ts
@@ -66,6 +66,29 @@ export function loadRememberedColumns(
   return stored.filter(isValidSliceQuery);
 }
 
+// Drops the memory entirely, so the next open falls back to the caller's
+// defaults rather than to "the user closed everything".
+//
+// The case this exists for: a remembered set large enough that loading it all
+// at once gets the whole batch rejected. That failure is reproducible by
+// construction — refreshing replays the same request — so the table would stay
+// broken until someone thought to clear their storage. Forgetting on failure
+// makes the retry the user was already going to attempt the thing that fixes
+// it. The cost is a column set they have to re-pick; the alternative is a
+// feature that stays dead.
+export function forgetRememberedColumns(
+  scope: RememberedColumnsScope,
+  slice_type: string
+) {
+  try {
+    const all = readAll();
+    delete all[entryKey(scope, slice_type)];
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(all));
+  } catch (e) {
+    // Same reasoning as rememberColumns: not worth interrupting anyone over.
+  }
+}
+
 export function rememberColumns(
   scope: RememberedColumnsScope,
   slice_type: string,

--- a/frontend/packages/@depmap/selects/src/components/SliceSelect/SearchIndexAwareSliceSelect.tsx
+++ b/frontend/packages/@depmap/selects/src/components/SliceSelect/SearchIndexAwareSliceSelect.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useEffect, useRef } from "react";
 import VanillaAsyncSelect from "react-select/async";
 import { WindowedMenuList } from "react-windowed-select";
 import extendReactSelect from "../../utils/extend-react-select";
 import { SliceSelection } from "./types";
-import { useDefaultOptions, useSearch } from "./hooks";
+import { useDefaultOptions, useSearch, useValueValidity } from "./hooks";
 import formatOptionLabel from "./formatOptionLabel";
 
 const AsyncSelect = extendReactSelect(VanillaAsyncSelect);
@@ -50,29 +50,18 @@ function SearchIndexAwareSliceSelect({
     dataset_id
   );
 
-  const invalidValue = useMemo(() => {
-    if (!dataset_id || !value || isLoadingDefaultOptions) {
-      return false;
+  const { invalidValue, disabledValueLabel } = useValueValidity(
+    slice_type,
+    dataType,
+    dataset_id,
+    value
+  );
+
+  useEffect(() => {
+    if (disabledValueLabel) {
+      searchQuery.current = disabledValueLabel;
     }
-
-    for (let i = 0; i < defaultOptions.length; i += 1) {
-      const opt = defaultOptions[i] as {
-        label: string;
-        value: string;
-        isDisabled: boolean;
-      };
-
-      if (value.id === opt.value || value.id === opt.label) {
-        if (opt.isDisabled) {
-          searchQuery.current = opt.label;
-        }
-
-        return opt.isDisabled;
-      }
-    }
-
-    return true;
-  }, [dataset_id, value, isLoadingDefaultOptions, defaultOptions]);
+  }, [disabledValueLabel]);
 
   return (
     <AsyncSelect

--- a/frontend/packages/@depmap/selects/src/components/SliceSelect/convertSearchResultToOptions.ts
+++ b/frontend/packages/@depmap/selects/src/components/SliceSelect/convertSearchResultToOptions.ts
@@ -6,7 +6,7 @@ import {
   fetchDatasetName,
 } from "./api-helpers";
 
-async function fetchDataTypeCompatibleIds(
+export async function fetchDataTypeCompatibleIds(
   slice_type: string,
   dataType: string | null
 ) {
@@ -18,7 +18,7 @@ async function fetchDataTypeCompatibleIds(
   return new Set(ids.map(({ id }) => id));
 }
 
-async function fetchDataVersionCompatibleIds(
+export async function fetchDataVersionCompatibleIds(
   slice_type: string,
   dataset_id: string | null
 ) {
@@ -31,6 +31,76 @@ async function fetchDataVersionCompatibleIds(
 }
 
 const chainLength = (str: string) => str.split(".").length;
+
+function computeDisabledState(
+  id: string,
+  dataTypeCompatibleIds: Set<string>,
+  dataVersionCompatibleIds: Set<string> | null,
+  dataType: string | null,
+  dimensionTypeDisplayName: string,
+  datasetName: string
+) {
+  if (!dataTypeCompatibleIds.has(id)) {
+    return {
+      isDisabled: true,
+      disabledReason: [
+        `The data type "${dataType}"`,
+        "has no data versions with this",
+        dimensionTypeDisplayName,
+      ].join(" "),
+    };
+  }
+
+  if (dataVersionCompatibleIds && !dataVersionCompatibleIds.has(id)) {
+    return {
+      isDisabled: true,
+      disabledReason: [
+        "The data version",
+        `"${datasetName}"`,
+        "doesn’t include this",
+        dimensionTypeDisplayName,
+      ].join(" "),
+    };
+  }
+
+  return { isDisabled: false, disabledReason: "" };
+}
+
+/**
+ * Determines whether a single, already-known identifier (typically the
+ * component's current `value`) is compatible with the given data type /
+ * dataset. Unlike `convertSearchResultToOptions`, this doesn't require the
+ * identifier to be present in a (possibly truncated) options list, so it's
+ * safe to use for validating a value even when `defaultOptions` only
+ * contains a small sample of all identifiers.
+ */
+export async function checkValueCompatibility(
+  id: string,
+  slice_type: string,
+  dataType: string | null,
+  dataset_id: string | null
+) {
+  const [
+    dataTypeCompatibleIds,
+    dataVersionCompatibleIds,
+    dimensionTypeDisplayName,
+    datasetName,
+  ] = await Promise.all([
+    fetchDataTypeCompatibleIds(slice_type, dataType),
+    fetchDataVersionCompatibleIds(slice_type, dataset_id),
+    fetchDimensionTypeDisplayName(slice_type),
+    fetchDatasetName(dataset_id),
+  ]);
+
+  return computeDisabledState(
+    id,
+    dataTypeCompatibleIds,
+    dataVersionCompatibleIds,
+    dataType,
+    dimensionTypeDisplayName,
+    datasetName
+  );
+}
 
 async function convertSearchResultToOptions(
   tokens: string[],
@@ -63,30 +133,14 @@ async function convertSearchResultToOptions(
 
   return result
     .map(({ id, label, matching_properties }) => {
-      let isDisabled = false;
-      let disabledReason = "";
-
-      if (!dataTypeCompatibleIds.has(id)) {
-        isDisabled = true;
-
-        disabledReason = [
-          `The data type "${dataType}"`,
-          "has no data versions with this",
-          dimensionTypeDisplayName,
-        ].join(" ");
-      } else if (
-        dataVersionCompatibleIds &&
-        !dataVersionCompatibleIds.has(id)
-      ) {
-        isDisabled = true;
-
-        disabledReason = [
-          "The data version",
-          `"${datasetName}"`,
-          "doesn’t include this",
-          dimensionTypeDisplayName,
-        ].join(" ");
-      }
+      const { isDisabled, disabledReason } = computeDisabledState(
+        id,
+        dataTypeCompatibleIds,
+        dataVersionCompatibleIds,
+        dataType,
+        dimensionTypeDisplayName,
+        datasetName
+      );
 
       const groupedProps: Record<string, Set<string>> = {};
 

--- a/frontend/packages/@depmap/selects/src/components/SliceSelect/hooks.ts
+++ b/frontend/packages/@depmap/selects/src/components/SliceSelect/hooks.ts
@@ -1,8 +1,19 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { breadboxAPI } from "@depmap/api";
 import { fetchDimensionIdentifiers } from "./api-helpers";
-import convertSearchResultToOptions from "./convertSearchResultToOptions";
+import convertSearchResultToOptions, {
+  checkValueCompatibility,
+} from "./convertSearchResultToOptions";
 import { tokenize } from "./utils";
+
+// react-select builds a full menu-option object (with several bound
+// closures) for every entry in `options`. Handing it every identifier for
+// a dimension type -- which can be hundreds of thousands of rows -- makes
+// the Select extremely slow to render and bloats memory. Real searches
+// already go through `useSearch` below, which is bounded by the backend's
+// `limit` param, so the *default* (pre-search) list only needs to show a
+// small, useful sample.
+const MAX_DEFAULT_OPTIONS = 100;
 
 export const useDefaultOptions = (
   slice_type: string,
@@ -19,20 +30,23 @@ export const useDefaultOptions = (
       const identifiers = await fetchDimensionIdentifiers(slice_type);
 
       // Make this look like a search result so we can reuse the logic of
-      // `convertSearchResultToOptions`.
-      const result = identifiers.map((identifier) => {
-        return {
-          type_name: slice_type,
-          id: identifier.id,
-          label: identifier.label,
-          matching_properties: [
-            {
-              property: "label",
-              value: identifier.label,
-            },
-          ],
-        };
-      });
+      // `convertSearchResultToOptions`. Only convert a bounded slice of
+      // identifiers -- see MAX_DEFAULT_OPTIONS above.
+      const result = identifiers
+        .slice(0, MAX_DEFAULT_OPTIONS)
+        .map((identifier) => {
+          return {
+            type_name: slice_type,
+            id: identifier.id,
+            label: identifier.label,
+            matching_properties: [
+              {
+                property: "label",
+                value: identifier.label,
+              },
+            ],
+          };
+        });
 
       const options = await convertSearchResultToOptions(
         [],
@@ -75,4 +89,58 @@ export const useSearch = (
     },
     [slice_type, dataType, dataset_id]
   );
+};
+
+/**
+ * Determines whether the currently selected value is still valid/enabled
+ * for the given slice type, data type, and dataset. This is checked
+ * directly against the backend rather than by scanning `defaultOptions`,
+ * since `defaultOptions` is now truncated (see MAX_DEFAULT_OPTIONS above)
+ * and may not contain the current value even when it's perfectly valid.
+ *
+ * Also returns the value's label so callers can continue to show it (e.g.
+ * in a search box) when it turns out to be disabled.
+ */
+export const useValueValidity = (
+  slice_type: string,
+  dataType: string | null,
+  dataset_id: string | null,
+  value: { id: string; label: string } | null
+) => {
+  const [invalidValue, setInvalidValue] = useState(false);
+  const [disabledValueLabel, setDisabledValueLabel] = useState<string | null>(
+    null
+  );
+  const requestId = useRef(0);
+
+  useEffect(() => {
+    if (!dataset_id || !value) {
+      setInvalidValue(false);
+      setDisabledValueLabel(null);
+      return;
+    }
+
+    requestId.current += 1;
+    const thisRequestId = requestId.current;
+
+    (async () => {
+      const { isDisabled } = await checkValueCompatibility(
+        value.id,
+        slice_type,
+        dataType,
+        dataset_id
+      );
+
+      // Ignore stale responses (e.g. the user changed `value`/`dataset_id`
+      // again before this request resolved).
+      if (thisRequestId !== requestId.current) {
+        return;
+      }
+
+      setInvalidValue(isDisabled);
+      setDisabledValueLabel(isDisabled ? value.label : null);
+    })();
+  }, [slice_type, dataType, dataset_id, value]);
+
+  return { invalidValue, disabledValueLabel };
 };

--- a/frontend/packages/@depmap/slice-table/src/components/LoadingProgress.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/LoadingProgress.tsx
@@ -1,0 +1,40 @@
+import React, { useEffect, useState } from "react";
+import { ProgressBar } from "react-bootstrap";
+import styles from "../styles/SliceTable.scss";
+
+// A warm persistent-cache load can finish in a frame or two, where a
+// determinate bar appearing and vanishing reads as a glitch.
+const REVEAL_DELAY_MS = 400;
+
+interface Props {
+  loaded: number;
+  total: number;
+}
+
+/** Determinate progress for SliceTable's one-request-per-column fetches. */
+function LoadingProgress({ loaded, total }: Props) {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => setVisible(true), REVEAL_DELAY_MS);
+
+    return () => window.clearTimeout(timeout);
+  }, []);
+
+  // Nothing to watch with a single column.
+  if (!visible || total <= 1) {
+    return null;
+  }
+
+  const percent = (loaded / total) * 100;
+  const text =
+    loaded === 0 ? "Loading..." : `Loading ${loaded} of ${total} columns`;
+
+  return (
+    <div className={styles.loadingProgress}>
+      <ProgressBar active striped now={percent} label={text} srOnly />
+    </div>
+  );
+}
+
+export default LoadingProgress;

--- a/frontend/packages/@depmap/slice-table/src/components/SlicePreview/CategoricalDataPreview.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/SlicePreview/CategoricalDataPreview.tsx
@@ -1,7 +1,12 @@
 import React, { useCallback, useMemo, useState } from "react";
 import { Checkbox } from "react-bootstrap";
+import { pluralize, uncapitalize } from "@depmap/data-explorer-2";
 import BarChart from "./BarChart";
 import shouldUseLogScale from "./shouldUseLogScale";
+import getCategoricalPreviewMode, {
+  CategoricalPreviewMode,
+  TRUNCATED_CATEGORY_COUNT,
+} from "./getCategoricalPreviewMode";
 import styles from "../../styles/AddColumnModal.scss";
 
 interface Props {
@@ -50,27 +55,63 @@ function CategoricalDataPreview({
 
   const totalCount = totalCountProp ?? (dataValues ? dataValues.length : 0);
 
-  const { plotData, valueToOriginal, naIndex } = useMemo(() => {
+  const {
+    plotData,
+    valueToOriginal,
+    naIndex,
+    previewMode,
+    distinctCount,
+    valueCount,
+  } = useMemo(() => {
     if (!dataValues) {
       return {
         plotData: { x: [] as string[], y: [] as number[] },
         valueToOriginal: new Map<string, string | number>(),
         naIndex: -1,
+        previewMode: "plot" as CategoricalPreviewMode,
+        distinctCount: 0,
+        valueCount: 0,
       };
     }
 
     const countsByValue = new Map<string | number, number>();
+    let numValues = 0;
 
     dataValues.flat().forEach((val: string | number | undefined) => {
       if (val !== undefined) {
         countsByValue.set(val, (countsByValue.get(val) ?? 0) + 1);
+        numValues += 1;
       }
     });
 
+    const mode = getCategoricalPreviewMode(countsByValue.size, numValues);
+
+    if (mode === "omit") {
+      // Skip building the plot entirely.
+      return {
+        plotData: { x: [] as string[], y: [] as number[] },
+        valueToOriginal: new Map<string, string | number>(),
+        naIndex: -1,
+        previewMode: mode,
+        distinctCount: countsByValue.size,
+        valueCount: numValues,
+      };
+    }
+
     // Convert to array and sort by counts descending
-    const entries = Array.from(countsByValue.entries()).sort(
+    const sorted = Array.from(countsByValue.entries()).sort(
       (a, b) => b[1] - a[1]
     );
+
+    const hasNaBar = showNulls && nullCount > 0;
+
+    // Keep the total number of bars at (or under) the limit, leaving room for
+    // the N/A bar so toggling it can't push us over and bring back the range
+    // slider.
+    const entries =
+      mode === "truncate"
+        ? sorted.slice(0, TRUNCATED_CATEGORY_COUNT - (hasNaBar ? 1 : 0))
+        : sorted;
 
     // Map string keys back to original values (preserves number vs string)
     const valToOrig = new Map<string, string | number>();
@@ -81,7 +122,7 @@ function CategoricalDataPreview({
     const x = entries.map(([value]) => `${value}`);
     const y = entries.map(([, count]) => count);
 
-    if (showNulls && nullCount > 0) {
+    if (hasNaBar) {
       // Insert at the correct position to maintain descending sort order.
       const insertAt = y.findIndex((count) => count <= nullCount);
       const pos = insertAt === -1 ? y.length : insertAt;
@@ -92,7 +133,10 @@ function CategoricalDataPreview({
     return {
       plotData: { x, y },
       valueToOriginal: valToOrig,
-      naIndex: showNulls && nullCount > 0 ? x.indexOf("N/A") : -1,
+      naIndex: hasNaBar ? x.indexOf("N/A") : -1,
+      previewMode: mode,
+      distinctCount: countsByValue.size,
+      valueCount: numValues,
     };
   }, [dataValues, showNulls, nullCount]);
 
@@ -140,8 +184,37 @@ function CategoricalDataPreview({
     return naIndex >= 0 ? new Set([naIndex]) : undefined;
   }, [naIndex]);
 
+  const entity = entityLabel ? uncapitalize(entityLabel) : "value";
+  const entities = entityLabel ? pluralize(entity) : "values";
+
+  if (previewMode === "omit") {
+    return (
+      <div className={styles.CategoricalDataPreview}>
+        <div className={styles.omittedPlot} data-preview-mode="omit">
+          <p>
+            <strong>{hoverLabel}</strong> has {distinctCount.toLocaleString()}{" "}
+            distinct values across {valueCount.toLocaleString()} {entities}.
+          </p>
+          <p>
+            Nearly every {entity} has its own value, so a distribution plot
+            wouldn’t tell you anything. It has been omitted.
+          </p>
+          {withFilter && (
+            <p>
+              Enter the value you want directly instead of picking it from a
+              plot.
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className={styles.CategoricalDataPreview}>
+    <div
+      className={styles.CategoricalDataPreview}
+      data-preview-mode={previewMode}
+    >
       <div className={styles.barChartContainer}>
         <BarChart
           data={plotData}
@@ -156,6 +229,20 @@ function CategoricalDataPreview({
           onSelect={withFilter ? handleSelect : undefined}
         />
       </div>
+      {previewMode === "truncate" && (
+        <div className={styles.truncationNote}>
+          Showing the {TRUNCATED_CATEGORY_COUNT} most common of{" "}
+          {distinctCount.toLocaleString()} values. There are too many to browse,
+          so this window is fixed.
+          {withFilter && (
+            <>
+              <br />
+              To use a value that isn’t shown, enter it directly instead of
+              picking it from the plot.
+            </>
+          )}
+        </div>
+      )}
       {nullCount > 0 && (
         <Checkbox
           className={styles.showNulls}

--- a/frontend/packages/@depmap/slice-table/src/components/SlicePreview/__tests__/CategoricalDataPreview.test.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/SlicePreview/__tests__/CategoricalDataPreview.test.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import CategoricalDataPreview from "../CategoricalDataPreview";
+import { TRUNCATED_CATEGORY_COUNT } from "../getCategoricalPreviewMode";
+
+jest.mock("../BarChart", () => ({
+  __esModule: true,
+  default: ({ data }: { data: { x: string[]; y: number[] } }) => (
+    <div data-testid="bar-chart" data-bars={data.x.join(",")}>
+      {data.x.length}
+    </div>
+  ),
+}));
+
+const renderPreview = (
+  dataValues: (string | number | string[])[],
+  initiallyShowNulls = false
+) =>
+  render(
+    <CategoricalDataPreview
+      dataValues={dataValues}
+      xAxisTitle="Some column"
+      hoverLabel="Some column"
+      entityLabel="Model"
+      initiallyShowNulls={initiallyShowNulls}
+    />
+  );
+
+const barCount = () => Number(screen.getByTestId("bar-chart").textContent);
+
+const bars = () =>
+  screen.getByTestId("bar-chart").getAttribute("data-bars")!.split(",");
+
+describe("CategoricalDataPreview", () => {
+  it("plots an ordinary categorical column", () => {
+    const dataValues = Array.from(
+      { length: 1000 },
+      (_, i) => `lineage_${i % 20}`
+    );
+
+    renderPreview(dataValues);
+
+    expect(barCount()).toBe(20);
+    expect(screen.queryByText(/most common of/)).toBe(null);
+  });
+
+  it("omits the plot when the column is ~1-to-1 with the ID column", () => {
+    const dataValues = Array.from({ length: 1000 }, (_, i) => `ACH-${i}`);
+
+    const { container } = renderPreview(dataValues);
+
+    expect(screen.queryByTestId("bar-chart")).toBe(null);
+    expect(container.querySelector("[data-preview-mode='omit']")).toBeTruthy();
+    expect(container.textContent).toContain(
+      "1,000 distinct values across 1,000 models"
+    );
+  });
+
+  it("plots a fixed window of the most common values when there are too many categories", () => {
+    // 400 distinct values whose counts vary: value_0 is the most common, and
+    // the counts fall off from there.
+    const dataValues: string[] = [];
+    for (let i = 0; i < 400; i += 1) {
+      for (let j = 0; j < 400 - i; j += 1) {
+        dataValues.push(`value_${i}`);
+      }
+    }
+
+    const { container } = renderPreview(dataValues);
+
+    expect(
+      container.querySelector("[data-preview-mode='truncate']")
+    ).toBeTruthy();
+    // Exactly at the limit, which is what keeps BarChart's range slider (the
+    // control that locks up the browser) from appearing at all.
+    expect(barCount()).toBe(TRUNCATED_CATEGORY_COUNT);
+    expect(bars()[0]).toBe("value_0");
+    expect(bars()).not.toContain("value_399");
+    expect(container.textContent).toContain(
+      `Showing the ${TRUNCATED_CATEGORY_COUNT} most common of 400 values`
+    );
+  });
+
+  it("keeps the truncated window at the limit when the N/A bar is shown", () => {
+    const dataValues: (string | undefined)[] = [];
+    for (let i = 0; i < 400; i += 1) {
+      for (let j = 0; j < 400 - i; j += 1) {
+        dataValues.push(`value_${i}`);
+      }
+    }
+    // Enough nulls to land in the middle of the truncated window.
+    for (let i = 0; i < 390; i += 1) {
+      dataValues.push(undefined);
+    }
+
+    renderPreview(dataValues as (string | number)[], true);
+
+    expect(barCount()).toBe(TRUNCATED_CATEGORY_COUNT);
+    expect(bars()).toContain("N/A");
+  });
+});

--- a/frontend/packages/@depmap/slice-table/src/components/SlicePreview/__tests__/getCategoricalPreviewMode.test.ts
+++ b/frontend/packages/@depmap/slice-table/src/components/SlicePreview/__tests__/getCategoricalPreviewMode.test.ts
@@ -1,0 +1,59 @@
+import getCategoricalPreviewMode, {
+  MAX_PLOTTABLE_CATEGORIES,
+  NEAR_UNIQUE_MIN_DISTINCT,
+} from "../getCategoricalPreviewMode";
+
+describe("getCategoricalPreviewMode", () => {
+  it("plots an ordinary categorical column", () => {
+    // e.g. lineage across 2000 models
+    expect(getCategoricalPreviewMode(30, 2000)).toBe("plot");
+  });
+
+  it("plots a small column even when every value is unique", () => {
+    expect(getCategoricalPreviewMode(10, 10)).toBe("plot");
+  });
+
+  it("omits a column that is a 1-to-1 mapping of the ID column", () => {
+    expect(getCategoricalPreviewMode(2000, 2000)).toBe("omit");
+  });
+
+  it("omits a column that is close to 1-to-1", () => {
+    // 95% of values are distinct
+    expect(getCategoricalPreviewMode(1900, 2000)).toBe("omit");
+  });
+
+  it("does not omit near-unique below the distinct-value floor", () => {
+    expect(getCategoricalPreviewMode(NEAR_UNIQUE_MIN_DISTINCT - 1, 49)).toBe(
+      "plot"
+    );
+  });
+
+  it("truncates when counts vary but there are too many categories", () => {
+    // The reported case: DepmapGeneName over transcripts. Far from 1-to-1, so
+    // the most common values are worth seeing — just not all 29,496 of them.
+    expect(getCategoricalPreviewMode(29496, 336580)).toBe("truncate");
+  });
+
+  it("truncates a column the plot could render but nobody could read", () => {
+    // ~3,700 categories still plots, but only 20 fit in the window and the
+    // tick labels past ~39 get dropped arbitrarily.
+    expect(getCategoricalPreviewMode(3657, 100000)).toBe("truncate");
+  });
+
+  it("plots right up to the category limit", () => {
+    expect(
+      getCategoricalPreviewMode(
+        MAX_PLOTTABLE_CATEGORIES,
+        MAX_PLOTTABLE_CATEGORIES * 10
+      )
+    ).toBe("plot");
+  });
+
+  it("prefers omitting over truncating when a huge column is also near-unique", () => {
+    expect(getCategoricalPreviewMode(100000, 100000)).toBe("omit");
+  });
+
+  it("handles an empty column", () => {
+    expect(getCategoricalPreviewMode(0, 0)).toBe("plot");
+  });
+});

--- a/frontend/packages/@depmap/slice-table/src/components/SlicePreview/getCategoricalPreviewMode.ts
+++ b/frontend/packages/@depmap/slice-table/src/components/SlicePreview/getCategoricalPreviewMode.ts
@@ -1,0 +1,64 @@
+// A categorical column is often a 1-to-1 (or nearly 1-to-1) mapping of the ID
+// column — think an ID, a name, or a free-text description. Plotting one bar
+// per distinct value is at best uninformative and at worst fatal: BarChart
+// shows a range slider above 20 categories, and dragging it relayouts every
+// tick label, which locks up the browser at tens of thousands of values.
+
+// Below this many distinct values, a bar chart is cheap and readable even if
+// every value happens to be unique.
+export const NEAR_UNIQUE_MIN_DISTINCT = 50;
+
+// Fraction of values that must be distinct to call the column "nearly unique."
+export const NEAR_UNIQUE_RATIO = 0.9;
+
+// Past this many bars, browsing the distribution stops being worth it. This is
+// set by legibility, not performance — the plot stays responsive well past it.
+// BarChart's window holds 20 bars and `updateTickDensity` can only label ~39,
+// so beyond that it keeps every k-th label by index; since bars are sorted by
+// count, which ones survive is arbitrary. 150 is about 7 windows of browsing,
+// which is tedious but tractable, and the range slider's overview still has a
+// readable shape.
+export const MAX_PLOTTABLE_CATEGORIES = 150;
+
+// How many bars to keep when truncating. This matches BarChart's initial
+// window (and its `nticks`), so the truncated plot looks like what the user
+// would have seen anyway before touching the range slider. Keeping it at 20
+// also keeps `showRangeSlider` false, which is what makes the window fixed.
+export const TRUNCATED_CATEGORY_COUNT = 20;
+
+export type CategoricalPreviewMode =
+  // Plot every category, with the usual range slider.
+  | "plot"
+  // Plot only the most common categories, with the window fixed.
+  | "truncate"
+  // Don't plot at all — there's nothing to see.
+  | "omit";
+
+/**
+ * Decide how to preview a categorical distribution.
+ *
+ * @param distinctCount - number of distinct values
+ * @param valueCount - total number of values
+ */
+export default function getCategoricalPreviewMode(
+  distinctCount: number,
+  valueCount: number
+): CategoricalPreviewMode {
+  // Every bar would be the same height (or close to it), so a truncated view
+  // would be just as uninformative as the full one.
+  if (
+    distinctCount >= NEAR_UNIQUE_MIN_DISTINCT &&
+    valueCount > 0 &&
+    distinctCount / valueCount >= NEAR_UNIQUE_RATIO
+  ) {
+    return "omit";
+  }
+
+  // The counts vary enough that the most common values are worth seeing, even
+  // though there are far too many to browse.
+  if (distinctCount > MAX_PLOTTABLE_CATEGORIES) {
+    return "truncate";
+  }
+
+  return "plot";
+}

--- a/frontend/packages/@depmap/slice-table/src/components/SliceTable.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/SliceTable.tsx
@@ -8,6 +8,7 @@ import { PlotlyLoaderProvider } from "@depmap/data-explorer-2";
 import Controls from "./Controls";
 import rowSelectionChanged from "./rowSelectionChanged";
 import Actions from "./Actions";
+import LoadingProgress from "./LoadingProgress";
 import {
   useSliceTableState,
   filterPredicate,
@@ -37,6 +38,11 @@ interface Props {
     initialRowSelection?: RowSelectionState;
   };
   onChangeSlices?: (nextSlices: SliceQuery[]) => void;
+  // Called when the table fails to load, in addition to (not instead of) the
+  // error the table renders itself. For callers that persist their column
+  // choice: a set that fails to load will keep failing to load, so a plain
+  // retry never recovers unless something throws the persisted set away.
+  onLoadError?: (error: string) => void;
   // Pass a predicate to make only some rows selectable — the checkbox renders
   // disabled for the rest, and "select all" skips them.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -133,6 +139,7 @@ function SliceTable({
   PlotlyLoader,
   getInitialState = () => ({}),
   onChangeSlices = NOOP,
+  onLoadError = NOOP,
   enableRowSelection = false,
   enableMultiRowSelection = false,
   maxRowSelection = undefined,
@@ -196,6 +203,7 @@ function SliceTable({
     data,
     error,
     loading,
+    progress,
     columns,
     rowFilter,
     rowSelection,
@@ -224,6 +232,18 @@ function SliceTable({
   });
 
   const combinedLoading = loading || externalLoading;
+
+  // Held in a ref so the effect below depends on the error alone. Callers pass
+  // this inline, and a new function identity every render would otherwise mean
+  // one notification per render for as long as the error is on screen.
+  const onLoadErrorRef = useRef(onLoadError);
+  onLoadErrorRef.current = onLoadError;
+
+  useEffect(() => {
+    if (error) {
+      onLoadErrorRef.current(error);
+    }
+  }, [error]);
 
   // Compared against what was last *reported*, not against the initial
   // selection. Comparing against the initial one suppressed every return to it:
@@ -289,6 +309,14 @@ function SliceTable({
         {combinedLoading && (
           <div className={styles.loadingContainer}>
             <Spinner position="static" />
+            {/* Gated on `progress` so a caller's own `isLoading` keeps the
+                bare spinner — it has no column count behind it. */}
+            {progress && (
+              <LoadingProgress
+                loaded={progress.loaded}
+                total={progress.total}
+              />
+            )}
           </div>
         )}
         {error && (

--- a/frontend/packages/@depmap/slice-table/src/components/useData.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/useData.tsx
@@ -86,6 +86,10 @@ interface AlignedData {
   }>;
   data: Record<string, string | number | undefined>[];
   loading: boolean;
+  // Non-null only while this hook's own fetch is in flight, so a consumer can
+  // tell it apart from loading for some other reason. `total` counts the
+  // slices being fetched, including the label slice at index 0.
+  progress: { loaded: number; total: number } | null;
   error: string | null;
   entityLabel: string;
   exportToCsv: (options?: {
@@ -697,6 +701,7 @@ export default function useAlignedData({
     // invisible when every load took a network round trip; with persistent-
     // cache hits it can be most of what the user sees.
     loading: true,
+    progress: null,
     error: null,
     entityLabel: "",
     exportToCsv: () => "",
@@ -814,7 +819,12 @@ export default function useAlignedData({
     let isCancelled = false;
 
     const loadData = async () => {
-      setState((prev) => ({ ...prev, loading: true, error: null }));
+      setState((prev) => ({
+        ...prev,
+        loading: true,
+        progress: null,
+        error: null,
+      }));
 
       try {
         // Step 1: Load index type metadata
@@ -873,45 +883,80 @@ export default function useAlignedData({
           values: [],
         };
 
-        // Step 3: Load data. A single slice's failure degrades to a stub
-        // column rather than rejecting the whole table.
-        const dataResponses = await Promise.all(
-          slicesToFetch.map((slice, i) => {
-            if (failures[i]) {
-              return Promise.resolve(EMPTY_RESPONSE);
-            }
+        setState((prev) => ({
+          ...prev,
+          progress: { loaded: 0, total: slicesToFetch.length },
+        }));
 
-            if (i === 0) {
-              return createDataFetchPromise(slice);
-            }
+        let loaded = 0;
+        const onSliceSettled = () => {
+          loaded += 1;
 
-            return createDataFetchPromise(slice).catch((e) => {
-              window.console.warn(
-                "[SliceTable] failed to load slice",
+          if (isCancelled) {
+            return;
+          }
+
+          setState((prev) =>
+            prev.progress
+              ? { ...prev, progress: { ...prev.progress, loaded } }
+              : prev
+          );
+        };
+
+        // Step 3: Load each slice's data and its display label together. A
+        // single slice's failure degrades to a stub column rather than
+        // rejecting the whole table.
+        //
+        // The two run concurrently rather than as sequential passes, since
+        // label resolution costs a request for matrix feature/sample slices
+        // and used to start only after every column's data had landed.
+        const settled = await Promise.all(
+          slicesToFetch.map(
+            (slice, i): Promise<[SliceResponse, string]> => {
+              if (failures[i]) {
+                onSliceSettled();
+                return Promise.resolve([
+                  EMPTY_RESPONSE,
+                  fallbackDisplayLabel(slice),
+                ]);
+              }
+
+              // Index 0 is the label slice: without it there are no rows, so it
+              // keeps no `.catch` and fails the whole table via the outer try.
+              const dataPromise =
+                i === 0
+                  ? createDataFetchPromise(slice)
+                  : createDataFetchPromise(slice).catch((e) => {
+                      window.console.warn(
+                        "[SliceTable] failed to load slice",
+                        slice,
+                        e
+                      );
+                      failures[i] = "fetch_failed";
+                      return EMPTY_RESPONSE;
+                    });
+
+              const labelPromise = resolveDisplayLabel(
                 slice,
-                e
+                indexType
+              ).catch(() => fallbackDisplayLabel(slice));
+
+              return Promise.all([dataPromise, labelPromise]).finally(
+                onSliceSettled
               );
-              failures[i] = "fetch_failed";
-              return EMPTY_RESPONSE;
-            });
-          })
-        );
-
-        if (isCancelled) return;
-
-        // Resolve display labels for each slice. Failed slices fall back to
-        // their raw identifiers rather than issuing more doomed requests.
-        const displayLabels = await Promise.all(
-          slicesToFetch.map((slice, i) =>
-            failures[i]
-              ? Promise.resolve(fallbackDisplayLabel(slice))
-              : resolveDisplayLabel(slice, indexType).catch(() =>
-                  fallbackDisplayLabel(slice)
-                )
+            }
           )
         );
 
         if (isCancelled) return;
+
+        const dataResponses = settled.map(([response]) => response);
+
+        // A slice that failed after its label resolution was already under way
+        // still reports raw identifiers, matching the stub column's header.
+        const displayLabels = settled.map(([, label], i) =>
+          failures[i] ? fallbackDisplayLabel(slicesToFetch[i]) : label
+        );
 
         // Grab the sample/feature labels for any referenced types
         const idToLabelMappings = {} as Record<string, Record<string, string>>;
@@ -965,6 +1010,7 @@ export default function useAlignedData({
           columns,
           entityLabel: indexType.display_name || indexType.name,
           loading: false,
+          progress: null,
           error: null,
         }));
       } catch (error) {
@@ -976,6 +1022,7 @@ export default function useAlignedData({
           setState((prev) => ({
             ...prev,
             loading: false,
+            progress: null,
             error: `Failed to load data: ${errorMessage}`,
           }));
         }
@@ -993,6 +1040,7 @@ export default function useAlignedData({
     columns: state.columns,
     data: state.data,
     loading: state.loading,
+    progress: state.progress,
     error: state.error,
     entityLabel: state.entityLabel,
     exportToCsv,

--- a/frontend/packages/@depmap/slice-table/src/components/useSliceTableState.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/useSliceTableState.tsx
@@ -275,7 +275,7 @@ export function useSliceTableState({
   }, [initialSlices, slices, onChangeSlices]);
 
   // Fetch data without any filtering — useData now returns the full dataset
-  const { columns, data, loading, error, exportToCsv } = useData({
+  const { columns, data, loading, progress, error, exportToCsv } = useData({
     getColumnDisplayOptions,
     index_type_name,
     slices,
@@ -801,6 +801,7 @@ export function useSliceTableState({
     data,
     error,
     loading,
+    progress,
     columns: extendedColumns,
     rowFilter,
     handleClickAddColumn,

--- a/frontend/packages/@depmap/slice-table/src/styles/AddColumnModal.scss
+++ b/frontend/packages/@depmap/slice-table/src/styles/AddColumnModal.scss
@@ -87,6 +87,30 @@
     min-height: 500px;
   }
 
+  .omittedPlot {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin-left: 30px;
+    padding: 30px;
+    color: grey;
+    font-size: 14px;
+    min-height: 500px;
+    border: 1px dashed #ccc;
+
+    p {
+      text-align: center;
+    }
+  }
+
+  .truncationNote {
+    margin: 5px 30px;
+    color: grey;
+    font-size: 13px;
+    font-style: italic;
+    text-align: center;
+  }
+
   & > div:first-child {
     @extend .fadein;
 

--- a/frontend/packages/@depmap/slice-table/src/styles/SliceTable.scss
+++ b/frontend/packages/@depmap/slice-table/src/styles/SliceTable.scss
@@ -7,9 +7,42 @@
 
 .loadingContainer {
   display: flex;
+  flex-direction: column;
+  gap: 12px;
   height: 100%;
   justify-content: center;
   align-items: center;
+}
+
+.loadingProgress {
+  position: relative;
+  width: 320px;
+  max-width: 80%;
+
+  :global(.progress) {
+    margin-bottom: 0;
+  }
+}
+
+.progressLabel {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: 12px;
+  line-height: 20px;
+  white-space: nowrap;
+  pointer-events: none;
+  color: #333;
+}
+
+.progressLabelOnBar {
+  color: #fff;
+  transition: clip-path 0.6s ease;
 }
 
 .errorContainer {


### PR DESCRIPTION
- cache data from the new dataset coverage endpoint
  - used by the context selector to show you how well represented a context is across each dataset

- improve performance of feature select
  - optimized for long lists of features like transcrripts

- show per-column load progress in SliceTable
  - helps mitigate the long load times of many transcript annotation columns

- fix: discard remembered columns when the table fails to load
  - The facet picker persists which annotations you've added but those requests can overwhelm Breadbox. This makes sure you don't get stuck in a loop where the table can never be loaded because it's too heavy.

- skip bar chart when showing distribution of near-unique columns