### PR TITLE
feat(breadbox): support multiple datatypes per release file

### DIFF
--- a/breadbox/alembic/versions/bd6abe9454f9_release_file_datatypes_many_to_many.py
+++ b/breadbox/alembic/versions/bd6abe9454f9_release_file_datatypes_many_to_many.py
@@ -1,0 +1,91 @@
+"""release file datatypes many to many
+
+Revision ID: bd6abe9454f9
+Revises: 5513a3b26601
+Create Date: 2026-09-03 12:38:58.366886
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "bd6abe9454f9"
+down_revision = "5513a3b26601"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # 1. Create the join table backing ReleaseFile.datatypes (a set of free-text
+    # values, not FK'd to the `data_type` lookup table used by Dataset).
+    op.create_table(
+        "release_file_datatype",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("release_file_id", sa.String(), nullable=False),
+        sa.Column("datatype", sa.String(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["release_file_id"],
+            ["release_file.id"],
+            name=op.f("fk_release_file_datatype_release_file_id_release_file"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_release_file_datatype")),
+        sa.UniqueConstraint(
+            "release_file_id",
+            "datatype",
+            name=op.f("uq_release_file_datatype_release_file_id"),
+        ),
+    )
+
+    # 2. Backfill: one row per existing release_file.datatype
+    op.execute(
+        """
+        INSERT INTO release_file_datatype (release_file_id, datatype)
+        SELECT id, datatype FROM release_file
+        """
+    )
+
+    # 3. Drop the old single-valued column (SQLite requires batch mode)
+    with op.batch_alter_table("release_file", schema=None) as batch_op:
+        batch_op.drop_column("datatype")
+
+    # 4. Rebuild the FTS5 search index with file_datatypes in place of
+    # file_datatype. FTS5 virtual tables don't support ALTER COLUMN, so we
+    # drop and recreate, then repopulate from the current source tables.
+    op.execute("DROP TABLE IF EXISTS release_file_search_index")
+    op.execute(
+        """
+        CREATE VIRTUAL TABLE release_file_search_index USING fts5(
+        file_id,
+        file_name,
+        file_description,
+        file_datatypes,
+        release_version_name,
+        release_name,
+        release_version_description,
+        release_version_content_hash,
+        tokenize='unicode61'
+        );
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO release_file_search_index
+            (file_id, file_name, file_description, file_datatypes,
+             release_version_name, release_name, release_version_description,
+             release_version_content_hash)
+        SELECT
+            rf.id, rf.file_name, COALESCE(rf.description, ''),
+            (SELECT group_concat(rfd.datatype, ' ')
+             FROM release_file_datatype rfd WHERE rfd.release_file_id = rf.id),
+            rv.version_name, rv.release_name, COALESCE(rv.description, ''),
+            rv.content_hash
+        FROM release_file rf
+        JOIN release_version rv ON rv.id = rf.release_version_id
+        """
+    )
+
+
+def downgrade():
+    raise NotImplementedError("Downgrades are not supported")

--- a/breadbox/breadbox/crud/release_version.py
+++ b/breadbox/breadbox/crud/release_version.py
@@ -128,8 +128,8 @@ def create_release_version(
         release_file = ReleaseFile(
             **f.model_dump(exclude={"datatypes"}), release_version_id=release_version.id
         )
-        for dt in dict.fromkeys(f.datatypes):  # dedupe; datatypes is conceptually a set
-            release_file.datatypes.append(dt)
+        # datatypes is conceptually a set; dedupe
+        release_file.datatypes = list(set(f.datatypes))
         db.add(release_file)
         created_files.append(release_file)
 

--- a/breadbox/breadbox/crud/release_version.py
+++ b/breadbox/breadbox/crud/release_version.py
@@ -10,6 +10,7 @@ from breadbox.db.session import SessionWithUser
 from ..models.release_version import (
     ReleaseVersion,
     ReleaseFile,
+    ReleaseFileDatatype,
     ReleasePipeline,
     ReleaseFileSearchIndex,
 )
@@ -77,7 +78,8 @@ def get_release_versions(
         # matching the requested datatype.
         file_exists = exists().where(
             ReleaseFile.release_version_id == ReleaseVersion.id,
-            ReleaseFile.datatype == datatype,
+            ReleaseFile.id == ReleaseFileDatatype.release_file_id,
+            ReleaseFileDatatype.datatype == datatype,
         )
         query = query.filter(file_exists)
 
@@ -124,8 +126,10 @@ def create_release_version(
     created_files = []
     for f in params.files:
         release_file = ReleaseFile(
-            **f.model_dump(), release_version_id=release_version.id
+            **f.model_dump(exclude={"datatypes"}), release_version_id=release_version.id
         )
+        for dt in dict.fromkeys(f.datatypes):  # dedupe; datatypes is conceptually a set
+            release_file.datatypes.append(dt)
         db.add(release_file)
         created_files.append(release_file)
 
@@ -168,7 +172,7 @@ def _update_search_index(
                 file_id=file.id,
                 file_name=file.file_name,
                 file_description=file.description or "",
-                file_datatype=file.datatype,
+                file_datatypes=" ".join(file.datatypes),
                 release_version_name=release.version_name,
                 release_name=release.release_name,
                 release_version_description=release.description or "",

--- a/breadbox/breadbox/models/release_version.py
+++ b/breadbox/breadbox/models/release_version.py
@@ -2,6 +2,7 @@ from typing import List, Optional
 from sqlalchemy import String, Integer, Boolean, Date, ForeignKey, UniqueConstraint
 from datetime import date
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.ext.associationproxy import association_proxy
 
 from breadbox.db.base_class import Base, UUIDMixin
 
@@ -58,7 +59,6 @@ class ReleaseFile(Base, UUIDMixin):
 
     # File Metadata
     file_name: Mapped[str] = mapped_column(String, nullable=False, index=True)
-    datatype: Mapped[str] = mapped_column(String, nullable=False)
     size: Mapped[Optional[str]] = mapped_column(String, nullable=True)  # e.g., "1.2GB"
     description: Mapped[Optional[str]] = mapped_column(String, nullable=True)
 
@@ -76,6 +76,34 @@ class ReleaseFile(Base, UUIDMixin):
 
     release_version: Mapped["ReleaseVersion"] = relationship(
         "ReleaseVersion", back_populates="files"
+    )
+
+    # datatypes is conceptually a set (order doesn't matter, no duplicates)
+    datatype_rows: Mapped[List["ReleaseFileDatatype"]] = relationship(
+        "ReleaseFileDatatype",
+        back_populates="release_file",
+        cascade="all, delete-orphan",
+    )
+    datatypes = association_proxy(
+        "datatype_rows",
+        "datatype",
+        creator=lambda dt: ReleaseFileDatatype(datatype=dt),
+    )
+
+
+class ReleaseFileDatatype(Base):
+    __tablename__ = "release_file_datatype"
+    __table_args__ = (UniqueConstraint("release_file_id", "datatype"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    release_file_id: Mapped[str] = mapped_column(
+        String, ForeignKey("release_file.id", ondelete="CASCADE"), nullable=False
+    )
+    # Free text, not FK'd to the `data_type` lookup table used by Dataset.
+    datatype: Mapped[str] = mapped_column(String, nullable=False)
+
+    release_file: Mapped["ReleaseFile"] = relationship(
+        "ReleaseFile", back_populates="datatype_rows"
     )
 
 
@@ -97,7 +125,7 @@ class ReleaseFileSearchIndex(Base):
     # File-specific metadata
     file_name: Mapped[str] = mapped_column(String)
     file_description: Mapped[str] = mapped_column(String)
-    file_datatype: Mapped[str] = mapped_column(String)
+    file_datatypes: Mapped[str] = mapped_column(String)
     release_version_name: Mapped[str] = mapped_column(String)
     release_name: Mapped[str] = mapped_column(String)
     release_version_description: Mapped[str] = mapped_column(String)

--- a/breadbox/breadbox/schemas/release_version.py
+++ b/breadbox/breadbox/schemas/release_version.py
@@ -16,7 +16,12 @@ class ReleaseFileSchema(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
     file_name: Annotated[str, Field(description="The name of the file when downloaded")]
-    datatype: Annotated[str, Field(description="The type of data, e.g., 'crispr'")]
+    datatypes: Annotated[
+        List[str],
+        Field(
+            default_factory=list, description="The type(s) of data, e.g., ['crispr']",
+        ),
+    ] = []
     size: Annotated[
         Optional[str], Field(description="Human readable size, e.g. '1.2GB'")
     ] = None
@@ -134,8 +139,14 @@ class ReleaseFileSearchResponse(BaseModel):
     id: str = Field(..., alias="file_id")
     file_name: str
     file_description: str
-    file_datatype: str
+    file_datatypes: List[str]
     release_version_name: str
     release_name: str
     release_version_description: str
     release_version_content_hash: str
+
+    @field_validator("file_datatypes", mode="before")
+    @classmethod
+    def _split_datatypes(cls, v):
+        # The FTS5 index stores datatypes as a single space-joined string.
+        return v.split() if isinstance(v, str) else v

--- a/breadbox/tests/api/test_release_files.py
+++ b/breadbox/tests/api/test_release_files.py
@@ -15,12 +15,14 @@ class TestSearchReleaseFiles:
         factories.release_version(
             minimal_db,
             version_name="Release A",
-            files=[{"file_name": "sequencing_data.csv", "datatype": "genomics"}],
+            files=[{"file_name": "sequencing_data.csv", "datatypes": ["genomics"]}],
         )
         factories.release_version(
             minimal_db,
             version_name="Release B",
-            files=[{"file_name": "proteomics_results.csv", "datatype": "proteomics"}],
+            files=[
+                {"file_name": "proteomics_results.csv", "datatypes": ["proteomics"]}
+            ],
         )
 
         minimal_db.flush()
@@ -41,7 +43,8 @@ class TestSearchReleaseFiles:
         """Verify that limit and offset correctly slice the result set."""
         # Setup: Create 5 files that all match the word "common"
         files = [
-            {"file_name": f"common_file_{i}.csv", "datatype": "test"} for i in range(5)
+            {"file_name": f"common_file_{i}.csv", "datatypes": ["test"]}
+            for i in range(5)
         ]
         factories.release_version(minimal_db, version_name="Paginated", files=files)
         minimal_db.flush()
@@ -86,7 +89,7 @@ class TestSearchReleaseFiles:
             files=[
                 {
                     "file_name": "data.csv",
-                    "datatype": "test",
+                    "datatypes": ["test"],
                     "description": "This contains the secret results",
                 }
             ],
@@ -112,14 +115,14 @@ class TestSearchReleaseFiles:
         factories.release_version(
             minimal_db,
             version_name="Rel_1",
-            files=[{"file_name": "lung_cancer_genomics.csv", "datatype": "misc"}],
+            files=[{"file_name": "lung_cancer_genomics.csv", "datatypes": ["misc"]}],
         )
 
         # 2. Match in Datatype
         factories.release_version(
             minimal_db,
             version_name="Rel_2",
-            files=[{"file_name": "expression.csv", "datatype": "lung_biology"}],
+            files=[{"file_name": "expression.csv", "datatypes": ["lung_biology"]}],
         )
 
         # 3. Match in Description
@@ -129,7 +132,7 @@ class TestSearchReleaseFiles:
             files=[
                 {
                     "file_name": "metadata.json",
-                    "datatype": "clinical",
+                    "datatypes": ["clinical"],
                     "description": "Patient samples collected from lung tissue",
                 }
             ],
@@ -139,7 +142,7 @@ class TestSearchReleaseFiles:
         factories.release_version(
             minimal_db,
             version_name="Lung_Atlas_v2",
-            files=[{"file_name": "atlas.csv", "datatype": "rna"}],
+            files=[{"file_name": "atlas.csv", "datatypes": ["rna"]}],
         )
 
         # Search for the global keyword

--- a/breadbox/tests/api/test_release_versions.py
+++ b/breadbox/tests/api/test_release_versions.py
@@ -74,7 +74,7 @@ class TestGet:
         release = factories.release_version(
             minimal_db,
             files=[
-                {"file_name": "test.csv", "datatype": "crispr", "is_main_file": True}
+                {"file_name": "test.csv", "datatypes": ["crispr"], "is_main_file": True}
             ],
         )
         release_version_id = str(release.id)
@@ -108,7 +108,7 @@ class TestPost:
             "description": "New release",
             "content_hash": "a" * 32,
             "files": [
-                {"file_name": "data.csv", "datatype": "crispr", "is_main_file": True}
+                {"file_name": "data.csv", "datatypes": ["crispr"], "is_main_file": True}
             ],
             "release_pipelines": [{"pipeline_name": "Standard", "description": "Desc"}],
         }

--- a/breadbox/tests/conftest.py
+++ b/breadbox/tests/conftest.py
@@ -188,7 +188,7 @@ def minimal_db(db: SessionWithUser, settings: Settings, public_group, transient_
             file_id,
             file_name,
             file_description,
-            file_datatype,
+            file_datatypes,
             release_version_name,
             release_name,
             release_version_description,

--- a/breadbox/tests/crud/test_release_version.py
+++ b/breadbox/tests/crud/test_release_version.py
@@ -96,7 +96,7 @@ def test_delete_release_version_cascade_and_search_sync(minimal_db: SessionWithU
     file_metadata = [
         {
             "file_name": "target_file.csv",
-            "datatype": "crispr",
+            "datatypes": ["crispr"],
             "is_main_file": True,
             "md5_hash": "0" * 32,
         }
@@ -153,7 +153,7 @@ def test_get_release_versions_filtering(minimal_db: SessionWithUser):
         version_name="v1",
         version_date=today - timedelta(days=400),
     )
-    factories.release_file(minimal_db, release_a, datatype="crispr")
+    factories.release_file(minimal_db, release_a, datatypes=["crispr"])
 
     # Release B: RNAseq data from last month
     release_b = factories.release_version(
@@ -162,13 +162,13 @@ def test_get_release_versions_filtering(minimal_db: SessionWithUser):
         version_name="v1",
         version_date=today - timedelta(days=30),
     )
-    factories.release_file(minimal_db, release_b, datatype="rnaseq")
+    factories.release_file(minimal_db, release_b, datatypes=["rnaseq"])
 
     # Release C: CRISPR data from today (Same release name as A)
     release_c = factories.release_version(
         minimal_db, release_name="Project A", version_name="v2", version_date=today
     )
-    factories.release_file(minimal_db, release_c, datatype="crispr")
+    factories.release_file(minimal_db, release_c, datatypes=["crispr"])
 
     # Test 1: Filter by release_name
     # Should find both v1 and v2 of Project A
@@ -183,7 +183,7 @@ def test_get_release_versions_filtering(minimal_db: SessionWithUser):
     assert set(r.id for r in crispr_results) == {release_a.id, release_c.id}
     # Ensure distinctness (no duplicates even if release has multiple crispr files)
     factories.release_file(
-        minimal_db, release_c, datatype="crispr", file_name="another_crispr.csv"
+        minimal_db, release_c, datatypes=["crispr"], file_name="another_crispr.csv"
     )
     crispr_results_deduped = get_release_versions(minimal_db, datatype="crispr")
     assert len(crispr_results_deduped) == 2
@@ -229,7 +229,7 @@ def test_get_release_versions_include_files_toggle(minimal_db: SessionWithUser):
     factories.release_version(
         minimal_db,
         version_name="IncludeTest",
-        files=[{"file_name": file_name, "datatype": "crispr", "is_main_file": True}],
+        files=[{"file_name": file_name, "datatypes": ["crispr"], "is_main_file": True}],
     )
 
     minimal_db.flush()
@@ -265,7 +265,7 @@ def test_get_release_version_include_files_toggle(minimal_db: SessionWithUser):
     file_name = "detail.csv"
     release = factories.release_version(
         minimal_db,
-        files=[{"file_name": file_name, "datatype": "crispr", "is_main_file": True}],
+        files=[{"file_name": file_name, "datatypes": ["crispr"], "is_main_file": True}],
     )
     release_id = release.id
     minimal_db.flush()

--- a/breadbox/tests/factories.py
+++ b/breadbox/tests/factories.py
@@ -546,8 +546,7 @@ def release_file(
         md5_hash=kwargs.get("md5_hash", "0" * 32),
         pipeline_name=kwargs.get("pipeline_name", "Test Pipeline"),
     )
-    for dt in dict.fromkeys(datatypes):
-        file.datatypes.append(dt)
+    file.datatypes = list(set(datatypes))
     db.add(file)
     db.flush()
     return file

--- a/breadbox/tests/factories.py
+++ b/breadbox/tests/factories.py
@@ -532,7 +532,7 @@ def release_file(
     db: SessionWithUser,
     release_version: ReleaseVersion,
     file_name: str = "test_file.csv",
-    datatype: str = "crispr",
+    datatypes: List[str] = ["crispr"],
     is_main_file: bool = True,
     **kwargs,
 ) -> ReleaseFile:
@@ -540,13 +540,14 @@ def release_file(
     file = ReleaseFile(
         release_version_id=release_version.id,
         file_name=file_name,
-        datatype=datatype,
         is_main_file=is_main_file,
         size=kwargs.get("size", "10MB"),
         bucket_url=kwargs.get("bucket_url"),
         md5_hash=kwargs.get("md5_hash", "0" * 32),
         pipeline_name=kwargs.get("pipeline_name", "Test Pipeline"),
     )
+    for dt in dict.fromkeys(datatypes):
+        file.datatypes.append(dt)
     db.add(file)
     db.flush()
     return file


### PR DESCRIPTION
Change ReleaseFile.datatype (single string) to datatypes (many-to-many list of free-text strings), backed by a new release_file_datatype join table. The FTS5 search index column file_datatype is renamed to file_datatypes, storing space-joined values so each datatype remains individually searchable.

- models: add ReleaseFileDatatype join table, expose ReleaseFile.datatypes via association_proxy; rename ReleaseFileSearchIndex.file_datatype
- schemas: ReleaseFileSchema.datatypes: List[str]; ReleaseFileSearchResponse .file_datatypes: List[str] with validator splitting the FTS5 string
- crud: update datatype filter join, create_release_version dedupes and appends datatypes, search index population joins datatypes with a space
- alembic: new migration creates the join table, backfills from the old column, drops it, and rebuilds the FTS5 virtual table; downgrade is not supported
- tests: update factories and payloads across release version/file tests