### PR TITLE
Bump pinned GitHub Actions versions

### DIFF
--- a/.github/actions/prepare-breadbox/action.yaml
+++ b/.github/actions/prepare-breadbox/action.yaml
@@ -17,7 +17,7 @@ runs:
         virtualenvs-in-project: true
 
     - name: "Set up poetry cache"
-      uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+      uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       id: cached-poetry-dependencies
       with:
         path: "${{ steps.poetry-cachedir.outputs.POETRY_CACHEDIR }}"

--- a/.github/workflows/build_app.yml
+++ b/.github/workflows/build_app.yml
@@ -29,9 +29,9 @@ jobs:
   run-frontend-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Setup Node 20.20.2
-        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20.20.2
       - name: Install yarn dependencies
@@ -44,12 +44,12 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn --cwd frontend cache dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+      - uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -62,7 +62,7 @@ jobs:
           echo "SHA=\"${{ github.sha }}\"" > portal-backend/depmap/settings/build.py
           echo "BUILD=\"${{ github.run_number	}}\"" >> portal-backend/depmap/settings/build.py
       - name: Login to Artifact Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: us-central1-docker.pkg.dev
           username: _json_key
@@ -83,9 +83,9 @@ jobs:
       matrix:
         pytest-group: [1, 2, 3, 4, 5]
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Login to Artifact Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: us-central1-docker.pkg.dev
           username: _json_key
@@ -93,7 +93,7 @@ jobs:
       - name: Pull Docker image
         run: docker pull ${{ env.ARTIFACT_REGISTRY_REPO }}:${{ env.DOCKER_TAG }}
       - name: Get pytest durations
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: .test_durations
           key: ${{ runner.os }}-pytest-durations
@@ -106,9 +106,9 @@ jobs:
       - run-pytest
       - run-frontend-tests
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Login to Artifact Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: us-central1-docker.pkg.dev
           username: _json_key

--- a/.github/workflows/build_breadbox.yml
+++ b/.github/workflows/build_breadbox.yml
@@ -38,12 +38,12 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Update build id
         run: |
           echo "SHA=\"${{ github.sha }}\"" > breadbox/build.py
       - name: Login to Artifact Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: us-central1-docker.pkg.dev
           username: _json_key
@@ -64,9 +64,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-docker
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Login to Artifact Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: us-central1-docker.pkg.dev
           username: _json_key
@@ -84,9 +84,9 @@ jobs:
       - build-docker
       - run-pytest
     steps:
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Login to Artifact Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: us-central1-docker.pkg.dev
           username: _json_key

--- a/.github/workflows/build_breadbox_client.yaml
+++ b/.github/workflows/build_breadbox_client.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out"
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           fetch-depth: 0
@@ -34,7 +34,7 @@ jobs:
         uses: ./.github/actions/prepare-breadbox-client # checks out and generates breadbox client code
 
       - name: "Authenticate to Google Cloud"
-        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           credentials_json: "${{ secrets.DEPMAP_ARTIFACTS_SVC_ACCT }}"
 

--- a/.github/workflows/build_lrt_docker.yml
+++ b/.github/workflows/build_lrt_docker.yml
@@ -18,9 +18,9 @@ jobs:
   build-docker-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Login to Artifact Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: us-central1-docker.pkg.dev
           username: _json_key

--- a/.github/workflows/build_pipeline_docker.yml
+++ b/.github/workflows/build_pipeline_docker.yml
@@ -18,9 +18,9 @@ jobs:
   build-docker-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Login to Artifact Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: us-central1-docker.pkg.dev
           username: _json_key

--- a/.github/workflows/build_tda_docker.yml
+++ b/.github/workflows/build_tda_docker.yml
@@ -18,9 +18,9 @@ jobs:
   build-docker-image:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Login to Artifact Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: us-central1-docker.pkg.dev
           username: _json_key

--- a/.github/workflows/record_pytest_durations.yml
+++ b/.github/workflows/record_pytest_durations.yml
@@ -9,13 +9,13 @@ jobs:
   record-pytest-durations:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
       - name: Set up Python 3.9
-        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: 3.13
       - name: Cache pip
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
@@ -23,7 +23,7 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements/') }}
           restore-keys: ${{ runner.os }}-pip-
       - name: Cache node modules
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: "frontend/node_modules"
           key: ${{ runner.os }}-react-frontend-node-modules-${{ hashFiles('frontend/yarn.lock') }}
@@ -36,7 +36,7 @@ jobs:
           yarn --cwd ../frontend install
           yarn --cwd ../frontend "build:portal"
       - name: Cache pytest durations
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3.5.0
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: .test_durations
           key: ${{ runner.os }}-pytest-durations


### PR DESCRIPTION
Update the CI workflows and shared breadbox action to newer pinned releases of `actions/checkout`, `actions/cache`, `actions/setup-node`, `actions/setup-python`, `docker/login-action`, and `google-github-actions/auth`. This keeps the GitHub Actions stack current across app, breadbox, client, docker-image, and pytest-duration jobs.