### PR TITLE
add a separate point size setting for faceted plots

### DIFF
--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerDensity1DPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerDensity1DPlot.tsx
@@ -89,6 +89,7 @@ function DataExplorerDensity1DPlot({
   const { plotStyles } = useDataExplorerSettings();
   const {
     pointSize,
+    facetedPointSize,
     pointOpacity,
     outlineWidth,
     palette,
@@ -267,7 +268,11 @@ function DataExplorerDensity1DPlot({
               onClickResetSelection={clearSelection}
               hiddenLegendValues={hiddenLegendValues}
               hiddenFacetValues={hiddenFacetValues}
-              pointSize={pointSize}
+              // hasFacetOptionsEnabled, not Boolean(sortedFacetKeys): an
+              // unset facet_by still yields one LEGEND_ALL track, so
+              // sortedFacetKeys is never empty and would report every plot
+              // as faceted. See useDensity1DPlotData's own note on this.
+              pointSize={hasFacetOptionsEnabled ? facetedPointSize : pointSize}
               pointOpacity={pointOpacity}
               outlineWidth={outlineWidth}
               palette={palette}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerScatterPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerScatterPlot.tsx
@@ -113,6 +113,7 @@ function DataExplorerScatterPlot({
   const { plotStyles } = useDataExplorerSettings();
   const {
     pointSize,
+    facetedPointSize,
     pointOpacity,
     outlineWidth,
     palette,
@@ -341,7 +342,7 @@ function DataExplorerScatterPlot({
                 pointsToAnnotate={pointsToAnnotate}
                 selectionCount={selection?.size ?? 0}
                 onClickResetSelection={clearSelection}
-                pointSize={pointSize}
+                pointSize={facetedPointSize}
                 pointOpacity={pointOpacity}
                 outlineWidth={outlineWidth}
                 palette={palette}

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerWaterfallPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/DataExplorerWaterfallPlot.tsx
@@ -88,6 +88,7 @@ function DataExplorerWaterfallPlot({
   const { plotStyles } = useDataExplorerSettings();
   const {
     pointSize,
+    facetedPointSize,
     pointOpacity,
     outlineWidth,
     palette,
@@ -263,7 +264,10 @@ function DataExplorerWaterfallPlot({
               pointsToAnnotate={pointsToAnnotate}
               selectionCount={selection?.size ?? 0}
               hasFacetOptionsEnabled={hasFacetOptionsEnabled}
-              pointSize={pointSize}
+              // Same predicate that drives the x-clustering itself (it's
+              // what facetSide feeds formatDataForWaterfall), so the smaller
+              // size applies exactly when the ranking is split into clusters.
+              pointSize={hasFacetOptionsEnabled ? facetedPointSize : pointSize}
               pointOpacity={pointOpacity}
               outlineWidth={outlineWidth}
               customHoverinfo="y+text"

--- a/frontend/packages/@depmap/data-explorer-2/src/components/SettingsModal/CategoricalPaletteSelector.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/SettingsModal/CategoricalPaletteSelector.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
+import GradientEditorPopover from "./GradientEditorPopover";
 import styles from "../../styles/SettingsModal.scss";
 
 interface Props {
@@ -17,27 +18,14 @@ function CategoricalPaletteSelector({
   onChange,
   onChangeNumColors,
 }: Props) {
-  const div = useRef<HTMLDivElement>(null);
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
   const [showEditor, setShowEditor] = useState(false);
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (div.current && !div.current.contains(event.target as HTMLElement)) {
-        setShowEditor(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [div]);
 
   return (
     <div className={styles.gradient}>
       <label htmlFor={name}>{label}</label>
       <span
+        ref={setAnchor}
         style={{ width: value.length * 6 + 2 }}
         onClick={() => setShowEditor(true)}
       >
@@ -46,41 +34,43 @@ function CategoricalPaletteSelector({
           <span key={i} style={{ backgroundColor: color }} />
         ))}
       </span>
-      {showEditor && (
-        <div ref={div} className={styles.gradientEditor}>
-          <div
-            className={styles.gradientEditorItems}
-            style={{ minHeight: 27 * 2 }}
-          >
-            {value.map((color, index) => (
-              <input
-                // eslint-disable-next-line react/no-array-index-key
-                key={index}
-                type="color"
-                value={color}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  return onChange(e.target.value, index);
-                }}
-              />
-            ))}
-          </div>
-          <div>
-            <label htmlFor="num-colors">number of levels</label>
+      <GradientEditorPopover
+        show={showEditor}
+        anchor={anchor}
+        onHide={() => setShowEditor(false)}
+      >
+        <div
+          className={styles.gradientEditorItems}
+          style={{ minHeight: 27 * 2 }}
+        >
+          {value.map((color, index) => (
             <input
-              type="number"
-              min={0}
-              value={value.length}
+              // eslint-disable-next-line react/no-array-index-key
+              key={index}
+              type="color"
+              value={color}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                const numColors = e.target.valueAsNumber;
-
-                if (!Number.isNaN(numColors)) {
-                  onChangeNumColors(numColors);
-                }
+                return onChange(e.target.value, index);
               }}
             />
-          </div>
+          ))}
         </div>
-      )}
+        <div>
+          <label htmlFor="num-colors">number of levels</label>
+          <input
+            type="number"
+            min={0}
+            value={value.length}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              const numColors = e.target.valueAsNumber;
+
+              if (!Number.isNaN(numColors)) {
+                onChangeNumColors(numColors);
+              }
+            }}
+          />
+        </div>
+      </GradientEditorPopover>
     </div>
   );
 }

--- a/frontend/packages/@depmap/data-explorer-2/src/components/SettingsModal/GradientEditorPopover.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/SettingsModal/GradientEditorPopover.tsx
@@ -1,0 +1,114 @@
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import ReactDOM from "react-dom";
+import styles from "../../styles/SettingsModal.scss";
+
+// Gap between the bottom of the trigger swatch and the top of the popover.
+const GAP = 5;
+
+interface Props {
+  show: boolean;
+  // The trigger swatch. The popover is positioned just below it, and
+  // mousedowns inside it don't count as "outside" (otherwise clicking the
+  // swatch would close and immediately reopen the popover).
+  anchor: HTMLElement | null;
+  onHide: () => void;
+  children: React.ReactNode;
+}
+
+// The editor lives in a portal because Modal.Body (.SettingsModal) sets
+// overflow-y: auto to scroll the settings list, which clips any descendant
+// that tries to overflow it — and the color pickers, which sit near the
+// bottom of the list, are exactly that.
+function GradientEditorPopover({ show, anchor, onHide, children }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [position, setPosition] = useState<{
+    top: number;
+    left: number;
+  } | null>(null);
+
+  const updatePosition = useCallback(() => {
+    if (!anchor) {
+      return;
+    }
+
+    const rect = anchor.getBoundingClientRect();
+    setPosition({ top: rect.bottom + GAP, left: rect.left });
+  }, [anchor]);
+
+  // Layout effect (not a plain effect) so the popover has its position
+  // before the browser paints and never flashes in the wrong spot.
+  useLayoutEffect(() => {
+    if (show) {
+      updatePosition();
+    } else {
+      setPosition(null);
+    }
+  }, [show, updatePosition]);
+
+  // Fixed positioning is relative to the viewport, so the popover has to be
+  // repositioned when anything moves the swatch. Capture phase: the scroll
+  // that matters is .SettingsModal's own, which doesn't bubble.
+  useEffect(() => {
+    if (!show) {
+      return undefined;
+    }
+
+    window.addEventListener("scroll", updatePosition, true);
+    window.addEventListener("resize", updatePosition);
+
+    return () => {
+      window.removeEventListener("scroll", updatePosition, true);
+      window.removeEventListener("resize", updatePosition);
+    };
+  }, [show, updatePosition]);
+
+  useEffect(() => {
+    if (!show) {
+      return undefined;
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as HTMLElement;
+
+      if (
+        !ref.current?.contains(target) &&
+        !anchor?.contains(target) &&
+        target !== anchor
+      ) {
+        onHide();
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [show, anchor, onHide]);
+
+  if (!show || !position) {
+    return null;
+  }
+
+  return ReactDOM.createPortal(
+    <div
+      ref={ref}
+      // stylesSection is carried along deliberately: the inputs and labels in
+      // here are styled by its descendant selectors, and the portal moves
+      // them out from under it.
+      className={`${styles.stylesSection} ${styles.gradientEditor}`}
+      style={position}
+    >
+      {children}
+    </div>,
+    document.body
+  );
+}
+
+export default GradientEditorPopover;

--- a/frontend/packages/@depmap/data-explorer-2/src/components/SettingsModal/GradientSelector.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/SettingsModal/GradientSelector.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */
-import React, { useEffect, useRef, useState } from "react";
+import React, { useState } from "react";
+import GradientEditorPopover from "./GradientEditorPopover";
 import styles from "../../styles/SettingsModal.scss";
 
 interface Props {
@@ -10,27 +11,13 @@ interface Props {
 }
 
 function GradientSelector({ name, label, value, onChange }: Props) {
-  const ref = useRef<HTMLDivElement>(null);
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
   const [showEditor, setShowEditor] = useState(false);
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (ref.current && !ref.current.contains(event.target as HTMLElement)) {
-        setShowEditor(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [ref]);
 
   return (
     <div className={styles.gradient}>
       <label htmlFor={name}>{label}</label>
-      <span onClick={() => setShowEditor(true)}>
+      <span ref={setAnchor} onClick={() => setShowEditor(true)}>
         {value.slice(0, -1).map((pair, i) => (
           <span
             key={pair[0]}
@@ -42,22 +29,24 @@ function GradientSelector({ name, label, value, onChange }: Props) {
           />
         ))}
       </span>
-      {showEditor && (
-        <div ref={ref} className={styles.gradientEditor}>
-          <div className={styles.gradientEditorItems}>
-            {value.map((pair, index) => (
-              <input
-                key={pair[0]}
-                type="color"
-                value={pair[1]}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                  return onChange(e.target.value, index);
-                }}
-              />
-            ))}
-          </div>
+      <GradientEditorPopover
+        show={showEditor}
+        anchor={anchor}
+        onHide={() => setShowEditor(false)}
+      >
+        <div className={styles.gradientEditorItems}>
+          {value.map((pair, index) => (
+            <input
+              key={pair[0]}
+              type="color"
+              value={pair[1]}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                return onChange(e.target.value, index);
+              }}
+            />
+          ))}
         </div>
-      )}
+      </GradientEditorPopover>
     </div>
   );
 }

--- a/frontend/packages/@depmap/data-explorer-2/src/components/SettingsModal/index.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/SettingsModal/index.tsx
@@ -28,6 +28,7 @@ function SettingsModal({
 
   const isValid =
     isValidNumber(settings.plotStyles.pointSize, 3, 50) &&
+    isValidNumber(settings.plotStyles.facetedPointSize, 3, 50) &&
     isValidNumber(settings.plotStyles.pointOpacity, 0, 1) &&
     isValidNumber(settings.plotStyles.outlineWidth, 0, 10) &&
     settings.plotStyles.palette.qualitativeFew.length > 0 &&
@@ -54,6 +55,21 @@ function SettingsModal({
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                 const pointSize = e.target.valueAsNumber;
                 setSettings(updateStyle("pointSize", pointSize));
+              }}
+            />
+            <span>px</span>
+          </div>
+          <div>
+            <label htmlFor="faceted-point-size">faceted point size</label>
+            <input
+              type="number"
+              name="faceted-point-size"
+              min={3}
+              max={50}
+              value={settings.plotStyles.facetedPointSize ?? ""}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                const facetedPointSize = e.target.valueAsNumber;
+                setSettings(updateStyle("facetedPointSize", facetedPointSize));
               }}
             />
             <span>px</span>

--- a/frontend/packages/@depmap/data-explorer-2/src/contexts/DataExplorerSettingsContext.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/contexts/DataExplorerSettingsContext.tsx
@@ -13,6 +13,11 @@ const SettingsModal = React.lazy(
 export const DEFAULT_SETTINGS = {
   plotStyles: {
     pointSize: 10,
+    // Faceting subdivides the plot area — into small multiples (scatter),
+    // violin tracks (density 1D), or x-clusters (waterfall) — so every point
+    // has less room. Faceted plots get their own (smaller) point size
+    // instead of reusing `pointSize`.
+    facetedPointSize: 7,
     pointOpacity: 0.5,
     outlineWidth: 2,
     xAxisFontSize: 14,

--- a/frontend/packages/@depmap/data-explorer-2/src/styles/SettingsModal.scss
+++ b/frontend/packages/@depmap/data-explorer-2/src/styles/SettingsModal.scss
@@ -83,11 +83,14 @@
   }
 }
 
+// Portaled to document.body (see GradientEditorPopover), so `top`/`left` come
+// from the trigger swatch's bounding rect as inline styles rather than from a
+// margin offset against a positioned ancestor.
 .gradientEditor {
-  z-index: 1;
-  position: absolute;
-  margin-left: 131px;
-  margin-top: 32px;
+  // Above Bootstrap's .modal (1050), which is now an ancestor in paint order
+  // rather than in the DOM.
+  z-index: 1060;
+  position: fixed;
   padding: 5px;
   border: 1px solid #999;
   border-radius: 4px;
@@ -95,6 +98,8 @@
   filter: drop-shadow(5px 5px 10px #aaa);
 
   label {
+    // .SettingsModal used to supply this, overriding Bootstrap's bold label.
+    font-weight: normal;
     margin-top: 20px;
     width: auto;
   }

--- a/frontend/packages/embed-frontend/src/components/Plot/EmbeddedScatterPlot.tsx
+++ b/frontend/packages/embed-frontend/src/components/Plot/EmbeddedScatterPlot.tsx
@@ -47,7 +47,13 @@ function EmbeddedScatterPlot({
   plotConfig,
 }: Props) {
   const { plotStyles } = useDataExplorerSettings();
-  const { pointSize, pointOpacity, outlineWidth, palette } = plotStyles;
+  const {
+    pointSize,
+    facetedPointSize,
+    pointOpacity,
+    outlineWidth,
+    palette,
+  } = plotStyles;
 
   const {
     formattedData,
@@ -113,7 +119,7 @@ function EmbeddedScatterPlot({
             regressionLinesByFacet={regressionLinesByFacet}
             placeholderEmptyFacets={Boolean(plotConfig.expand_by?.length)}
             showIdentityLine={showIdentityLine}
-            pointSize={pointSize}
+            pointSize={facetedPointSize}
             pointOpacity={pointOpacity}
             outlineWidth={outlineWidth}
             palette={palette}

--- a/frontend/packages/embed-frontend/src/components/Plot/EmbeddedWaterfallPlot.tsx
+++ b/frontend/packages/embed-frontend/src/components/Plot/EmbeddedWaterfallPlot.tsx
@@ -17,13 +17,20 @@ interface Props {
 
 function DataExplorerWaterfallPlot({ data, height, plotConfig }: Props) {
   const { plotStyles } = useDataExplorerSettings();
-  const { pointSize, pointOpacity, outlineWidth, palette } = plotStyles;
+  const {
+    pointSize,
+    facetedPointSize,
+    pointOpacity,
+    outlineWidth,
+    palette,
+  } = plotStyles;
 
-  const { formattedData, contLegendKeys, colorMap } = useWaterfallPlotData(
-    data,
-    plotConfig,
-    palette
-  );
+  const {
+    formattedData,
+    contLegendKeys,
+    colorMap,
+    hasFacetOptionsEnabled,
+  } = useWaterfallPlotData(data, plotConfig, palette);
 
   if (!formattedData) {
     return null;
@@ -46,7 +53,11 @@ function DataExplorerWaterfallPlot({ data, height, plotConfig }: Props) {
         height={height}
         xLabel={formattedData?.xLabel || ""}
         yLabel={formattedData?.yLabel || ""}
-        pointSize={pointSize}
+        // The hook bakes facet_by's x-clustering into formattedData, so this
+        // plot is genuinely faceted even though hasFacetOptionsEnabled isn't
+        // threaded to PrototypeScatterPlot here (that prop only drives inert
+        // color and drag-selection regions, neither of which embeds use).
+        pointSize={hasFacetOptionsEnabled ? facetedPointSize : pointSize}
         pointOpacity={pointOpacity}
         outlineWidth={outlineWidth}
         customHoverinfo="y+text"


### PR DESCRIPTION
Faceting divides the plot area among many panels, so the point size that reads well on an unfaceted plot leaves faceted ones overcrowded. Faceted plots now take their own size, adjustable in the Data Explorer settings modal.