### PR TITLE
add an option for per-color regression lines in faceted scatterplots

### DIFF
--- a/frontend/packages/@depmap/data-explorer-2/docs/generating-de2-links.md
+++ b/frontend/packages/@depmap/data-explorer-2/docs/generating-de2-links.md
@@ -412,7 +412,7 @@ This produces two heatmaps on the same page: the first is the correlation of the
 
 ### Faceted scatterplot (small multiples)
 
-Setting `facet_by` on a `scatter` plot is the most visually distinctive case: instead of one panel, DE2 renders one small-multiples panel per facet, each with its own regression line (if `show_regression_line` is set) and identity line. This example facets the same TP53-CRISPR-vs-TP53-expression scatterplot from the [basic scatterplot example](#scatterplot) above by `OncotreeLineage`, producing one panel per lineage. ([Open](https://cds.team/depmap/data_explorer_2/?plot=eyJwbG90X3R5cGUiOiJzY2F0dGVyIiwiaW5kZXhfdHlwZSI6ImRlcG1hcF9tb2RlbCIsImRpbWVuc2lvbnMiOnsieCI6eyJheGlzX3R5cGUiOiJyYXdfc2xpY2UiLCJhZ2dyZWdhdGlvbiI6ImZpcnN0IiwiZGF0YXNldF9pZCI6IkNocm9ub3NfQ29tYmluZWQiLCJzbGljZV90eXBlIjoiZ2VuZSIsImNvbnRleHQiOnsiZGltZW5zaW9uX3R5cGUiOiJnZW5lIiwibmFtZSI6IlRQNTMiLCJleHByIjp7Ij09IjpbeyJ2YXIiOiJnaXZlbl9pZCJ9LCI3MTU3Il19LCJ2YXJzIjp7fX19LCJ5Ijp7ImF4aXNfdHlwZSI6InJhd19zbGljZSIsImFnZ3JlZ2F0aW9uIjoiZmlyc3QiLCJkYXRhc2V0X2lkIjoiZXhwcmVzc2lvbiIsInNsaWNlX3R5cGUiOiJnZW5lIiwiY29udGV4dCI6eyJkaW1lbnNpb25fdHlwZSI6ImdlbmUiLCJuYW1lIjoiVFA1MyIsImV4cHIiOnsiPT0iOlt7InZhciI6ImdpdmVuX2lkIn0sIjcxNTciXX0sInZhcnMiOnt9fX19LCJmYWNldF9ieSI6InByb3BlcnR5IiwibWV0YWRhdGEiOnsiZmFjZXRfcHJvcGVydHkiOnsiaWRlbnRpZmllcl90eXBlIjoiY29sdW1uIiwiZGF0YXNldF9pZCI6ImRlcG1hcF9tb2RlbF9tZXRhZGF0YSIsImlkZW50aWZpZXIiOiJPbmNvdHJlZUxpbmVhZ2UifX19))
+Setting `facet_by` on a `scatter` plot is the most visually distinctive case: instead of one panel, DE2 renders one small-multiples panel per facet, each with its own regression line (if `show_regression_line` is set — or one line per color, with [show_regression_line_per_color](#show_regression_line_per_color-boolean)) and identity line. This example facets the same TP53-CRISPR-vs-TP53-expression scatterplot from the [basic scatterplot example](#scatterplot) above by `OncotreeLineage`, producing one panel per lineage. ([Open](https://cds.team/depmap/data_explorer_2/?plot=eyJwbG90X3R5cGUiOiJzY2F0dGVyIiwiaW5kZXhfdHlwZSI6ImRlcG1hcF9tb2RlbCIsImRpbWVuc2lvbnMiOnsieCI6eyJheGlzX3R5cGUiOiJyYXdfc2xpY2UiLCJhZ2dyZWdhdGlvbiI6ImZpcnN0IiwiZGF0YXNldF9pZCI6IkNocm9ub3NfQ29tYmluZWQiLCJzbGljZV90eXBlIjoiZ2VuZSIsImNvbnRleHQiOnsiZGltZW5zaW9uX3R5cGUiOiJnZW5lIiwibmFtZSI6IlRQNTMiLCJleHByIjp7Ij09IjpbeyJ2YXIiOiJnaXZlbl9pZCJ9LCI3MTU3Il19LCJ2YXJzIjp7fX19LCJ5Ijp7ImF4aXNfdHlwZSI6InJhd19zbGljZSIsImFnZ3JlZ2F0aW9uIjoiZmlyc3QiLCJkYXRhc2V0X2lkIjoiZXhwcmVzc2lvbiIsInNsaWNlX3R5cGUiOiJnZW5lIiwiY29udGV4dCI6eyJkaW1lbnNpb25fdHlwZSI6ImdlbmUiLCJuYW1lIjoiVFA1MyIsImV4cHIiOnsiPT0iOlt7InZhciI6ImdpdmVuX2lkIn0sIjcxNTciXX0sInZhcnMiOnt9fX19LCJmYWNldF9ieSI6InByb3BlcnR5IiwibWV0YWRhdGEiOnsiZmFjZXRfcHJvcGVydHkiOnsiaWRlbnRpZmllcl90eXBlIjoiY29sdW1uIiwiZGF0YXNldF9pZCI6ImRlcG1hcF9tb2RlbF9tZXRhZGF0YSIsImlkZW50aWZpZXIiOiJPbmNvdHJlZUxpbmVhZ2UifX19))
 
 ```json
 {
@@ -1171,6 +1171,86 @@ Only works with the `scatter` plot type. Toggles the optional linear regression 
     }
   },
   "show_regression_line": true
+}
+```
+
+### show_regression_line_per_color [boolean]
+
+A sub-option of `show_regression_line`, and only meaningful on a **faceted** `scatter` plot whose `color_by` shows a _different_ partition than its `facet_by`.
+
+By default, each small-multiples panel gets **one** regression line, fit over all of that panel's points regardless of color. Setting this to `true` instead fits **one line per color within each panel**, each drawn in its legend color.
+
+This is off by default deliberately: a panel with many colors becomes hard to read. Set it only when the per-color trends are the point of the plot.
+
+It is ignored (and dropped from the plot config) unless all of the following hold, since there is otherwise nothing to split:
+
+- `plot_type` is `scatter`
+- `facet_by` is set and complete
+- `color_by` is set and complete, and is not `"facet"` or `"uniform"`
+- `color_by` and `facet_by` do not resolve to the same annotation
+
+([Open](https://cds.team/depmap/data_explorer_2/?plot=eyJwbG90X3R5cGUiOiJzY2F0dGVyIiwiaW5kZXhfdHlwZSI6ImRlcG1hcF9tb2RlbCIsImRpbWVuc2lvbnMiOnsieCI6eyJheGlzX3R5cGUiOiJyYXdfc2xpY2UiLCJhZ2dyZWdhdGlvbiI6ImZpcnN0IiwiZGF0YXNldF9pZCI6IkNocm9ub3NfQ29tYmluZWQiLCJzbGljZV90eXBlIjoiZ2VuZSIsImNvbnRleHQiOnsiZGltZW5zaW9uX3R5cGUiOiJnZW5lIiwibmFtZSI6IlRQNTMiLCJleHByIjp7Ij09IjpbeyJ2YXIiOiJnaXZlbl9pZCJ9LCI3MTU3Il19LCJ2YXJzIjp7fX19LCJ5Ijp7ImF4aXNfdHlwZSI6InJhd19zbGljZSIsImFnZ3JlZ2F0aW9uIjoiZmlyc3QiLCJkYXRhc2V0X2lkIjoiZXhwcmVzc2lvbiIsInNsaWNlX3R5cGUiOiJnZW5lIiwiY29udGV4dCI6eyJkaW1lbnNpb25fdHlwZSI6ImdlbmUiLCJuYW1lIjoiVFA1MyIsImV4cHIiOnsiPT0iOlt7InZhciI6ImdpdmVuX2lkIn0sIjcxNTciXX0sInZhcnMiOnt9fX19LCJmYWNldF9ieSI6InByb3BlcnR5IiwiY29sb3JfYnkiOiJwcm9wZXJ0eSIsIm1ldGFkYXRhIjp7ImZhY2V0X3Byb3BlcnR5Ijp7ImlkZW50aWZpZXJfdHlwZSI6ImNvbHVtbiIsImRhdGFzZXRfaWQiOiJkZXBtYXBfbW9kZWxfbWV0YWRhdGEiLCJpZGVudGlmaWVyIjoiT25jb3RyZWVMaW5lYWdlIn0sImNvbG9yX3Byb3BlcnR5Ijp7ImlkZW50aWZpZXJfdHlwZSI6ImNvbHVtbiIsImRhdGFzZXRfaWQiOiJkZXBtYXBfbW9kZWxfbWV0YWRhdGEiLCJpZGVudGlmaWVyIjoiUHJpbWFyeU9yTWV0YXN0YXNpcyJ9fSwic2hvd19yZWdyZXNzaW9uX2xpbmUiOnRydWUsInNob3dfcmVncmVzc2lvbl9saW5lX3Blcl9jb2xvciI6dHJ1ZX0=))
+
+```json
+{
+  "plot_type": "scatter",
+  "index_type": "depmap_model",
+  "dimensions": {
+    "x": {
+      "axis_type": "raw_slice",
+      "aggregation": "first",
+      "dataset_id": "Chronos_Combined",
+      "slice_type": "gene",
+      "context": {
+        "dimension_type": "gene",
+        "name": "TP53",
+        "expr": {
+          "==": [
+            {
+              "var": "given_id"
+            },
+            "7157"
+          ]
+        },
+        "vars": {}
+      }
+    },
+    "y": {
+      "axis_type": "raw_slice",
+      "aggregation": "first",
+      "dataset_id": "expression",
+      "slice_type": "gene",
+      "context": {
+        "dimension_type": "gene",
+        "name": "TP53",
+        "expr": {
+          "==": [
+            {
+              "var": "given_id"
+            },
+            "7157"
+          ]
+        },
+        "vars": {}
+      }
+    }
+  },
+  "facet_by": "property",
+  "color_by": "property",
+  "metadata": {
+    "facet_property": {
+      "identifier_type": "column",
+      "dataset_id": "depmap_model_metadata",
+      "identifier": "OncotreeLineage"
+    },
+    "color_property": {
+      "identifier_type": "column",
+      "dataset_id": "depmap_model_metadata",
+      "identifier": "PrimaryOrMetastasis"
+    }
+  },
+  "show_regression_line": true,
+  "show_regression_line_per_color": true
 }
 ```
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/__tests__/utils.test.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/__tests__/utils.test.ts
@@ -595,6 +595,146 @@ describe("normalizePlot", () => {
       expect(result.color_by).toBeUndefined();
     });
   });
+
+  // `show_regression_line_per_color` splits each small-multiples panel's fit by
+  // color. It only means anything while color_by and facet_by are two real,
+  // DISTINCT partitions, so unlike the other scatter booleans its survival is
+  // (by definition, not by accident — ADR 0002 §3) conditional on those two
+  // axes. ADR 0002 §5: a new field gets a round-trip test.
+  describe("show_regression_line_per_color", () => {
+    // Distinct, complete color and facet annotations — the one configuration
+    // where the option applies.
+    const coloredAndFaceted = ({
+      ...basePlot,
+      color_by: "property",
+      facet_by: "property",
+      metadata: {
+        color_property: {
+          dataset_id: "model-metadata",
+          identifier: "PrimaryOrMetastasis",
+          identifier_type: "column",
+        },
+        facet_property: {
+          dataset_id: "model-metadata",
+          identifier: "OncotreeLineage",
+          identifier_type: "column",
+        },
+      },
+    } as unknown) as DataExplorerPlotConfig;
+
+    test("survives when color_by and facet_by are both complete and distinct", () => {
+      const result = normalizePlot({
+        ...coloredAndFaceted,
+        show_regression_line_per_color: true,
+      });
+
+      expect(result.show_regression_line_per_color).toBe(true);
+    });
+
+    test("survives a full plotToQueryString/readPlotFromQueryString round trip", async () => {
+      setQueryString("/");
+      const search = await plotToQueryString({
+        ...coloredAndFaceted,
+        show_regression_line: true,
+        show_regression_line_per_color: true,
+      });
+
+      setQueryString(search);
+      const result = await readPlotFromQueryString();
+      setQueryString("/");
+
+      expect(result?.show_regression_line_per_color).toBe(true);
+    });
+
+    test("is dropped when facet_by is unset (no panels to split)", () => {
+      const result = normalizePlot(({
+        ...coloredAndFaceted,
+        facet_by: undefined,
+        show_regression_line_per_color: true,
+      } as unknown) as DataExplorerPlotConfig);
+
+      expect(result.show_regression_line_per_color).toBeUndefined();
+    });
+
+    test("is dropped when color_by defers to facet_by ('facet')", () => {
+      // The Legend then IS the facet key, so every panel is monochromatic and
+      // the split would reproduce the same single line.
+      const result = normalizePlot(({
+        ...coloredAndFaceted,
+        color_by: "facet",
+        show_regression_line_per_color: true,
+      } as unknown) as DataExplorerPlotConfig);
+
+      expect(result.show_regression_line_per_color).toBeUndefined();
+    });
+
+    test("is dropped when color_by is 'uniform' (nothing to split by)", () => {
+      const result = normalizePlot(({
+        ...coloredAndFaceted,
+        color_by: "uniform",
+        show_regression_line_per_color: true,
+      } as unknown) as DataExplorerPlotConfig);
+
+      expect(result.show_regression_line_per_color).toBeUndefined();
+    });
+
+    test("is dropped when both axes name the identical annotation", () => {
+      const result = normalizePlot(({
+        ...coloredAndFaceted,
+        metadata: {
+          color_property: {
+            dataset_id: "model-metadata",
+            identifier: "OncotreeLineage",
+            identifier_type: "column",
+          },
+          facet_property: {
+            dataset_id: "model-metadata",
+            identifier: "OncotreeLineage",
+            identifier_type: "column",
+          },
+        },
+        show_regression_line_per_color: true,
+      } as unknown) as DataExplorerPlotConfig);
+
+      expect(result.show_regression_line_per_color).toBeUndefined();
+    });
+
+    test("is dropped when color_by's own backing is incomplete", () => {
+      // Checked against the NORMALIZED plot: color_by is mid-selection here
+      // (mode chosen, annotation not), so it doesn't survive — and the option
+      // must not survive a partition that isn't there.
+      const result = normalizePlot(({
+        ...coloredAndFaceted,
+        metadata: {
+          facet_property: {
+            dataset_id: "model-metadata",
+            identifier: "OncotreeLineage",
+            identifier_type: "column",
+          },
+        },
+        show_regression_line_per_color: true,
+      } as unknown) as DataExplorerPlotConfig);
+
+      expect(result.color_by).toBeUndefined();
+      expect(result.show_regression_line_per_color).toBeUndefined();
+    });
+
+    test("is dropped on a non-scatter plot type", () => {
+      const result = normalizePlot(({
+        ...coloredAndFaceted,
+        plot_type: "density_1d",
+        show_regression_line_per_color: true,
+      } as unknown) as DataExplorerPlotConfig);
+
+      expect(result.show_regression_line_per_color).toBeUndefined();
+    });
+
+    test("is absent when the plot never had one", () => {
+      expect(
+        normalizePlot(coloredAndFaceted).show_regression_line_per_color
+      ).toBeUndefined();
+    });
+  });
 });
 
 describe("readPlotFromQueryString / plotToQueryString — v1->v2 color_by migration", () => {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/LinearRegressionInfo/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/LinearRegressionInfo/index.tsx
@@ -14,7 +14,11 @@ import renderConditionally from "../../../../../utils/render-conditionally";
 import { PlotConfigReducerAction } from "../../../reducers/plotConfigReducer";
 import { isCompletePlot } from "../../../validation";
 import Section from "../../Section";
-import { ShowRegressionLineCheckbox } from "../selectors";
+import { canShowRegressionLinePerColor } from "../../../utils";
+import {
+  ShowRegressionLineCheckbox,
+  ShowRegressionLinePerColorCheckbox,
+} from "../selectors";
 import styles from "../../../styles/ConfigurationPanel.scss";
 
 interface Props {
@@ -184,6 +188,21 @@ function LinearRegressionInfo({ plot, dispatch }: Props) {
           dispatch({
             type: "select_show_regression_line",
             payload: show_regression_line,
+          });
+        }}
+      />
+      {/* Deliberately NOT also gated on `show_regression_line`: the two are
+          independent settings that happen to compose, and hiding this one
+          while lines are off would silently discard a choice the user made
+          (the reducer's normalize only drops it when the color/facet partitions
+          themselves stop supporting it). Offered whenever it can apply. */}
+      <ShowRegressionLinePerColorCheckbox
+        show={canShowRegressionLinePerColor(plot)}
+        value={plot.show_regression_line_per_color || false}
+        onChange={(show_regression_line_per_color: boolean) => {
+          dispatch({
+            type: "select_show_regression_line_per_color",
+            payload: show_regression_line_per_color,
           });
         }}
       />

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/selectors.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/ConfigurationPanel/selectors.tsx
@@ -567,6 +567,30 @@ export function ShowRegressionLineCheckbox({ value, onChange }: any) {
   );
 }
 
+// Sub-option of ShowRegressionLineCheckbox, so it's `renderConditionally` —
+// unlike its parent, it's only offered when a faceted plot has a color
+// partition of its own to split each panel's fit by (see
+// canShowRegressionLinePerColor).
+export const ShowRegressionLinePerColorCheckbox = renderConditionally(
+  ({
+    value,
+    onChange,
+  }: {
+    value: boolean;
+    onChange: (nextValue: boolean) => void;
+  }) => {
+    return (
+      <Checkbox
+        className={styles.checkbox}
+        checked={value}
+        onChange={(e) => onChange((e.target as any).checked)}
+      >
+        <span>One line per color in each facet</span>
+      </Checkbox>
+    );
+  }
+);
+
 export const UseClusteringCheckbox = renderConditionally(
   ({ value, onChange }: any) => {
     return (

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/SmallMultiplesScatter.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/SmallMultiplesScatter.tsx
@@ -129,8 +129,10 @@ interface Props {
   // everywhere; the line itself is injected per subplot after autorange.
   showIdentityLine?: boolean;
   // Per-facet regression lines keyed by facet label (from useScatterPlotData).
-  // Each panel draws its own; a facet with no entry draws none.
-  regressionLinesByFacet?: Map<string, RegressionLine> | null;
+  // Each panel draws its own; a facet with no entry (or an empty one) draws
+  // none. Usually one line per panel; several when the plot is configured to
+  // fit one per color (show_regression_line_per_color).
+  regressionLinesByFacet?: Map<string, RegressionLine[]> | null;
   // When true, a facet with no plottable point is kept as an empty panel
   // labeled "(no data)" rather than dropped. Used by expanded plots so a
   // paginated transcript window keeps its full set of panels even when the
@@ -851,11 +853,11 @@ function SmallMultiplesScatter({
       if (showIdentityLine || regressionLinesByFacet) {
         for (let k = 0; k < facets.length; k += 1) {
           const suffix = k === 0 ? "" : String(k + 1);
-          const facetLine = regressionLinesByFacet?.get(facets[k]) ?? null;
+          const facetLines = regressionLinesByFacet?.get(facets[k]) ?? null;
           downloadShapes.push(
             ...(calcPlotIndicatorLineShapes(
               showIdentityLine,
-              facetLine ? [facetLine] : null,
+              facetLines,
               extents,
               false,
               { xref: `x${suffix}`, yref: `y${suffix}` }
@@ -900,7 +902,8 @@ function SmallMultiplesScatter({
     }
 
     // Per-facet indicator shapes: the identity line (same in every panel) plus
-    // this panel's regression line, if one was fit (regressionLinesByFacet).
+    // this panel's regression line(s), if any were fit (regressionLinesByFacet
+    // — one per panel normally, one per color under the per-color option).
     // The shared `extents` is identical across panels (ranges linked by
     // `matches`); only the subplot refs and per-facet slope/intercept differ.
     // Built here, injected after autorange settles (below).
@@ -908,11 +911,11 @@ function SmallMultiplesScatter({
     if (showIdentityLine || regressionLinesByFacet) {
       for (let k = 0; k < facets.length; k += 1) {
         const suffix = k === 0 ? "" : String(k + 1);
-        const facetLine = regressionLinesByFacet?.get(facets[k]) ?? null;
+        const facetLines = regressionLinesByFacet?.get(facets[k]) ?? null;
         indicatorShapes.push(
           ...(calcPlotIndicatorLineShapes(
             showIdentityLine,
-            facetLine ? [facetLine] : null,
+            facetLines,
             extents,
             true,
             { xref: `x${suffix}`, yref: `y${suffix}` }

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/useScatterPlotData.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/useScatterPlotData.ts
@@ -64,7 +64,12 @@ export interface ScatterPlotData {
   regressionLines: RegressionLine[] | null;
   // Per-facet fits for the faceted renderer, keyed by facet label. null when
   // not faceted (facet_by unset); the single-panel path uses regressionLines.
-  regressionLinesByFacet: Map<string, RegressionLine> | null;
+  //
+  // An array per facet, not a single line: normally it holds exactly one (the
+  // panel's pooled fit), but `show_regression_line_per_color` splits it into
+  // one fit per color legend entry. A one-element array is the uniform shape
+  // for both, so the renderer never has to know which case it's drawing.
+  regressionLinesByFacet: Map<string, RegressionLine[]> | null;
   showIdentityLine: boolean;
   // Which triad (color's own, or facet's own via the version-2 default
   // defer) actually backs the legend — PlotLegend/LegendLabel need this to
@@ -519,45 +524,111 @@ export default function useScatterPlotData(
     const { facetKeys, facetColorKeys } = facetInfo;
     const visible = pointVisibility ?? x.map(() => true);
 
+    // The opt-in per-color split (show_regression_line_per_color): color_by's
+    // OWN partition, the same one the legend shows, used below to subdivide
+    // each panel. Null — and the pooled per-panel fit below is what runs —
+    // whenever the option is off, or when there's no separate color partition
+    // to split by at all: colorMatchesFacet (color IS the facet, so every
+    // panel is already monochromatic and the split would reproduce the same
+    // single line) or an absent colorMode.mode (color_by "uniform", which
+    // resolveColorMode deliberately reports as no mode). Those two cases are
+    // also why the checkbox is hidden, so this is the data-side half of the
+    // same condition — canShowRegressionLinePerColor can only see the config,
+    // and "the two axes name the same annotation through different modes" is
+    // only visible here, in the response.
+    const colorPartition =
+      plotConfig.show_regression_line_per_color &&
+      !colorMatchesFacet &&
+      colorMode.mode
+        ? computeFacets(data, colorMode.mode, colorMode.target, colorChosen)
+        : null;
+
     // A facet's line takes that facet's color only when facet_by resolves
     // to the SAME source as color_by (the panel is then monochromatic);
     // otherwise neutral, since a facet spanning several colors has no
-    // single color to borrow. See colorMatchesFacet's own comment.
+    // single color to borrow. See colorMatchesFacet's own comment. (Under the
+    // per-color split each line covers exactly one color, so each takes that
+    // color instead — see below.)
 
     // The "N/A" bucket gets a fit too, same as any other facet —
     // see computeFacetedLinReg's comment for the reasoning.
     const facets = [...new Set(facetKeys)];
-    const lines = new Map<string, RegressionLine>();
+    const lines = new Map<string, RegressionLine[]>();
 
-    facets.forEach((facet) => {
-      const inFacet = facetMaskFor(facetKeys, facet, x, y, visible);
+    // Fits over the points `keep` selects, sharing the finite-input hygiene
+    // between the pooled and per-color paths so the two can't drift.
+    const fit = (keep: (i: number) => boolean) => {
       const fx: number[] = [];
       const fy: number[] = [];
       for (let i = 0; i < x.length; i += 1) {
-        if (inFacet(i) && Number.isFinite(x[i]) && Number.isFinite(y[i])) {
+        if (keep(i) && Number.isFinite(x[i]) && Number.isFinite(y[i])) {
           fx.push(x[i] as number);
           fy.push(y[i] as number);
         }
       }
 
       const { slope, intercept } = linregress(fx, fy);
-      // facet is always the formatted display string; colorMap is keyed by
-      // the original LegendKey (a shared Symbol for LEGEND_BOTH/OTHER/
-      // RANGE_N facets), so a stringified facet must be translated back via
-      // facetColorKeys before the lookup — looking it up directly always
-      // misses and silently falls through to palette.other.
-      const colorKey = facetColorKeys?.[facet] ?? facet;
-      lines.set(facet, {
+
+      return {
         m: slope,
         b: intercept,
         hidden:
           fx.length < 3 ||
           !Number.isFinite(slope) ||
           !plotConfig.show_regression_line,
-        color: colorMatchesFacet
-          ? colorMap.get(colorKey) || palette.other
-          : "#333",
-      });
+      };
+    };
+
+    facets.forEach((facet) => {
+      const inFacet = facetMaskFor(facetKeys, facet, x, y, visible);
+
+      if (colorPartition) {
+        const colorKeys = colorPartition.facetKeys;
+        // Drawn in the legend's own order rather than first-seen order, so the
+        // stack of lines in a panel reads in the same sequence as the legend
+        // beside it.
+        const groups =
+          colorPartition.facetOrder ?? [...new Set(colorKeys)].sort();
+
+        lines.set(
+          facet,
+          groups
+            // A color absent from this panel gets no line rather than an
+            // empty one — every panel would otherwise carry a full set of
+            // lines, most of them fit over nothing.
+            .filter((group) =>
+              colorKeys.some((k, i) => k === group && inFacet(i))
+            )
+            .map((group) => {
+              // Same translation the pooled path does below, for the same
+              // reason: colorMap is keyed by the original LegendKey, never by
+              // the formatted display string.
+              const colorKey = colorPartition.facetColorKeys?.[group] ?? group;
+
+              return {
+                ...fit((i) => inFacet(i) && colorKeys[i] === group),
+                color: colorMap.get(colorKey) || palette.other,
+              };
+            })
+        );
+
+        return;
+      }
+
+      // facet is always the formatted display string; colorMap is keyed by
+      // the original LegendKey (a shared Symbol for LEGEND_BOTH/OTHER/
+      // RANGE_N facets), so a stringified facet must be translated back via
+      // facetColorKeys before the lookup — looking it up directly always
+      // misses and silently falls through to palette.other.
+      const colorKey = facetColorKeys?.[facet] ?? facet;
+      lines.set(facet, [
+        {
+          ...fit(inFacet),
+          color: colorMatchesFacet
+            ? colorMap.get(colorKey) || palette.other
+            : "#333",
+        },
+      ]);
     });
 
     return lines;
@@ -566,10 +637,13 @@ export default function useScatterPlotData(
     formattedData,
     plotConfig.facet_by,
     plotConfig.show_regression_line,
+    plotConfig.show_regression_line_per_color,
     pointVisibility,
     colorMap,
     palette,
     colorMatchesFacet,
+    colorMode,
+    colorChosen,
     facetChosen,
   ]);
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/reducers/__tests__/plotConfigReducer.test.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/reducers/__tests__/plotConfigReducer.test.ts
@@ -1760,4 +1760,106 @@ describe("plotConfigReducer", () => {
       expect(swapped.facet_categories).toEqual(["Lung"]);
     });
   });
+
+  // The per-color regression split only exists while color_by and facet_by are
+  // two real, distinct partitions — the same condition that shows its checkbox.
+  // Its checkbox disappearing and the option quietly staying set would be the
+  // worse failure of the two, so normalize drops it with the condition.
+  describe("show_regression_line_per_color", () => {
+    const coloredAndFaceted: PartialDataExplorerPlotConfig = {
+      plot_type: "scatter" as const,
+      index_type: "depmap_model",
+      color_by: "property" as const,
+      facet_by: "property" as const,
+      metadata: {
+        color_property: {
+          dataset_id: "m",
+          identifier: "PrimaryOrMetastasis",
+          identifier_type: "column",
+        } as any,
+        facet_property: {
+          dataset_id: "m",
+          identifier: "OncotreeLineage",
+          identifier_type: "column",
+        } as any,
+      },
+      dimensions: { x: {}, y: {} },
+    };
+
+    const turnOn = (plot: PartialDataExplorerPlotConfig) =>
+      plotConfigReducer(plot, {
+        type: "select_show_regression_line_per_color",
+        payload: true,
+      });
+
+    it("sticks when both partitions are real and distinct", () => {
+      expect(turnOn(coloredAndFaceted).show_regression_line_per_color).toBe(
+        true
+      );
+    });
+
+    it("is absent, not false, when switched back off", () => {
+      // Same convention as every other boolean option here: absent is the
+      // default, and `false` is junk we refuse to serialize.
+      const off = plotConfigReducer(turnOn(coloredAndFaceted), {
+        type: "select_show_regression_line_per_color",
+        payload: false,
+      });
+
+      expect(off).not.toHaveProperty("show_regression_line_per_color");
+    });
+
+    it("does not stick on an unfaceted plot", () => {
+      const unfaceted = plotConfigReducer(coloredAndFaceted, {
+        type: "select_facet_by",
+        payload: null,
+      });
+
+      expect(turnOn(unfaceted)).not.toHaveProperty(
+        "show_regression_line_per_color"
+      );
+    });
+
+    it("is dropped when faceting is turned off afterwards", () => {
+      const unfaceted = plotConfigReducer(turnOn(coloredAndFaceted), {
+        type: "select_facet_by",
+        payload: null,
+      });
+
+      expect(unfaceted).not.toHaveProperty("show_regression_line_per_color");
+    });
+
+    it("is dropped when color_by stops being its own partition", () => {
+      // "uniform" (no color at all) and "facet" (color defers to the facet
+      // key, so every panel is monochromatic) both leave one line per panel.
+      ["uniform" as const, "facet" as const].forEach((color_by) => {
+        const recolored = plotConfigReducer(turnOn(coloredAndFaceted), {
+          type: "select_color_by",
+          payload: color_by,
+        });
+
+        expect(recolored).not.toHaveProperty("show_regression_line_per_color");
+      });
+    });
+
+    // Repointing color_by at the annotation facet_by already shows is the one
+    // convergence this reducer does NOT catch: select_color_property returns
+    // without going through `normalize` (it can't — normalize would strip a
+    // scatter's sort_by, which orders the facets). Same weaker arrangement
+    // `normalize`'s own comment describes for the hand-picked categories, and
+    // tolerable for the same reason: the leftover value is inert. It draws
+    // nothing (useScatterPlotData gates on colorMatchesFacet, which sees the
+    // response and so catches convergence the config can't express) and it
+    // can't be serialized (normalizePlot re-checks on the write path — see its
+    // "identical annotation" test). It becomes live again only if color_by is
+    // repointed at something distinct, which is when it was last meaningful.
+    it("is dropped when the plot type changes away from scatter", () => {
+      const density = plotConfigReducer(turnOn(coloredAndFaceted), {
+        type: "select_plot_type",
+        payload: "density_1d",
+      });
+
+      expect(density).not.toHaveProperty("show_regression_line_per_color");
+    });
+  });
 });

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/reducers/plotConfigReducer.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/reducers/plotConfigReducer.ts
@@ -16,7 +16,12 @@ import {
   isExpansionDimension,
 } from "../../../utils/misc";
 import { contextsMatch } from "../../../utils/context";
-import { canSwapColorAndFacet, isAxisComplete, SwappablePlot } from "../utils";
+import {
+  canShowRegressionLinePerColor,
+  canSwapColorAndFacet,
+  isAxisComplete,
+  SwappablePlot,
+} from "../utils";
 
 export type PlotConfigReducerAction =
   | { type: "set_plot"; payload: PartialDataExplorerPlotConfig }
@@ -58,6 +63,7 @@ export type PlotConfigReducerAction =
   | { type: "select_hide_identity_line"; payload: boolean }
   | { type: "select_use_clustering"; payload: boolean }
   | { type: "select_show_regression_line"; payload: boolean }
+  | { type: "select_show_regression_line_per_color"; payload: boolean }
   | {
       type: "select_scatter_y_slice";
       payload: {
@@ -214,6 +220,28 @@ const normalize = (plot: PartialDataExplorerPlotConfig) => {
 
   if (plot.show_regression_line === false || plot.plot_type !== "scatter") {
     nextPlot = omit(nextPlot, "show_regression_line");
+  }
+
+  // The per-color split only exists while color_by and facet_by are two real,
+  // distinct partitions — the same condition that shows its checkbox. Dropped
+  // the moment that stops holding (color_by switched to "uniform"/"facet",
+  // facet_by cleared, either axis pointed at what the other already shows), so
+  // it can't sit in the config invisibly and reassert itself later, the same
+  // reasoning as the hand-picked categories above. Checked against `nextPlot`,
+  // so an axis this same normalize pass just cleared already counts as gone.
+  //
+  // And, like the categories, this only sees "there is no distinct partition
+  // any more", not a change of *backing* that happens to converge the two axes
+  // (select_color_property returns without normalizing). That leftover is inert
+  // rather than merely unlikely: useScatterPlotData won't draw a per-color
+  // split while colorMatchesFacet, and normalizePlot re-checks before anything
+  // is serialized.
+  if (
+    plot.show_regression_line_per_color === false ||
+    plot.plot_type !== "scatter" ||
+    !canShowRegressionLinePerColor(nextPlot)
+  ) {
+    nextPlot = omit(nextPlot, "show_regression_line_per_color");
   }
 
   if (
@@ -923,6 +951,19 @@ function plotConfigReducer(
       return normalize({
         ...plot,
         show_regression_line: action.payload,
+      });
+    }
+
+    case "select_show_regression_line_per_color": {
+      if (plot.plot_type !== "scatter") {
+        window.console.warn(
+          "`show_regression_line_per_color` is only supported by the 'scatter' plot type."
+        );
+      }
+
+      return normalize({
+        ...plot,
+        show_regression_line_per_color: action.payload,
       });
     }
 

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/utils.ts
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/utils.ts
@@ -467,6 +467,36 @@ export function canSwapColorAndFacet(plot: SwappablePlot): boolean {
   return getColorFacetSwapMode(plot) !== null;
 }
 
+// Whether `show_regression_line_per_color` has anything to mean: there must be
+// panels to split (a complete facet_by) AND a color partition of its own to
+// split them by (a complete color_by that isn't just facet_by under another
+// name). Everything else already draws exactly one line per panel, so the
+// option would be a checkbox with no effect.
+//
+// Same three conditions as the "swap" arm of getColorFacetSwapMode, and
+// deliberately not written as `getColorFacetSwapMode(plot) === "swap"`: the two
+// answer different questions and only coincide today. Reusing the swap mode
+// here would silently redefine this option the next time swappability changes
+// (e.g. if ADR 0004's "smart translated swap" is ever built).
+//
+// Config-level only. Two axes naming the *same* underlying annotation through
+// different modes still read as different here; that case resolves to one
+// partition in the data (colorMatchesFacet in useScatterPlotData) and is
+// caught there, where the response is available.
+export function canShowRegressionLinePerColor(plot: SwappablePlot): boolean {
+  const { color_by, facet_by } = plot;
+
+  const colorComplete =
+    SWAPPABLE_AXIS_VALUES.has(color_by as string) &&
+    isAxisComplete(color_by, "color", plot);
+
+  const facetComplete =
+    SWAPPABLE_AXIS_VALUES.has(facet_by as string) &&
+    isAxisComplete(facet_by, "facet", plot);
+
+  return colorComplete && facetComplete && !axesAlreadyMatch(color_by, plot);
+}
+
 function compress(obj: object): string {
   // thanks to https://gist.github.com/heinrich-ulbricht/683ea2ac8ac0e7bc607e4f4a57534937
   const json = JSON.stringify(obj);
@@ -489,6 +519,7 @@ export function normalizePlot(plot: DataExplorerPlotConfig) {
     hide_points,
     use_clustering,
     show_regression_line,
+    show_regression_line_per_color,
     filters,
     metadata,
     // `version` is deliberately NOT listed here — it must survive into `rest`
@@ -687,6 +718,22 @@ export function normalizePlot(plot: DataExplorerPlotConfig) {
         normalized.dimensions = omit(normalized.dimensions, "facet");
       }
     }
+  }
+
+  // `show_regression_line_per_color` is a sub-option of the faceted regression:
+  // it only means anything while color_by and facet_by BOTH survive as real,
+  // distinct partitions. Checked against `normalized` rather than `plot`
+  // deliberately — this has to run after the color/facet arms above have
+  // settled, so an axis whose backing was just dropped as incomplete takes the
+  // option down with it instead of leaving it stranded on a plot that now draws
+  // one line per panel. (ADR 0002 §3's "no incidental coupling" is satisfied:
+  // the dependency on color_by/facet_by is the option's whole definition.)
+  if (
+    plot.plot_type === "scatter" &&
+    show_regression_line_per_color &&
+    canShowRegressionLinePerColor(normalized)
+  ) {
+    normalized.show_regression_line_per_color = true;
   }
 
   return normalized;

--- a/frontend/packages/@depmap/types/src/data-explorer-2.ts
+++ b/frontend/packages/@depmap/types/src/data-explorer-2.ts
@@ -332,6 +332,17 @@ export interface DataExplorerPlotConfig {
   hide_identity_line?: boolean;
   show_regression_line?: boolean;
 
+  // A sub-option of `show_regression_line`, meaningful only on a faceted
+  // scatter whose `color_by` resolves to a DIFFERENT partition than its
+  // `facet_by`. Absent/false (the default) keeps the established behavior: one
+  // pooled fit per small-multiples panel, recomputed as legend entries are
+  // toggled off. True splits each panel's fit by color instead, giving one
+  // line per legend entry per panel — deliberately opt-in, since a panel with
+  // many colors becomes unreadable. Normalized away as soon as it can't
+  // apply (see `canShowRegressionLinePerColor`), so it never sits in a config
+  // describing something the plot can't draw.
+  show_regression_line_per_color?: boolean;
+
   // unique to correlation_heatmap
   use_clustering?: boolean;
 }


### PR DESCRIPTION
A faceted scatterplot fits one regression line per panel, pooling every color together. This adds an opt-in checkbox, off by default, that splits each panel's fit by color instead, for users who want to compare per-color trends within a facet and accept the extra clutter. It only appears when color_by and facet_by show different things.