### PR TITLE
add retry button to SliceTable

### DIFF
--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/promptForExpansionMembers.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/promptForExpansionMembers.tsx
@@ -351,10 +351,11 @@ function MembersTable({
           // (see the implicitFilter HACK above), so a set someone built up over
           // several sittings can arrive as enough concurrent load for Breadbox
           // to refuse the batch outright. That failure is deterministic —
-          // reopening or refreshing replays the identical requests — so the
-          // memory has to go for the retry to have any chance. Dropping it puts
-          // the table back to id and label, which is what a first-time open
-          // would have loaded.
+          // reopening, refreshing, or hitting the table's own "Try again"
+          // button replays the identical requests — so the memory has to go for
+          // the retry to have any chance. Dropping it puts the table back to id
+          // and label, which is what a first-time open would have loaded, and
+          // is the set "Try again" then re-reads.
           onLoadError={() =>
             forgetRememberedColumns("expansion-members", slice_type)
           }

--- a/frontend/packages/@depmap/slice-table/src/components/SliceTable.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/SliceTable.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import cx from "classnames";
 import { Spinner } from "@depmap/common-components";
 import ReactTable from "@depmap/react-table";
@@ -38,10 +44,16 @@ interface Props {
     initialRowSelection?: RowSelectionState;
   };
   onChangeSlices?: (nextSlices: SliceQuery[]) => void;
-  // Called when the table fails to load, in addition to (not instead of) the
-  // error the table renders itself. For callers that persist their column
-  // choice: a set that fails to load will keep failing to load, so a plain
-  // retry never recovers unless something throws the persisted set away.
+  // Called when the table fails to load outright — it couldn't even build its
+  // index — in addition to (not instead of) the error the table renders itself.
+  // A single column failing to load doesn't come through here; that degrades to
+  // a stub column and leaves the rest of the table usable.
+  //
+  // For callers that persist their column choice: a set that fails to load will
+  // keep failing to load, so this is the hook for throwing the persisted set
+  // away. The "Try again" button rendered alongside the error re-reads
+  // `getInitialState` for exactly that reason, so whatever this callback
+  // discards is gone by the time the retry starts.
   onLoadError?: (error: string) => void;
   // Pass a predicate to make only some rows selectable — the checkbox renders
   // disabled for the rest, and "select all" skips them.
@@ -162,6 +174,7 @@ function SliceTable({
   sliceTableRef = undefined,
 }: Props) {
   const [revision, setRevision] = useState(1);
+  const [retryToken, setRetryToken] = useState(0);
 
   const { initialSlices, viewOnlySlices, initialRowSelection } = useMemo(() => {
     return {
@@ -229,7 +242,19 @@ function SliceTable({
     tableRef,
     implicitFilter,
     hiddenDatasets,
+    retryToken,
   });
+
+  // Two counters bumped together, not one. The revision re-reads
+  // `getInitialState`, which is what gives `onLoadError` a chance to have
+  // mattered — a caller that forgot its remembered columns retries with the
+  // smaller set. The token is what guarantees a refetch at all: when the caller
+  // hands back the identical slices (a stable array, or nothing persisted to
+  // forget), the revision alone changes nothing useData can see.
+  const handleClickRetry = useCallback(() => {
+    setRevision((r) => r + 1);
+    setRetryToken((t) => t + 1);
+  }, []);
 
   const combinedLoading = loading || externalLoading;
 
@@ -319,15 +344,29 @@ function SliceTable({
             )}
           </div>
         )}
-        {error && (
+        {error && !combinedLoading && (
           <div className={styles.errorContainer}>
-            <p>⚠️ Sorry, there was an error loading the table.</p>
+            <div>
+              <p>⚠️ Sorry, there was an error loading the table.</p>
+              <button
+                type="button"
+                className={cx("btn", "btn-default", styles.retryButton)}
+                onClick={handleClickRetry}
+              >
+                <span className="glyphicon glyphicon-refresh" /> Try again
+              </button>
+            </div>
             <details>{error}</details>
           </div>
         )}
         <ReactTable
           tableRef={tableRef}
-          className={combinedLoading ? styles.hidden : ""}
+          // Hidden rather than unmounted so `tableRef` stays live. An error here
+          // means the index itself couldn't be built, so the table has no rows
+          // to show and no prospect of any — leaving it visible put "There are
+          // no rows to display" under the error message, which reads as a second
+          // unrelated thing having gone wrong.
+          className={combinedLoading || error ? styles.hidden : ""}
           height="100%"
           data={filteredData}
           columns={columns}

--- a/frontend/packages/@depmap/slice-table/src/components/__tests__/SliceTable.test.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/__tests__/SliceTable.test.tsx
@@ -1,0 +1,135 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SliceQuery } from "@depmap/types";
+import SliceTable from "../SliceTable";
+
+// The hook under the table. Mocked so a test can put the table into the
+// only state that matters here: the hard failure, where the index itself
+// couldn't be built.
+jest.mock("../useData", () => jest.fn());
+
+// `styles` is otherwise an empty object (see __mocks__/styleMock.js), which
+// would make "hidden" and "not hidden" both come out as undefined.
+jest.mock("../../styles/SliceTable.scss", () => ({
+  hidden: "hiddenTable",
+}));
+
+// Stands in for the real table so its className — the whole mechanism by
+// which a failed load stops rendering "There are no rows to display" — is
+// observable without a stylesheet.
+jest.mock("@depmap/react-table", () => ({
+  __esModule: true,
+  default: ({ className }: { className: string }) => (
+    <div data-testid="react-table" className={className} />
+  ),
+  SearchBar: () => <div data-testid="search-bar" />,
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const useData = require("../useData") as jest.Mock;
+
+const FAILED_LOAD = {
+  columns: [],
+  data: [],
+  loading: false,
+  progress: null,
+  error: "Failed to load data: too many requests",
+  entityLabel: "",
+  exportToCsv: () => "",
+};
+
+const SUCCESSFUL_LOAD = { ...FAILED_LOAD, error: null };
+
+const renderTable = (
+  props: Partial<React.ComponentProps<typeof SliceTable>> = {}
+) =>
+  render(
+    <SliceTable
+      index_type_name="depmap_model"
+      PlotlyLoader={() => null}
+      {...props}
+    />
+  );
+
+describe("SliceTable error state", () => {
+  it("hides the table and offers a retry when the load fails outright", () => {
+    useData.mockReturnValue(FAILED_LOAD);
+    renderTable();
+
+    expect(screen.getByText(/error loading the table/)).toBeTruthy();
+    expect(screen.getByTestId("react-table").className).toBe("hiddenTable");
+    expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
+  });
+
+  it("leaves the table visible and offers no retry when the load succeeds", () => {
+    useData.mockReturnValue(SUCCESSFUL_LOAD);
+    renderTable();
+
+    expect(screen.getByTestId("react-table").className).toBe("");
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+  });
+
+  it("retries against the caller's re-read initial state, not the slices that just failed", () => {
+    useData.mockReturnValue(FAILED_LOAD);
+
+    // Mirrors a caller that drops its persisted columns in `onLoadError`: the
+    // first read hands over a set big enough to sink the table, and every
+    // read after that hands over nothing. A retry that replayed the original
+    // set would fail identically, forever.
+    const rememberedColumns: SliceQuery[] = [
+      { dataset_id: "d1", identifier_type: "column", identifier: "c1" },
+    ];
+    let forgotten = false;
+
+    renderTable({
+      getInitialState: () => ({
+        initialSlices: forgotten ? [] : rememberedColumns,
+      }),
+      onLoadError: () => {
+        forgotten = true;
+      },
+    });
+
+    const slicesOf = (call: unknown[]) =>
+      (call[0] as { slices: SliceQuery[] }).slices;
+    const retryTokenOf = (call: unknown[]) =>
+      (call[0] as { retryToken: number }).retryToken;
+
+    expect(slicesOf(useData.mock.calls[0])).toEqual(rememberedColumns);
+
+    const callsBeforeRetry = useData.mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    const lastCall = useData.mock.calls[useData.mock.calls.length - 1];
+    expect(useData.mock.calls.length).toBeGreaterThan(callsBeforeRetry);
+    expect(slicesOf(lastCall)).toEqual([]);
+    expect(retryTokenOf(lastCall)).toBeGreaterThan(
+      retryTokenOf(useData.mock.calls[0])
+    );
+  });
+
+  it("bumps the retry token even when the caller's initial slices are unchanged", () => {
+    useData.mockReturnValue(FAILED_LOAD);
+
+    // A caller with nothing to forget hands back the same array every time.
+    // Without a token of its own, useData would see identical arguments and
+    // never refetch, leaving the button doing nothing at all.
+    const stableSlices: SliceQuery[] = [
+      { dataset_id: "d1", identifier_type: "column", identifier: "c1" },
+    ];
+
+    renderTable({ getInitialState: () => ({ initialSlices: stableSlices }) });
+
+    const tokenBefore = (useData.mock.calls[
+      useData.mock.calls.length - 1
+    ][0] as { retryToken: number }).retryToken;
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    const tokenAfter = (useData.mock.calls[
+      useData.mock.calls.length - 1
+    ][0] as { retryToken: number }).retryToken;
+
+    expect(tokenAfter).toBeGreaterThan(tokenBefore);
+  });
+});

--- a/frontend/packages/@depmap/slice-table/src/components/useData.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/useData.tsx
@@ -30,6 +30,12 @@ interface Parameters {
   getColumnDisplayOptions?: (
     sliceQuery: SliceQuery
   ) => ColumnDisplayOptions | null;
+  // Bumped by SliceTable's "Try again" button. It's a dependency of the fetch
+  // effect and nothing else, which is what makes a retry refetch even when the
+  // request is identical to the one that just failed — the common case, since a
+  // caller whose slices are a stable array (an imported JSON list, say) gives
+  // this hook nothing else that changes.
+  retryToken?: number;
 }
 
 // Types for better code clarity
@@ -691,6 +697,7 @@ export default function useAlignedData({
   slices,
   viewOnlySlices = undefined,
   getColumnDisplayOptions = undefined,
+  retryToken = 0,
 }: Parameters): AlignedData {
   const [state, setState] = useState<AlignedData>({
     columns: [],
@@ -1034,7 +1041,15 @@ export default function useAlignedData({
     return () => {
       isCancelled = true;
     };
-  }, [getColumnDisplayOptions, index_type_name, slices, viewOnlySlices]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    getColumnDisplayOptions,
+    index_type_name,
+    slices,
+    viewOnlySlices,
+    // Not read by `loadData` — see `retryToken`'s comment above.
+    retryToken,
+  ]);
 
   return {
     columns: state.columns,

--- a/frontend/packages/@depmap/slice-table/src/components/useSliceTableState.tsx
+++ b/frontend/packages/@depmap/slice-table/src/components/useSliceTableState.tsx
@@ -68,6 +68,10 @@ interface Props {
     sliceQuery: SliceQuery
   ) => import("./useData").ColumnDisplayOptions | null;
   hiddenDatasets?: Set<string>;
+  // Bumped by SliceTable's "Try again" button. See `retryToken` in useData for
+  // why the refetch needs a token of its own, and the adjustment below for what
+  // else a retry re-initializes.
+  retryToken: number;
 }
 
 // A column the caller supplies itself, for values that aren't Breadbox slices —
@@ -200,6 +204,7 @@ export function useSliceTableState({
   customColumnPlacement = "end",
   getColumnDisplayOptions = undefined,
   hiddenDatasets = undefined,
+  retryToken,
 }: Props) {
   const [slices, setSlices] = useState<SliceQuery[]>(initialSlices || []);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>(
@@ -226,6 +231,21 @@ export function useSliceTableState({
   if (syncedInitialSelection !== initialRowSelection) {
     setSyncedInitialSelection(initialRowSelection);
     setRowSelection(initialRowSelection);
+  }
+
+  // A retry re-reads `getInitialState` — SliceTable bumps its revision in the
+  // same click — so by the time this runs, `initialSlices` is the freshly-read
+  // set. For a caller that drops what it persisted in `onLoadError` (see
+  // forgetRememberedColumns) that is the smaller set, which is the whole point:
+  // replaying the column set that was just rejected would fail identically
+  // every time, so the retry has to start from whatever the caller now
+  // considers its starting point. Adjusted during render for the same reason
+  // the row selection above is.
+  const [syncedRetryToken, setSyncedRetryToken] = useState(retryToken);
+
+  if (syncedRetryToken !== retryToken) {
+    setSyncedRetryToken(retryToken);
+    setSlices(initialSlices);
   }
 
   const prevIndexTypeName = useRef(index_type_name);
@@ -280,6 +300,7 @@ export function useSliceTableState({
     index_type_name,
     slices,
     viewOnlySlices,
+    retryToken,
   });
 
   // Populate the slice data cache whenever columns or data change.

--- a/frontend/packages/@depmap/slice-table/src/styles/SliceTable.scss
+++ b/frontend/packages/@depmap/slice-table/src/styles/SliceTable.scss
@@ -46,11 +46,36 @@
 }
 
 .errorContainer {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
   height: 100%;
+  max-width: 600px;
+  margin: auto;
 
-  p {
-    font-size: 20px;
+  & > div {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+
+    p {
+      margin-top: 50px;
+      font-size: 20px;
+    }
+
+    button {
+      margin-top: 10px;
+    }
   }
+
+  details {
+    margin-top: 20px;
+    align-self: left;
+  }
+}
+
+.retryButton {
+  margin-top: 16px;
 }
 
 .Controls {


### PR DESCRIPTION
Before, when it failed to load you had no recourse. Now you can at least click to retry.