### PR TITLE
fix faceting in embedded plots

### DIFF
--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/PrototypeDensity1D.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/PrototypeDensity1D.tsx
@@ -63,6 +63,14 @@ interface Props {
   // keys are non-continuous (or absent) and can't collide this way.
   facetDisplayNames?: Partial<Record<LegendKey, string>>;
   legendTitle?: string | null;
+  // Reveals Plotly's own legend, built from the color keys. Data Explorer
+  // hides it because it renders its own richer legend panel alongside the
+  // plot (that's what the dummy traces below normally exist only to fake, for
+  // downloaded images) — but embedded plots live outside Data Explorer with
+  // no panel to fall back on, so for them Plotly's legend is all there is.
+  // Mirrors PrototypeScatterPlot / SmallMultiplesScatter's identically named
+  // prop.
+  showBuiltinLegend?: boolean;
   // Whether facet_by and color_by resolve to the SAME underlying source
   // (see resolveColorMode / useDensity1DPlotData's own colorMatchesFacet
   // comment for the full rationale, including why this is NOT simply
@@ -212,6 +220,7 @@ function PrototypeDensity1D({
   legendDisplayNames,
   facetDisplayNames,
   legendTitle,
+  showBuiltinLegend = false,
   colorMatchesFacet = false,
   height,
   hoverTextKey,
@@ -648,6 +657,26 @@ function PrototypeDensity1D({
         } as any;
       });
 
+    // Dummy traces that exist only to populate Plotly's legend with the right
+    // names and colors. Used for downloaded images (where our own legend panel
+    // can't be rendered) and, when showBuiltinLegend is set, for the live plot
+    // too — the two must agree, hence one definition.
+    const legendTraces = colorKeys
+      .filter((key) => !hiddenLegendValues.has(key))
+      .map((legendKey) => {
+        const fillcolor = colorMap.get(legendKey);
+
+        return {
+          type: "violin",
+          showlegend: true,
+          x: [null],
+          line: { color: "#666" },
+          hoverinfo: "skip",
+          name: legendDisplayNames[legendKey],
+          fillcolor,
+        };
+      });
+
     const plotlyData = [
       ...violinTraces,
       ...violinOutlineTraces,
@@ -659,6 +688,15 @@ function PrototypeDensity1D({
       .filter(Boolean)
       .filter((trace) => hasSomeNonNullValue(trace.x))
       .reverse() as Partial<PlotData>[];
+
+    // Appended after the all-null filter above (which would drop them, their
+    // x being [null]) and after the reverse, so the indices that
+    // isClickableTrace / isContinuousCurve compare against are untouched.
+    if (showBuiltinLegend) {
+      legendTraces.forEach((t) =>
+        plotlyData.push(t as typeof plotlyData[number])
+      );
+    }
 
     const isClickableTrace = (n: number) => {
       return ([
@@ -700,10 +738,14 @@ function PrototypeDensity1D({
         namelength: -1,
       },
 
-      // We have a custom legend so we hide Plotly's legend. However, this
-      // property is toggled just before capturing a snapshot image. See the
-      // definition of plot.downloadImage() below.
-      showlegend: false,
+      // Data Explorer has a custom legend, so Plotly's is hidden there. It's
+      // toggled on just before capturing a snapshot image (see
+      // plot.downloadImage() below), and stays on throughout for embedded
+      // plots, which have no custom legend to defer to (showBuiltinLegend).
+      showlegend: showBuiltinLegend,
+      ...(showBuiltinLegend
+        ? { legend: { title: { text: legendTitle } } }
+        : {}),
 
       xaxis: axes.current.xaxis || {
         title: {
@@ -891,6 +933,16 @@ function PrototypeDensity1D({
 
     // After initializing the plot with `autorange` set to true, store what
     // Plotly calculated for the axes zoom level and turn off autorange.
+    // The legend is drawn from dummy traces (see legendTraces) that hold no
+    // real points, so Plotly's default click behavior toggles the dummy and
+    // nothing else: the entry greys out while the plot stays put. Returning
+    // false suppresses that, leaving the legend a static key rather than a
+    // control that appears to do something. Registered unconditionally — with
+    // no legend shown (Data Explorer's case) these never fire.
+    // TODO: make these actually filter, as Data Explorer's own legend does.
+    on("plotly_legendclick", () => false);
+    on("plotly_legenddoubleclick", () => false);
+
     on("plotly_afterplot", () => {
       if (!axes.current.xaxis || !axes.current.yaxis) {
         axes.current = {
@@ -1080,26 +1132,11 @@ function PrototypeDensity1D({
     plot.resetZoom = () => setTimeout(zoom, 0, "reset");
 
     plot.downloadImage = (options) => {
-      // Add some extra traces used to populate the legend.
-      const legendTraces = colorKeys
-        .filter((key) => !hiddenLegendValues.has(key))
-        .map((legendKey) => {
-          const fillcolor = colorMap.get(legendKey);
-
-          return {
-            type: "violin",
-            showlegend: true,
-            x: [null],
-            line: { color: "#666" },
-            hoverinfo: "skip",
-            name: legendDisplayNames[legendKey],
-            fillcolor,
-          };
-        });
-
       const imagePlot = {
         ...plot,
-        data: [...plot.data, ...legendTraces],
+        // Under showBuiltinLegend the legend traces are already in plot.data;
+        // appending them again would double every legend entry.
+        data: showBuiltinLegend ? plot.data : [...plot.data, ...legendTraces],
         layout: {
           ...plot.layout,
           showlegend: true,
@@ -1147,6 +1184,7 @@ function PrototypeDensity1D({
     legendDisplayNames,
     facetDisplayNames,
     legendTitle,
+    showBuiltinLegend,
     colorMatchesFacet,
     hoverTextKey,
     annotationTextKey,

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/PrototypeScatterPlot.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/PrototypeScatterPlot.tsx
@@ -825,6 +825,16 @@ function PrototypeScatterPlot({
       assignAnnotationPositions(pts);
     };
 
+    // The legend is drawn from dummy traces (getLegendTraces) that hold no
+    // real points, so Plotly's default click behavior toggles the dummy and
+    // nothing else: the entry greys out while the plot stays put. Returning
+    // false suppresses that, leaving the legend a static key rather than a
+    // control that appears to do something. Registered unconditionally — with
+    // no legend shown (Data Explorer's case) these never fire.
+    // TODO: make these actually filter, as Data Explorer's own legend does.
+    on("plotly_legendclick", () => false);
+    on("plotly_legenddoubleclick", () => false);
+
     // After initializing the plot with `autorange` set to true, store what
     // Plotly calculated for the axes zoom level and turn off autorange.
     on("plotly_afterplot", () => {

--- a/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/SmallMultiplesScatter.tsx
+++ b/frontend/packages/@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/SmallMultiplesScatter.tsx
@@ -944,6 +944,16 @@ function SmallMultiplesScatter({
     // would otherwise drop the identity/regression lines. Re-asserting here
     // puts them back; Plotly de-dupes the no-op repeats when nothing changed,
     // so it doesn't loop. Mirrors PrototypeScatterPlot's handling.
+    // The legend is drawn from dummy traces (getLegendTraces) that hold no
+    // real points, so Plotly's default click behavior toggles the dummy and
+    // nothing else: the entry greys out while the plot stays put. Returning
+    // false suppresses that, leaving the legend a static key rather than a
+    // control that appears to do something. Registered unconditionally — with
+    // no legend shown (Data Explorer's case) these never fire.
+    // TODO: make these actually filter, as Data Explorer's own legend does.
+    on("plotly_legendclick", () => false);
+    on("plotly_legenddoubleclick", () => false);
+
     on("plotly_afterplot", () => {
       if (
         indicatorShapes.length === 0 ||

--- a/frontend/packages/embed-frontend/src/components/Plot/EmbeddedDensity1DPlot.tsx
+++ b/frontend/packages/embed-frontend/src/components/Plot/EmbeddedDensity1DPlot.tsx
@@ -17,23 +17,50 @@ interface Props {
 
 function EmbeddedDensity1DPlot({ data, height, plotConfig }: Props) {
   const { plotStyles } = useDataExplorerSettings();
-  const { pointSize, pointOpacity, outlineWidth, palette } = plotStyles;
+  const {
+    pointSize,
+    facetedPointSize,
+    pointOpacity,
+    outlineWidth,
+    palette,
+  } = plotStyles;
 
   const {
     formattedData,
     colorData,
+    facetData,
+    sortedFacetKeys,
+    hasFacetOptionsEnabled,
+    colorMatchesFacet,
     legendState,
+    facetLegendState,
     colorMap,
     legendDisplayNames,
+    facetDisplayNames,
     legendTitle,
     pointVisibility,
   } = useDensity1DPlotData(data, plotConfig, palette);
 
   const { hiddenLegendValues } = legendState;
+  // Seeded by useLegendState with facet's own no-data keys, so facets with
+  // nothing to plot start hidden. There's no Facets panel out here to toggle
+  // them back on, but that seeding is the whole reason to pass this: without
+  // it an empty facet renders as a blank track.
+  const { hiddenLegendValues: hiddenFacetValues } = facetLegendState;
 
   if (!formattedData) {
     return null;
   }
+
+  // Only worth revealing when something is actually colored — otherwise the
+  // legend is one entry for the single ungrouped bucket. Same condition
+  // EmbeddedScatterPlot uses.
+  const showBuiltinLegend = Boolean(
+    data?.metadata.color_property ||
+      data?.dimensions.color ||
+      data?.filters.color1 ||
+      data?.filters.color2
+  );
 
   return (
     <PlotlyLoaderProvider PlotlyLoader={DensityLoader}>
@@ -42,16 +69,23 @@ function EmbeddedDensity1DPlot({ data, height, plotConfig }: Props) {
         xKey="x"
         colorMap={colorMap}
         colorData={colorData}
+        facetData={facetData}
+        groupKeys={sortedFacetKeys}
+        colorMatchesFacet={colorMatchesFacet}
         continuousColorKey="contColorData"
         legendDisplayNames={legendDisplayNames}
+        facetDisplayNames={facetDisplayNames}
         legendTitle={legendTitle}
+        showBuiltinLegend={showBuiltinLegend}
         pointVisibility={pointVisibility || undefined}
         useSemiOpaqueViolins={!plotConfig.hide_points}
+        placeholderEmptyTracks={Boolean(plotConfig.expand_by?.length)}
         hoverTextKey="hoverText"
         annotationTextKey="annotationText"
         height={height}
         hiddenLegendValues={hiddenLegendValues}
-        pointSize={pointSize}
+        hiddenFacetValues={hiddenFacetValues}
+        pointSize={hasFacetOptionsEnabled ? facetedPointSize : pointSize}
         pointOpacity={pointOpacity}
         outlineWidth={outlineWidth}
         palette={palette}

--- a/frontend/packages/embed-frontend/src/components/Plot/EmbeddedScatterPlot.tsx
+++ b/frontend/packages/embed-frontend/src/components/Plot/EmbeddedScatterPlot.tsx
@@ -4,7 +4,10 @@ import useScatterPlotData from "@depmap/data-explorer-2/src/components/DataExplo
 import PrototypeScatterPlot from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/PrototypeScatterPlot";
 import SmallMultiplesScatter from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/SmallMultiplesScatter";
 import { useDataExplorerSettings } from "@depmap/data-explorer-2/src/contexts/DataExplorerSettingsContext";
-import { computeFacets } from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/plotUtils";
+import {
+  chosenCategoriesFor,
+  computeFacets,
+} from "@depmap/data-explorer-2/src/components/DataExplorerPage/components/plot/prototype/plotUtils";
 import {
   DataExplorerPlotConfig,
   DataExplorerPlotResponse,
@@ -72,10 +75,15 @@ function EmbeddedScatterPlot({
     canShowIdentityLine(data)
   );
 
-  const facetInfo = useMemo(() => computeFacets(data, plotConfig.facet_by), [
-    data,
-    plotConfig.facet_by,
-  ]);
+  // facet_categories is the user's own pick from the category picker, and it
+  // overrides computeFacets' ranking entirely — omit it and an embedded link
+  // carrying one renders a different set of panels than Data Explorer does.
+  const facetChosen = chosenCategoriesFor(plotConfig, "facet");
+
+  const facetInfo = useMemo(
+    () => computeFacets(data, plotConfig.facet_by, "facet", facetChosen),
+    [data, plotConfig.facet_by, facetChosen]
+  );
 
   if (!formattedData) {
     return null;

--- a/frontend/packages/embed-frontend/src/components/Plot/EmbeddedWaterfallPlot.tsx
+++ b/frontend/packages/embed-frontend/src/components/Plot/EmbeddedWaterfallPlot.tsx
@@ -62,7 +62,12 @@ function DataExplorerWaterfallPlot({ data, height, plotConfig }: Props) {
         outlineWidth={outlineWidth}
         customHoverinfo="y+text"
         hideXAxisGrid
-        hideXAxis={Boolean(data?.metadata?.color_property)}
+        // facet_property too, matching DataExplorerWaterfallPlot: clustering
+        // makes x a per-cluster rank, so the tick numbers are as meaningless
+        // as they are under a color_property.
+        hideXAxis={Boolean(
+          data?.metadata?.color_property || data?.metadata?.facet_property
+        )}
         palette={palette}
         xAxisFontSize={13}
         yAxisFontSize={13}


### PR DESCRIPTION
Embedded plots rendered facets differently than Data Explorer does — most visibly the density plot, which grouped its violin tracks by color rather than by the facet the config asked for, and kept facets that had no data. They also now fall back to Plotly's legend, since no Data Explorer legend panel sits alongside them to explain the colors.